### PR TITLE
課金誘導ダイアログを実装

### DIFF
--- a/lib/presentation/bill_details/bill_details_page.dart
+++ b/lib/presentation/bill_details/bill_details_page.dart
@@ -12,8 +12,9 @@ import 'components/plan_table.dart';
 import 'components/premium_plan.dart';
 
 class BillDetailsPage extends StatelessWidget {
-  const BillDetailsPage({super.key});
+  const BillDetailsPage({super.key, this.isDialog = false});
 
+  final bool isDialog;
   @override
   Widget build(BuildContext context) {
     const bottomModalHeight = 150.0;
@@ -39,34 +40,68 @@ class BillDetailsPage extends StatelessWidget {
                 pinned: true,
                 backgroundColor: Colors.transparent,
                 surfaceTintColor: Colors.transparent,
-                leading: Padding(
-                  padding: const EdgeInsets.all(8),
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: AppColor.white,
-                      borderRadius: BorderRadius.circular(50),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withOpacity(0.1),
-                          blurRadius: 4,
-                          offset: const Offset(0, 2),
+                leading: isDialog
+                    ? const SizedBox()
+                    : Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: AppColor.white,
+                            borderRadius: BorderRadius.circular(50),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withOpacity(0.1),
+                                blurRadius: 4,
+                                offset: const Offset(0, 2),
+                              ),
+                            ],
+                          ),
+                          child: IconButton(
+                            alignment: Alignment.center,
+                            iconSize: 24,
+                            icon: const Icon(
+                              Symbols.arrow_back_ios_new,
+                              color: AppColor.black,
+                              weight: 600,
+                            ),
+                            onPressed: () {
+                              context.pop();
+                            },
+                          ),
                         ),
-                      ],
-                    ),
-                    child: IconButton(
-                      alignment: Alignment.center,
-                      iconSize: 24,
-                      icon: const Icon(
-                        Symbols.arrow_back_ios_new,
-                        color: AppColor.black,
-                        weight: 600,
                       ),
-                      onPressed: () {
-                        context.pop();
-                      },
-                    ),
-                  ),
-                ),
+                actions: isDialog
+                    ? [
+                        Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: AppColor.white,
+                              shape: BoxShape.circle,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.1),
+                                  blurRadius: 4,
+                                  offset: const Offset(0, 2),
+                                ),
+                              ],
+                            ),
+                            child: IconButton(
+                              alignment: Alignment.center,
+                              iconSize: 24,
+                              icon: const Icon(
+                                Symbols.close,
+                                color: AppColor.black,
+                                weight: 600,
+                              ),
+                              onPressed: () {
+                                context.pop();
+                              },
+                            ),
+                          ),
+                        ),
+                      ]
+                    : null,
               ),
               const SliverToBoxAdapter(
                 child: Padding(

--- a/lib/utils/routes/app_router.dart
+++ b/lib/utils/routes/app_router.dart
@@ -321,7 +321,9 @@ class BillDetailsDialogRouteData extends GoRouteData {
   Page<void> buildPage(BuildContext context, GoRouterState state) {
     return MaterialPage<void>(
       key: state.pageKey,
-      child: const BillDetailsPage(),
+      child: const BillDetailsPage(
+        isDialog: true,
+      ),
       fullscreenDialog: true,
     );
   }

--- a/lib/utils/routes/app_router.dart
+++ b/lib/utils/routes/app_router.dart
@@ -311,6 +311,22 @@ class BillDetailsPageRouteData extends GoRouteData {
   }
 }
 
+@TypedGoRoute<BillDetailsDialogRouteData>(
+  path: Routes.billDetailsDialog,
+)
+class BillDetailsDialogRouteData extends GoRouteData {
+  const BillDetailsDialogRouteData();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return MaterialPage<void>(
+      key: state.pageKey,
+      child: const BillDetailsPage(),
+      fullscreenDialog: true,
+    );
+  }
+}
+
 @TypedGoRoute<SignInPageRouteData>(
   path: Routes.signIn,
   routes: [

--- a/lib/utils/routes/app_router.g.dart
+++ b/lib/utils/routes/app_router.g.dart
@@ -12,6 +12,7 @@ List<RouteBase> get $appRoutes => [
       $homeScreenRouteData,
       $myPlanPageRouteData,
       $myPageRouteData,
+      $billDetailsDialogRouteData,
       $signInPageRouteData,
       $registerProfilePageRouteData,
       $buddyChatPageRouteData,
@@ -410,6 +411,29 @@ extension $BillDetailsPageRouteDataExtension on BillDetailsPageRouteData {
 
   String get location => GoRouteData.$location(
         '/myPage/billDetailsPage',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $billDetailsDialogRouteData => GoRouteData.$route(
+      path: '/billDetailsDialog',
+      factory: $BillDetailsDialogRouteDataExtension._fromState,
+    );
+
+extension $BillDetailsDialogRouteDataExtension on BillDetailsDialogRouteData {
+  static BillDetailsDialogRouteData _fromState(GoRouterState state) =>
+      const BillDetailsDialogRouteData();
+
+  String get location => GoRouteData.$location(
+        '/billDetailsDialog',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/lib/utils/routes/routes.dart
+++ b/lib/utils/routes/routes.dart
@@ -22,5 +22,6 @@ class Routes {
   static const buddyChatPage = '/buddyChatPage';
   static const popularPlansPage = 'popularPlansPage';
   static const billDetails = 'billDetailsPage';
+  static const billDetailsDialog = '/billDetailsDialog';
   static const planDetailPage = '/planDetailPage';
 }


### PR DESCRIPTION
## 対応したこと
- BillDetailsDialogRouteDataを定義
    - Pageとの違いは遷移時のアニメーションが主
- bill_details_page.dartにボタンを切り替える処理を追加(isDialog)
    - isDialogはデフォルトでfalse(通常の戻るボタン),trueの場合はダイアログの閉じるボタン

### 使用方法
- `BillDetailsDialogRouteData`で遷移する
    - `BillDetailsPageRouteData`を呼び出すとダイアログではなくページが呼び出されるので注意
<!-- 対応したことを箇条書きでわかりやすく -->

## 関連資料
特になし
<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->

## 残タスク
特になし
<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

## 画面キャプチャ
※ プレミアムプランから遷移していますが、仮になので気にしないでください
<table>
  <tr>
    <th>Page</th>
    <th>Dialog</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/a5bb26dc-ad1f-4958-8d42-125f0a5b972e" alt="Dialog" width="300"/></td>
    <td><video src="https://github.com/user-attachments/assets/6354ee66-b229-45b1-ab87-298f74a3d445" alt="Page" width="300"/></td>
  </tr>
</table>


<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
