### PR TITLE
アカウント連携解除時に出てくるダイアログの変更

### DIFF
--- a/lib/presentation/account/account_page.dart
+++ b/lib/presentation/account/account_page.dart
@@ -9,6 +9,7 @@ import '../../infrastructure/authentication/authentication_data_source.dart';
 import '../../utils/routes/app_router.dart';
 import '../../utils/styles/app_color.dart';
 import '../../utils/styles/app_text_style.dart';
+import '../components/confirm_dialog.dart';
 import '../components/wide_button.dart';
 import 'account_page_notifier.dart';
 
@@ -49,28 +50,17 @@ class AccountPage extends ConsumerWidget {
                 icon: SvgPicture.asset(Assets.icons.appleIcon),
                 onPressed: () async {
                   if (accountLinkage.appleLinkage) {
-                    //仮ダイアログ
                     await showDialog<void>(
                       context: context,
                       builder: (context) {
-                        return AlertDialog(
-                          title: Text(diaLogi18n.title),
-                          content: Text(diaLogi18n.appleText),
-                          actions: [
-                            TextButton(
-                              child: Text(diaLogi18n.no),
-                              onPressed: () => Navigator.pop(context),
-                            ),
-                            TextButton(
-                              child: Text(diaLogi18n.yes),
-                              onPressed: () async {
-                                Navigator.pop(context);
-                                await notifier.unlinkSocialAccount(
-                                  SocialAuthDomain.apple,
-                                );
-                              },
-                            ),
-                          ],
+                        return ConfirmDialog(
+                          onConfirm: () async {
+                            await notifier.unlinkSocialAccount(
+                              SocialAuthDomain.apple,
+                            );
+                          },
+                          titleText: diaLogi18n.title,
+                          bodyText: diaLogi18n.appleText,
                         );
                       },
                     );
@@ -91,28 +81,17 @@ class AccountPage extends ConsumerWidget {
                 icon: SvgPicture.asset(Assets.icons.googleIcon),
                 onPressed: () async {
                   if (accountLinkage.googleLinkage) {
-                    //仮ダイアログ
                     await showDialog<void>(
                       context: context,
                       builder: (context) {
-                        return AlertDialog(
-                          title: Text(diaLogi18n.title),
-                          content: Text(diaLogi18n.googleText),
-                          actions: [
-                            TextButton(
-                              child: Text(diaLogi18n.no),
-                              onPressed: () => Navigator.pop(context),
-                            ),
-                            TextButton(
-                              child: Text(diaLogi18n.yes),
-                              onPressed: () async {
-                                Navigator.pop(context);
-                                await notifier.unlinkSocialAccount(
-                                  SocialAuthDomain.google,
-                                );
-                              },
-                            ),
-                          ],
+                        return ConfirmDialog(
+                          onConfirm: () async {
+                            await notifier.unlinkSocialAccount(
+                              SocialAuthDomain.google,
+                            );
+                          },
+                          titleText: diaLogi18n.title,
+                          bodyText: diaLogi18n.googleText,
                         );
                       },
                     );


### PR DESCRIPTION
## 対応したこと

アカウント解除時に出てくるダイアログをデフォルトの物から、コンポーネントとの物に変更

## 画面キャプチャ
<p style="display: flex; justify-content: space-around;">
  <img src="https://github.com/user-attachments/assets/c8150949-f3a4-4d83-9c48-f0c341044bc3" alt="Image 1" width="45%">
  <img src="https://github.com/user-attachments/assets/8053e8f7-c1cf-45c0-8fe4-562e6c713054" alt="Image 2" width="45%">
</p>