### PR TITLE
AndroidStudioをアップデートした際に発生するエラーを修正

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (project.hasProperty('dart-defines')) {
 android {
     namespace = "com.shibuya.buddy"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "26.3.11579264"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (project.hasProperty('dart-defines')) {
 android {
     namespace = "com.shibuya.buddy"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "26.3.11579264"
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.3.2" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false


### PR DESCRIPTION
## 対応したこと
- settings.gradleファイルを修正
- gradle-wrapper.propertiesファイルを修正
- build.gradleファイルのndkversionを26に変更

上記のファイルを変更することにより最新のdevelopブランチでAndroidの実機ビルドをする時に発生するエラーを解決。
```
Execution failed for task ':flutter_plugin_android_lifecycle:compileDebugJavaWithJavac'
```

<!-- 対応したことを箇条書きでわかりやすく -->

## 関連資料
[[Solved] Execution failed for task :flutter_plugin_android_lifecycle:compileDebugJavaWithJavac](https://www.youtube.com/watch?v=Wthmab2pI-o)

