### PR TITLE
iOSのCDの発火タイミングを修正

### DIFF
--- a/.github/workflows/ios-deliver.yml
+++ b/.github/workflows/ios-deliver.yml
@@ -1,10 +1,9 @@
 name: ios-deliver
 
 on:
-  pull_request:
-    branches:
-      - "releases/**"
-    types: closed
+  release:
+    types:
+      - created
 
 jobs:
   ios-deliver:


### PR DESCRIPTION
## 対応したこと

<!-- 対応したことを箇条書きでわかりやすく -->

- 発火タイミングをリリースが作成されたタイミングに変更する


## 関連資料

<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->

## 残タスク

<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

## 画面キャプチャ

<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
