### PR TITLE
アカウントステータスのOverflowを修正

### DIFF
--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 4
-/// Strings: 912 (228 per locale)
+/// Strings: 920 (230 per locale)
 ///
-/// Built on 2025-01-19 at 13:22 UTC
+/// Built on 2025-01-20 at 15:07 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
@@ -29,98 +29,94 @@ part 'strings_en.g.dart';
 /// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
 /// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
 enum AppLocale with BaseAppLocale<AppLocale, Translations> {
-  en(languageCode: 'en'),
-  ja(languageCode: 'ja'),
-  zhHans(languageCode: 'zh', scriptCode: 'Hans'),
-  zhHant(languageCode: 'zh', scriptCode: 'Hant');
+	en(languageCode: 'en'),
+	ja(languageCode: 'ja'),
+	zhHans(languageCode: 'zh', scriptCode: 'Hans'),
+	zhHant(languageCode: 'zh', scriptCode: 'Hant');
 
-  const AppLocale({
-    required this.languageCode,
-    this.scriptCode, // ignore: unused_element
-    this.countryCode, // ignore: unused_element
-  });
+	const AppLocale({
+		required this.languageCode,
+		this.scriptCode, // ignore: unused_element
+		this.countryCode, // ignore: unused_element
+	});
 
-  @override
-  final String languageCode;
-  @override
-  final String? scriptCode;
-  @override
-  final String? countryCode;
+	@override final String languageCode;
+	@override final String? scriptCode;
+	@override final String? countryCode;
 
-  @override
-  Future<Translations> build({
-    Map<String, Node>? overrides,
-    PluralResolver? cardinalResolver,
-    PluralResolver? ordinalResolver,
-  }) async {
-    switch (this) {
-      case AppLocale.en:
-        return TranslationsEn(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-      case AppLocale.ja:
-        await l_ja.loadLibrary();
-        return l_ja.TranslationsJa(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-      case AppLocale.zhHans:
-        await l_zh_Hans.loadLibrary();
-        return l_zh_Hans.TranslationsZhHans(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-      case AppLocale.zhHant:
-        await l_zh_Hant.loadLibrary();
-        return l_zh_Hant.TranslationsZhHant(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-    }
-  }
+	@override
+	Future<Translations> build({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) async {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.ja:
+				await l_ja.loadLibrary();
+				return l_ja.TranslationsJa(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zhHans:
+				await l_zh_Hans.loadLibrary();
+				return l_zh_Hans.TranslationsZhHans(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zhHant:
+				await l_zh_Hant.loadLibrary();
+				return l_zh_Hant.TranslationsZhHant(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
 
-  @override
-  Translations buildSync({
-    Map<String, Node>? overrides,
-    PluralResolver? cardinalResolver,
-    PluralResolver? ordinalResolver,
-  }) {
-    switch (this) {
-      case AppLocale.en:
-        return TranslationsEn(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-      case AppLocale.ja:
-        return l_ja.TranslationsJa(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-      case AppLocale.zhHans:
-        return l_zh_Hans.TranslationsZhHans(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-      case AppLocale.zhHant:
-        return l_zh_Hant.TranslationsZhHant(
-          overrides: overrides,
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        );
-    }
-  }
+	@override
+	Translations buildSync({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.ja:
+				return l_ja.TranslationsJa(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zhHans:
+				return l_zh_Hans.TranslationsZhHans(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.zhHant:
+				return l_zh_Hant.TranslationsZhHant(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
 
-  /// Gets current instance managed by [LocaleSettings].
-  Translations get translations =>
-      LocaleSettings.instance.getTranslations(this);
+	/// Gets current instance managed by [LocaleSettings].
+	Translations get translations => LocaleSettings.instance.getTranslations(this);
 }
 
 /// Method A: Simple
@@ -149,14 +145,10 @@ Translations get t => LocaleSettings.instance.currentTranslations;
 /// final t = Translations.of(context); // Get t variable.
 /// String a = t.someKey.anotherKey; // Use t variable.
 /// String b = t['someKey.anotherKey']; // Only for edge cases!
-class TranslationProvider
-    extends BaseTranslationProvider<AppLocale, Translations> {
-  TranslationProvider({required super.child})
-      : super(settings: LocaleSettings.instance);
+class TranslationProvider extends BaseTranslationProvider<AppLocale, Translations> {
+	TranslationProvider({required super.child}) : super(settings: LocaleSettings.instance);
 
-  static InheritedLocaleData<AppLocale, Translations> of(
-          BuildContext context) =>
-      InheritedLocaleData.of<AppLocale, Translations>(context);
+	static InheritedLocaleData<AppLocale, Translations> of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context);
 }
 
 /// Method B shorthand via [BuildContext] extension method.
@@ -165,87 +157,56 @@ class TranslationProvider
 /// Usage (e.g. in a widget's build method):
 /// context.t.someKey.anotherKey
 extension BuildContextTranslationsExtension on BuildContext {
-  Translations get t => TranslationProvider.of(this).translations;
+	Translations get t => TranslationProvider.of(this).translations;
 }
 
 /// Manages all translation instances and the current locale
-class LocaleSettings
-    extends BaseFlutterLocaleSettings<AppLocale, Translations> {
-  LocaleSettings._()
-      : super(
-          utils: AppLocaleUtils.instance,
-          lazy: true,
-        );
+class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, Translations> {
+	LocaleSettings._() : super(
+		utils: AppLocaleUtils.instance,
+		lazy: true,
+	);
 
-  static final instance = LocaleSettings._();
+	static final instance = LocaleSettings._();
 
-  // static aliases (checkout base methods for documentation)
-  static AppLocale get currentLocale => instance.currentLocale;
-  static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
-  static Future<AppLocale> setLocale(AppLocale locale,
-          {bool? listenToDeviceLocale = false}) =>
-      instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
-  static Future<AppLocale> setLocaleRaw(String rawLocale,
-          {bool? listenToDeviceLocale = false}) =>
-      instance.setLocaleRaw(rawLocale,
-          listenToDeviceLocale: listenToDeviceLocale);
-  static Future<AppLocale> useDeviceLocale() => instance.useDeviceLocale();
-  static Future<void> setPluralResolver(
-          {String? language,
-          AppLocale? locale,
-          PluralResolver? cardinalResolver,
-          PluralResolver? ordinalResolver}) =>
-      instance.setPluralResolver(
-        language: language,
-        locale: locale,
-        cardinalResolver: cardinalResolver,
-        ordinalResolver: ordinalResolver,
-      );
+	// static aliases (checkout base methods for documentation)
+	static AppLocale get currentLocale => instance.currentLocale;
+	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> useDeviceLocale() => instance.useDeviceLocale();
+	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
 
-  // synchronous versions
-  static AppLocale setLocaleSync(AppLocale locale,
-          {bool? listenToDeviceLocale = false}) =>
-      instance.setLocaleSync(locale,
-          listenToDeviceLocale: listenToDeviceLocale);
-  static AppLocale setLocaleRawSync(String rawLocale,
-          {bool? listenToDeviceLocale = false}) =>
-      instance.setLocaleRawSync(rawLocale,
-          listenToDeviceLocale: listenToDeviceLocale);
-  static AppLocale useDeviceLocaleSync() => instance.useDeviceLocaleSync();
-  static void setPluralResolverSync(
-          {String? language,
-          AppLocale? locale,
-          PluralResolver? cardinalResolver,
-          PluralResolver? ordinalResolver}) =>
-      instance.setPluralResolverSync(
-        language: language,
-        locale: locale,
-        cardinalResolver: cardinalResolver,
-        ordinalResolver: ordinalResolver,
-      );
+	// synchronous versions
+	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale useDeviceLocaleSync() => instance.useDeviceLocaleSync();
+	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
 }
 
 /// Provides utility functions without any side effects.
 class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
-  AppLocaleUtils._()
-      : super(
-          baseLocale: AppLocale.en,
-          locales: AppLocale.values,
-        );
+	AppLocaleUtils._() : super(
+		baseLocale: AppLocale.en,
+		locales: AppLocale.values,
+	);
 
-  static final instance = AppLocaleUtils._();
+	static final instance = AppLocaleUtils._();
 
-  // static aliases (checkout base methods for documentation)
-  static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
-  static AppLocale parseLocaleParts(
-          {required String languageCode,
-          String? scriptCode,
-          String? countryCode}) =>
-      instance.parseLocaleParts(
-          languageCode: languageCode,
-          scriptCode: scriptCode,
-          countryCode: countryCode);
-  static AppLocale findDeviceLocale() => instance.findDeviceLocale();
-  static List<Locale> get supportedLocales => instance.supportedLocales;
-  static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+	// static aliases (checkout base methods for documentation)
+	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
+	static AppLocale findDeviceLocale() => instance.findDeviceLocale();
+	static List<Locale> get supportedLocales => instance.supportedLocales;
+	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
 }

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 4
 /// Strings: 920 (230 per locale)
 ///
-/// Built on 2025-01-20 at 15:07 UTC
+/// Built on 2025-01-20 at 15:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -144,7 +144,9 @@
         "passwordWeak": "Please combine alphanumeric characters for the password",
         "passwordMatch": "Passwords do not match",
         "informationRequired": "Please enter the information",
-        "urlInvalid": "The URL format is incorrect"
+        "urlInvalid": "The URL format is incorrect",
+        "usernameRequired": "Please enter your username",
+        "userNameMaxLength": "The username must be 16 characters or fewer"
     },
     "myPage": {
         "unregisteredUserName": "Unregistered",

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -146,7 +146,7 @@
         "informationRequired": "Please enter the information",
         "urlInvalid": "The URL format is incorrect",
         "usernameRequired": "Please enter your username",
-        "userNameMaxLength": "The username must be 16 characters or fewer"
+        "usernameMaxLength": "The username must be 16 characters or fewer"
     },
     "myPage": {
         "unregisteredUserName": "Unregistered",

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -130,7 +130,7 @@ class TranslationsValidationEn {
 	String get informationRequired => 'Please enter the information';
 	String get urlInvalid => 'The URL format is incorrect';
 	String get usernameRequired => 'Please enter your username';
-	String get userNameMaxLength => 'The username must be 16 characters or fewer';
+	String get usernameMaxLength => 'The username must be 16 characters or fewer';
 }
 
 // Path: myPage
@@ -1268,7 +1268,7 @@ extension on Translations {
 			case 'validation.informationRequired': return 'Please enter the information';
 			case 'validation.urlInvalid': return 'The URL format is incorrect';
 			case 'validation.usernameRequired': return 'Please enter your username';
-			case 'validation.userNameMaxLength': return 'The username must be 16 characters or fewer';
+			case 'validation.usernameMaxLength': return 'The username must be 16 characters or fewer';
 			case 'myPage.unregisteredUserName': return 'Unregistered';
 			case 'myPage.editProfile': return 'Edit Profile';
 			case 'myPage.premiumPlan': return 'Premium Plan';

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -8,1763 +8,1414 @@ part of 'strings.g.dart';
 
 // Path: <root>
 typedef TranslationsEn = Translations; // ignore: unused_element
-
 class Translations implements BaseTranslations<AppLocale, Translations> {
-  /// Returns the current translations of the given [context].
-  ///
-  /// Usage:
-  /// final t = Translations.of(context);
-  static Translations of(BuildContext context) =>
-      InheritedLocaleData.of<AppLocale, Translations>(context).translations;
+	/// Returns the current translations of the given [context].
+	///
+	/// Usage:
+	/// final t = Translations.of(context);
+	static Translations of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context).translations;
 
-  /// You can call this constructor and build your own translation instance of this locale.
-  /// Constructing via the enum [AppLocale.build] is preferred.
-  Translations(
-      {Map<String, Node>? overrides,
-      PluralResolver? cardinalResolver,
-      PluralResolver? ordinalResolver})
-      : assert(overrides == null,
-            'Set "translation_overrides: true" in order to enable this feature.'),
-        $meta = TranslationMetadata(
-          locale: AppLocale.en,
-          overrides: overrides ?? {},
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        ) {
-    $meta.setFlatMapFunction(_flatMapFunction);
-  }
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
 
-  /// Metadata for the translations of <en>.
-  @override
-  final TranslationMetadata<AppLocale, Translations> $meta;
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
 
-  /// Access flat map
-  dynamic operator [](String key) => $meta.getTranslation(key);
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
 
-  late final Translations _root = this; // ignore: unused_field
+	late final Translations _root = this; // ignore: unused_field
 
-  // Translations
-  late final TranslationsNavigationBarEn navigationBar =
-      TranslationsNavigationBarEn._(_root);
-  late final TranslationsHomePageEn homePage = TranslationsHomePageEn._(_root);
-  late final TranslationsAccountPageEn accountPage =
-      TranslationsAccountPageEn._(_root);
-  late final TranslationsAuthenticationEn authentication =
-      TranslationsAuthenticationEn._(_root);
-  late final TranslationsValidationEn validation =
-      TranslationsValidationEn._(_root);
-  late final TranslationsMyPageEn myPage = TranslationsMyPageEn._(_root);
-  late final TranslationsChangeLanguagePageEn changeLanguagePage =
-      TranslationsChangeLanguagePageEn._(_root);
-  late final TranslationsChangeThemePageEn changeThemePage =
-      TranslationsChangeThemePageEn._(_root);
-  late final TranslationsMyPlanPageEn myPlanPage =
-      TranslationsMyPlanPageEn._(_root);
-  late final TranslationsBuddyChatPageEn buddyChatPage =
-      TranslationsBuddyChatPageEn._(_root);
-  late final TranslationsPopularTopicsEn popularTopics =
-      TranslationsPopularTopicsEn._(_root);
-  late final TranslationsCreatePlanPageEn createPlanPage =
-      TranslationsCreatePlanPageEn._(_root);
-  late final TranslationsEditProfilePageEn editProfilePage =
-      TranslationsEditProfilePageEn._(_root);
-  late final TranslationsConfirmDialogEn confirmDialog =
-      TranslationsConfirmDialogEn._(_root);
-  late final TranslationsPromptEn prompt = TranslationsPromptEn._(_root);
-  late final TranslationsBillDetailsPageEn billDetailsPage =
-      TranslationsBillDetailsPageEn._(_root);
-  late final TranslationsPlanDetailsPageEn planDetailsPage =
-      TranslationsPlanDetailsPageEn._(_root);
-  Map<String, String> get locales => {
-        'en': 'English',
-        'ja': 'Japanese',
-        'zh': 'Chinese',
-      };
-  late final TranslationsErrorPageEn errorPage =
-      TranslationsErrorPageEn._(_root);
-  late final TranslationsMapPageEn mapPage = TranslationsMapPageEn._(_root);
+	// Translations
+	late final TranslationsNavigationBarEn navigationBar = TranslationsNavigationBarEn._(_root);
+	late final TranslationsHomePageEn homePage = TranslationsHomePageEn._(_root);
+	late final TranslationsAccountPageEn accountPage = TranslationsAccountPageEn._(_root);
+	late final TranslationsAuthenticationEn authentication = TranslationsAuthenticationEn._(_root);
+	late final TranslationsValidationEn validation = TranslationsValidationEn._(_root);
+	late final TranslationsMyPageEn myPage = TranslationsMyPageEn._(_root);
+	late final TranslationsChangeLanguagePageEn changeLanguagePage = TranslationsChangeLanguagePageEn._(_root);
+	late final TranslationsChangeThemePageEn changeThemePage = TranslationsChangeThemePageEn._(_root);
+	late final TranslationsMyPlanPageEn myPlanPage = TranslationsMyPlanPageEn._(_root);
+	late final TranslationsBuddyChatPageEn buddyChatPage = TranslationsBuddyChatPageEn._(_root);
+	late final TranslationsPopularTopicsEn popularTopics = TranslationsPopularTopicsEn._(_root);
+	late final TranslationsCreatePlanPageEn createPlanPage = TranslationsCreatePlanPageEn._(_root);
+	late final TranslationsEditProfilePageEn editProfilePage = TranslationsEditProfilePageEn._(_root);
+	late final TranslationsConfirmDialogEn confirmDialog = TranslationsConfirmDialogEn._(_root);
+	late final TranslationsPromptEn prompt = TranslationsPromptEn._(_root);
+	late final TranslationsBillDetailsPageEn billDetailsPage = TranslationsBillDetailsPageEn._(_root);
+	late final TranslationsPlanDetailsPageEn planDetailsPage = TranslationsPlanDetailsPageEn._(_root);
+	Map<String, String> get locales => {
+		'en': 'English',
+		'ja': 'Japanese',
+		'zh': 'Chinese',
+	};
+	late final TranslationsErrorPageEn errorPage = TranslationsErrorPageEn._(_root);
+	late final TranslationsMapPageEn mapPage = TranslationsMapPageEn._(_root);
 }
 
 // Path: navigationBar
 class TranslationsNavigationBarEn {
-  TranslationsNavigationBarEn._(this._root);
+	TranslationsNavigationBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsNavigationBarItemsEn items =
-      TranslationsNavigationBarItemsEn._(_root);
+	// Translations
+	late final TranslationsNavigationBarItemsEn items = TranslationsNavigationBarItemsEn._(_root);
 }
 
 // Path: homePage
 class TranslationsHomePageEn {
-  TranslationsHomePageEn._(this._root);
+	TranslationsHomePageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsHomePagePopularPlansEn popularPlans =
-      TranslationsHomePagePopularPlansEn._(_root);
-  late final TranslationsHomePagePopularTopicsEn popularTopics =
-      TranslationsHomePagePopularTopicsEn._(_root);
-  late final TranslationsHomePageRecentPlansEn recentPlans =
-      TranslationsHomePageRecentPlansEn._(_root);
+	// Translations
+	late final TranslationsHomePagePopularPlansEn popularPlans = TranslationsHomePagePopularPlansEn._(_root);
+	late final TranslationsHomePagePopularTopicsEn popularTopics = TranslationsHomePagePopularTopicsEn._(_root);
+	late final TranslationsHomePageRecentPlansEn recentPlans = TranslationsHomePageRecentPlansEn._(_root);
 }
 
 // Path: accountPage
 class TranslationsAccountPageEn {
-  TranslationsAccountPageEn._(this._root);
+	TranslationsAccountPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Account';
-  late final TranslationsAccountPageItemsEn items =
-      TranslationsAccountPageItemsEn._(_root);
-  late final TranslationsAccountPageSnackBarEn snackBar =
-      TranslationsAccountPageSnackBarEn._(_root);
-  late final TranslationsAccountPageDiaLogEn diaLog =
-      TranslationsAccountPageDiaLogEn._(_root);
+	// Translations
+	String get title => 'Account';
+	late final TranslationsAccountPageItemsEn items = TranslationsAccountPageItemsEn._(_root);
+	late final TranslationsAccountPageSnackBarEn snackBar = TranslationsAccountPageSnackBarEn._(_root);
+	late final TranslationsAccountPageDiaLogEn diaLog = TranslationsAccountPageDiaLogEn._(_root);
 }
 
 // Path: authentication
 class TranslationsAuthenticationEn {
-  TranslationsAuthenticationEn._(this._root);
+	TranslationsAuthenticationEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsAuthenticationSignInPageEn signInPage =
-      TranslationsAuthenticationSignInPageEn._(_root);
-  late final TranslationsAuthenticationFirebaseAuthEn firebaseAuth =
-      TranslationsAuthenticationFirebaseAuthEn._(_root);
-  late final TranslationsAuthenticationResetPasswordPageEn resetPasswordPage =
-      TranslationsAuthenticationResetPasswordPageEn._(_root);
-  late final TranslationsAuthenticationSignUpPageEn signUpPage =
-      TranslationsAuthenticationSignUpPageEn._(_root);
-  late final TranslationsAuthenticationEmailVerificationPageEn
-      emailVerificationPage =
-      TranslationsAuthenticationEmailVerificationPageEn._(_root);
-  late final TranslationsAuthenticationRegisterProfilePageEn
-      registerProfilePage =
-      TranslationsAuthenticationRegisterProfilePageEn._(_root);
-  late final TranslationsAuthenticationCompleteSendEmailPageEn
-      completeSendEmailPage =
-      TranslationsAuthenticationCompleteSendEmailPageEn._(_root);
+	// Translations
+	late final TranslationsAuthenticationSignInPageEn signInPage = TranslationsAuthenticationSignInPageEn._(_root);
+	late final TranslationsAuthenticationFirebaseAuthEn firebaseAuth = TranslationsAuthenticationFirebaseAuthEn._(_root);
+	late final TranslationsAuthenticationResetPasswordPageEn resetPasswordPage = TranslationsAuthenticationResetPasswordPageEn._(_root);
+	late final TranslationsAuthenticationSignUpPageEn signUpPage = TranslationsAuthenticationSignUpPageEn._(_root);
+	late final TranslationsAuthenticationEmailVerificationPageEn emailVerificationPage = TranslationsAuthenticationEmailVerificationPageEn._(_root);
+	late final TranslationsAuthenticationRegisterProfilePageEn registerProfilePage = TranslationsAuthenticationRegisterProfilePageEn._(_root);
+	late final TranslationsAuthenticationCompleteSendEmailPageEn completeSendEmailPage = TranslationsAuthenticationCompleteSendEmailPageEn._(_root);
 }
 
 // Path: validation
 class TranslationsValidationEn {
-  TranslationsValidationEn._(this._root);
+	TranslationsValidationEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get emailRequired => 'Please enter your email address';
-  String get emailInvalid => 'The email address format is incorrect';
-  String get passwordRequired => 'Please enter your password';
-  String get passwordShort => 'The password must be at least 8 characters long';
-  String get passwordWeak =>
-      'Please combine alphanumeric characters for the password';
-  String get passwordMatch => 'Passwords do not match';
-  String get informationRequired => 'Please enter the information';
-  String get urlInvalid => 'The URL format is incorrect';
+	// Translations
+	String get emailRequired => 'Please enter your email address';
+	String get emailInvalid => 'The email address format is incorrect';
+	String get passwordRequired => 'Please enter your password';
+	String get passwordShort => 'The password must be at least 8 characters long';
+	String get passwordWeak => 'Please combine alphanumeric characters for the password';
+	String get passwordMatch => 'Passwords do not match';
+	String get informationRequired => 'Please enter the information';
+	String get urlInvalid => 'The URL format is incorrect';
+	String get usernameRequired => 'Please enter your username';
+	String get userNameMaxLength => 'The username must be 16 characters or fewer';
 }
 
 // Path: myPage
 class TranslationsMyPageEn {
-  TranslationsMyPageEn._(this._root);
+	TranslationsMyPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get unregisteredUserName => 'Unregistered';
-  String get editProfile => 'Edit Profile';
-  String get premiumPlan => 'Premium Plan';
-  String get details => 'Details';
-  String get settings => 'Settings';
-  String get account => 'Account';
-  String get language => 'Language';
-  String get theme => 'Theme';
-  String get termsOfUsePrivacyPolicy => 'Terms of Use & Privacy Policy';
-  String get aboutThisApp => 'About This App';
-  String get aboutTheDeveloper => 'About the Developer';
-  late final TranslationsMyPageAccountStatusEn accountStatus =
-      TranslationsMyPageAccountStatusEn._(_root);
+	// Translations
+	String get unregisteredUserName => 'Unregistered';
+	String get editProfile => 'Edit Profile';
+	String get premiumPlan => 'Premium Plan';
+	String get details => 'Details';
+	String get settings => 'Settings';
+	String get account => 'Account';
+	String get language => 'Language';
+	String get theme => 'Theme';
+	String get termsOfUsePrivacyPolicy => 'Terms of Use & Privacy Policy';
+	String get aboutThisApp => 'About This App';
+	String get aboutTheDeveloper => 'About the Developer';
+	late final TranslationsMyPageAccountStatusEn accountStatus = TranslationsMyPageAccountStatusEn._(_root);
 }
 
 // Path: changeLanguagePage
 class TranslationsChangeLanguagePageEn {
-  TranslationsChangeLanguagePageEn._(this._root);
+	TranslationsChangeLanguagePageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Language';
-  late final TranslationsChangeLanguagePageItemsEn items =
-      TranslationsChangeLanguagePageItemsEn._(_root);
+	// Translations
+	String get title => 'Language';
+	late final TranslationsChangeLanguagePageItemsEn items = TranslationsChangeLanguagePageItemsEn._(_root);
 }
 
 // Path: changeThemePage
 class TranslationsChangeThemePageEn {
-  TranslationsChangeThemePageEn._(this._root);
+	TranslationsChangeThemePageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Theme';
-  late final TranslationsChangeThemePageItemsEn items =
-      TranslationsChangeThemePageItemsEn._(_root);
+	// Translations
+	String get title => 'Theme';
+	late final TranslationsChangeThemePageItemsEn items = TranslationsChangeThemePageItemsEn._(_root);
 }
 
 // Path: myPlanPage
 class TranslationsMyPlanPageEn {
-  TranslationsMyPlanPageEn._(this._root);
+	TranslationsMyPlanPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'My Plans';
-  late final TranslationsMyPlanPageTabsEn tabs =
-      TranslationsMyPlanPageTabsEn._(_root);
-  late final TranslationsMyPlanPageBookmarkItemsEn bookmarkItems =
-      TranslationsMyPlanPageBookmarkItemsEn._(_root);
-  late final TranslationsMyPlanPageCreatedPlansItemsEn createdPlansItems =
-      TranslationsMyPlanPageCreatedPlansItemsEn._(_root);
-  late final TranslationsMyPlanPageErrorEn error =
-      TranslationsMyPlanPageErrorEn._(_root);
+	// Translations
+	String get title => 'My Plans';
+	late final TranslationsMyPlanPageTabsEn tabs = TranslationsMyPlanPageTabsEn._(_root);
+	late final TranslationsMyPlanPageBookmarkItemsEn bookmarkItems = TranslationsMyPlanPageBookmarkItemsEn._(_root);
+	late final TranslationsMyPlanPageCreatedPlansItemsEn createdPlansItems = TranslationsMyPlanPageCreatedPlansItemsEn._(_root);
+	late final TranslationsMyPlanPageErrorEn error = TranslationsMyPlanPageErrorEn._(_root);
 }
 
 // Path: buddyChatPage
 class TranslationsBuddyChatPageEn {
-  TranslationsBuddyChatPageEn._(this._root);
+	TranslationsBuddyChatPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Buddy\'s Suggestions';
-  String possibleChatCount({required Object possibleChatCount}) =>
-      'You can send ${possibleChatCount} more messages';
-  late final TranslationsBuddyChatPageTextFieldsEn textFields =
-      TranslationsBuddyChatPageTextFieldsEn._(_root);
-  late final TranslationsBuddyChatPageButtonsEn buttons =
-      TranslationsBuddyChatPageButtonsEn._(_root);
-  late final TranslationsBuddyChatPagePlaceCardEn placeCard =
-      TranslationsBuddyChatPagePlaceCardEn._(_root);
-  late final TranslationsBuddyChatPageSnackBarEn snackBar =
-      TranslationsBuddyChatPageSnackBarEn._(_root);
+	// Translations
+	String get title => 'Buddy\'s Suggestions';
+	String possibleChatCount({required Object possibleChatCount}) => 'You can send ${possibleChatCount} more messages';
+	late final TranslationsBuddyChatPageTextFieldsEn textFields = TranslationsBuddyChatPageTextFieldsEn._(_root);
+	late final TranslationsBuddyChatPageButtonsEn buttons = TranslationsBuddyChatPageButtonsEn._(_root);
+	late final TranslationsBuddyChatPagePlaceCardEn placeCard = TranslationsBuddyChatPagePlaceCardEn._(_root);
+	late final TranslationsBuddyChatPageSnackBarEn snackBar = TranslationsBuddyChatPageSnackBarEn._(_root);
 }
 
 // Path: popularTopics
 class TranslationsPopularTopicsEn {
-  TranslationsPopularTopicsEn._(this._root);
+	TranslationsPopularTopicsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get sectionName => 'Popular Topics';
+	// Translations
+	String get sectionName => 'Popular Topics';
 }
 
 // Path: createPlanPage
 class TranslationsCreatePlanPageEn {
-  TranslationsCreatePlanPageEn._(this._root);
+	TranslationsCreatePlanPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Create Plan';
-  late final TranslationsCreatePlanPageLabelEn label =
-      TranslationsCreatePlanPageLabelEn._(_root);
-  late final TranslationsCreatePlanPageHintTextEn hintText =
-      TranslationsCreatePlanPageHintTextEn._(_root);
-  late final TranslationsCreatePlanPageModalEn modal =
-      TranslationsCreatePlanPageModalEn._(_root);
-  List<String> get numberOfPeopleOptions => [
-        '1 person',
-        '2 people',
-        '3 people',
-        '4 people',
-        '5 people',
-        '6 or more',
-      ];
-  List<String> get transportOptions => [
-        'Train',
-        'Walking',
-        'Car',
-        'Bus',
-      ];
-  List<String> get categoryOptions => [
-        'Family-friendly',
-        'Adult',
-        'Entertainment',
-        'Activity',
-        'History',
-      ];
-  List<String> get defaultTopics => [
-        'Gourmet',
-        'Shopping',
-        'Activities',
-        'Movies',
-      ];
-  String get submitButton => 'Submit Plan to AI';
-  late final TranslationsCreatePlanPageSnackBarEn snackBar =
-      TranslationsCreatePlanPageSnackBarEn._(_root);
+	// Translations
+	String get title => 'Create Plan';
+	late final TranslationsCreatePlanPageLabelEn label = TranslationsCreatePlanPageLabelEn._(_root);
+	late final TranslationsCreatePlanPageHintTextEn hintText = TranslationsCreatePlanPageHintTextEn._(_root);
+	late final TranslationsCreatePlanPageModalEn modal = TranslationsCreatePlanPageModalEn._(_root);
+	List<String> get numberOfPeopleOptions => [
+		'1 person',
+		'2 people',
+		'3 people',
+		'4 people',
+		'5 people',
+		'6 or more',
+	];
+	List<String> get transportOptions => [
+		'Train',
+		'Walking',
+		'Car',
+		'Bus',
+	];
+	List<String> get categoryOptions => [
+		'Family-friendly',
+		'Adult',
+		'Entertainment',
+		'Activity',
+		'History',
+	];
+	List<String> get defaultTopics => [
+		'Gourmet',
+		'Shopping',
+		'Activities',
+		'Movies',
+	];
+	String get submitButton => 'Submit Plan to AI';
+	late final TranslationsCreatePlanPageSnackBarEn snackBar = TranslationsCreatePlanPageSnackBarEn._(_root);
 }
 
 // Path: editProfilePage
 class TranslationsEditProfilePageEn {
-  TranslationsEditProfilePageEn._(this._root);
+	TranslationsEditProfilePageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Edit Profile';
-  late final TranslationsEditProfilePageTextFieldsEn textFields =
-      TranslationsEditProfilePageTextFieldsEn._(_root);
-  late final TranslationsEditProfilePageButtonsEn buttons =
-      TranslationsEditProfilePageButtonsEn._(_root);
-  late final TranslationsEditProfilePageSnackBarEn snackBar =
-      TranslationsEditProfilePageSnackBarEn._(_root);
+	// Translations
+	String get title => 'Edit Profile';
+	late final TranslationsEditProfilePageTextFieldsEn textFields = TranslationsEditProfilePageTextFieldsEn._(_root);
+	late final TranslationsEditProfilePageButtonsEn buttons = TranslationsEditProfilePageButtonsEn._(_root);
+	late final TranslationsEditProfilePageSnackBarEn snackBar = TranslationsEditProfilePageSnackBarEn._(_root);
 }
 
 // Path: confirmDialog
 class TranslationsConfirmDialogEn {
-  TranslationsConfirmDialogEn._(this._root);
+	TranslationsConfirmDialogEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsConfirmDialogAnswersEn answers =
-      TranslationsConfirmDialogAnswersEn._(_root);
-  late final TranslationsConfirmDialogPopPageEn popPage =
-      TranslationsConfirmDialogPopPageEn._(_root);
-  late final TranslationsConfirmDialogCompleteCreatePlanEn completeCreatePlan =
-      TranslationsConfirmDialogCompleteCreatePlanEn._(_root);
+	// Translations
+	late final TranslationsConfirmDialogAnswersEn answers = TranslationsConfirmDialogAnswersEn._(_root);
+	late final TranslationsConfirmDialogPopPageEn popPage = TranslationsConfirmDialogPopPageEn._(_root);
+	late final TranslationsConfirmDialogCompleteCreatePlanEn completeCreatePlan = TranslationsConfirmDialogCompleteCreatePlanEn._(_root);
 }
 
 // Path: prompt
 class TranslationsPromptEn {
-  TranslationsPromptEn._(this._root);
+	TranslationsPromptEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get planProposalMessage =>
-      'I’ve come up with this plan! What do you think?';
+	// Translations
+	String get planProposalMessage => 'I’ve come up with this plan! What do you think?';
 }
 
 // Path: billDetailsPage
 class TranslationsBillDetailsPageEn {
-  TranslationsBillDetailsPageEn._(this._root);
+	TranslationsBillDetailsPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Premium Plan';
-  String get description =>
-      'By subscribing to the Premium Plan, you can enjoy a more comfortable sightseeing experience in Shibuya.';
-  late final TranslationsBillDetailsPagePricingPlanEn pricingPlan =
-      TranslationsBillDetailsPagePricingPlanEn._(_root);
-  late final TranslationsBillDetailsPageFeaturesEn features =
-      TranslationsBillDetailsPageFeaturesEn._(_root);
-  late final TranslationsBillDetailsPagePricingOptionsEn pricingOptions =
-      TranslationsBillDetailsPagePricingOptionsEn._(_root);
-  String get upgradeButton => 'Upgrade to Premium';
+	// Translations
+	String get title => 'Premium Plan';
+	String get description => 'By subscribing to the Premium Plan, you can enjoy a more comfortable sightseeing experience in Shibuya.';
+	late final TranslationsBillDetailsPagePricingPlanEn pricingPlan = TranslationsBillDetailsPagePricingPlanEn._(_root);
+	late final TranslationsBillDetailsPageFeaturesEn features = TranslationsBillDetailsPageFeaturesEn._(_root);
+	late final TranslationsBillDetailsPagePricingOptionsEn pricingOptions = TranslationsBillDetailsPagePricingOptionsEn._(_root);
+	String get upgradeButton => 'Upgrade to Premium';
 }
 
 // Path: planDetailsPage
 class TranslationsPlanDetailsPageEn {
-  TranslationsPlanDetailsPageEn._(this._root);
+	TranslationsPlanDetailsPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsPlanDetailsPageDateTimeEn dateTime =
-      TranslationsPlanDetailsPageDateTimeEn._(_root);
-  late final TranslationsPlanDetailsPageItemEn item =
-      TranslationsPlanDetailsPageItemEn._(_root);
-  late final TranslationsPlanDetailsPageSnackBarEn snackBar =
-      TranslationsPlanDetailsPageSnackBarEn._(_root);
+	// Translations
+	late final TranslationsPlanDetailsPageDateTimeEn dateTime = TranslationsPlanDetailsPageDateTimeEn._(_root);
+	late final TranslationsPlanDetailsPageItemEn item = TranslationsPlanDetailsPageItemEn._(_root);
+	late final TranslationsPlanDetailsPageSnackBarEn snackBar = TranslationsPlanDetailsPageSnackBarEn._(_root);
 }
 
 // Path: errorPage
 class TranslationsErrorPageEn {
-  TranslationsErrorPageEn._(this._root);
+	TranslationsErrorPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'An error occurred...';
-  String get message => 'Please check your network connection and try again.';
-  String get retryButton => 'Retry';
+	// Translations
+	String get title => 'An error occurred...';
+	String get message => 'Please check your network connection and try again.';
+	String get retryButton => 'Retry';
 }
 
 // Path: mapPage
 class TranslationsMapPageEn {
-  TranslationsMapPageEn._(this._root);
+	TranslationsMapPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Map';
+	// Translations
+	String get title => 'Map';
 }
 
 // Path: navigationBar.items
 class TranslationsNavigationBarItemsEn {
-  TranslationsNavigationBarItemsEn._(this._root);
+	TranslationsNavigationBarItemsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get home => 'Home';
-  String get myPlan => 'My Plan';
-  String get myPage => 'My Page';
+	// Translations
+	String get home => 'Home';
+	String get myPlan => 'My Plan';
+	String get myPage => 'My Page';
 }
 
 // Path: homePage.popularPlans
 class TranslationsHomePagePopularPlansEn {
-  TranslationsHomePagePopularPlansEn._(this._root);
+	TranslationsHomePagePopularPlansEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Popular Plans';
+	// Translations
+	String get title => 'Popular Plans';
 }
 
 // Path: homePage.popularTopics
 class TranslationsHomePagePopularTopicsEn {
-  TranslationsHomePagePopularTopicsEn._(this._root);
+	TranslationsHomePagePopularTopicsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Popular Topics';
-  String numberOfTopics({required Object number}) => '${number} items~';
+	// Translations
+	String get title => 'Popular Topics';
+	String numberOfTopics({required Object number}) => '${number} items~';
 }
 
 // Path: homePage.recentPlans
 class TranslationsHomePageRecentPlansEn {
-  TranslationsHomePageRecentPlansEn._(this._root);
+	TranslationsHomePageRecentPlansEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Recently Created Plans';
+	// Translations
+	String get title => 'Recently Created Plans';
 }
 
 // Path: accountPage.items
 class TranslationsAccountPageItemsEn {
-  TranslationsAccountPageItemsEn._(this._root);
+	TranslationsAccountPageItemsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get signOut => 'Sign Out';
-  String get linkedWithGoogle => 'Linked with Google';
-  String get linkedWithApple => 'Linked with Apple';
-  String get alreadyLinkedGoogle => 'Already Linked with Google';
-  String get alreadyLinkedApple => 'Already Linked with Apple';
+	// Translations
+	String get signOut => 'Sign Out';
+	String get linkedWithGoogle => 'Linked with Google';
+	String get linkedWithApple => 'Linked with Apple';
+	String get alreadyLinkedGoogle => 'Already Linked with Google';
+	String get alreadyLinkedApple => 'Already Linked with Apple';
 }
 
 // Path: accountPage.snackBar
 class TranslationsAccountPageSnackBarEn {
-  TranslationsAccountPageSnackBarEn._(this._root);
+	TranslationsAccountPageSnackBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get signOut => 'You have been logged out.';
-  String get signOutFailure => 'An error occurred while signing out.';
-  String get successfulLinkage => 'Account linked successfully.';
-  String get linkageFailure => 'Failed to link account.';
-  String get providerAlreadyLinked => 'This account is already linked.';
-  String get accountDeactivation => 'Account linkage has been removed.';
-  String get invalidCredential => 'Please try logging in again.';
-  String get linkageCancelled => 'Account linking was cancelled.';
-  String get unlinkageFailure => 'Failed to remove account linkage.';
-  String get operationNotAllowed =>
-      'Provider is invalid. Please contact the developer.';
-  String get unknownError => 'An unknown error occurred.';
+	// Translations
+	String get signOut => 'You have been logged out.';
+	String get signOutFailure => 'An error occurred while signing out.';
+	String get successfulLinkage => 'Account linked successfully.';
+	String get linkageFailure => 'Failed to link account.';
+	String get providerAlreadyLinked => 'This account is already linked.';
+	String get accountDeactivation => 'Account linkage has been removed.';
+	String get invalidCredential => 'Please try logging in again.';
+	String get linkageCancelled => 'Account linking was cancelled.';
+	String get unlinkageFailure => 'Failed to remove account linkage.';
+	String get operationNotAllowed => 'Provider is invalid. Please contact the developer.';
+	String get unknownError => 'An unknown error occurred.';
 }
 
 // Path: accountPage.diaLog
 class TranslationsAccountPageDiaLogEn {
-  TranslationsAccountPageDiaLogEn._(this._root);
+	TranslationsAccountPageDiaLogEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get yes => 'Yes';
-  String get no => 'No';
-  String get title => 'Confirm Account Unlinking';
-  String get googleText =>
-      'Do you want to unlink the current account from your Google account?';
-  String get appleText =>
-      'Do you want to unlink the current account from your Apple account?';
+	// Translations
+	String get yes => 'Yes';
+	String get no => 'No';
+	String get title => 'Confirm Account Unlinking';
+	String get googleText => 'Do you want to unlink the current account from your Google account?';
+	String get appleText => 'Do you want to unlink the current account from your Apple account?';
 }
 
 // Path: authentication.signInPage
 class TranslationsAuthenticationSignInPageEn {
-  TranslationsAuthenticationSignInPageEn._(this._root);
+	TranslationsAuthenticationSignInPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Sign In';
-  String get optionText => ' or ';
-  late final TranslationsAuthenticationSignInPageTextFieldsEn textFields =
-      TranslationsAuthenticationSignInPageTextFieldsEn._(_root);
-  late final TranslationsAuthenticationSignInPageButtonsEn buttons =
-      TranslationsAuthenticationSignInPageButtonsEn._(_root);
+	// Translations
+	String get title => 'Sign In';
+	String get optionText => ' or ';
+	late final TranslationsAuthenticationSignInPageTextFieldsEn textFields = TranslationsAuthenticationSignInPageTextFieldsEn._(_root);
+	late final TranslationsAuthenticationSignInPageButtonsEn buttons = TranslationsAuthenticationSignInPageButtonsEn._(_root);
 }
 
 // Path: authentication.firebaseAuth
 class TranslationsAuthenticationFirebaseAuthEn {
-  TranslationsAuthenticationFirebaseAuthEn._(this._root);
+	TranslationsAuthenticationFirebaseAuthEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsAuthenticationFirebaseAuthErrorEn error =
-      TranslationsAuthenticationFirebaseAuthErrorEn._(_root);
+	// Translations
+	late final TranslationsAuthenticationFirebaseAuthErrorEn error = TranslationsAuthenticationFirebaseAuthErrorEn._(_root);
 }
 
 // Path: authentication.resetPasswordPage
 class TranslationsAuthenticationResetPasswordPageEn {
-  TranslationsAuthenticationResetPasswordPageEn._(this._root);
+	TranslationsAuthenticationResetPasswordPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Reset Password';
-  String get description =>
-      'A password reset email will be sent to the entered email address';
-  late final TranslationsAuthenticationResetPasswordPageTextFieldsEn
-      textFields =
-      TranslationsAuthenticationResetPasswordPageTextFieldsEn._(_root);
-  late final TranslationsAuthenticationResetPasswordPageButtonsEn buttons =
-      TranslationsAuthenticationResetPasswordPageButtonsEn._(_root);
+	// Translations
+	String get title => 'Reset Password';
+	String get description => 'A password reset email will be sent to the entered email address';
+	late final TranslationsAuthenticationResetPasswordPageTextFieldsEn textFields = TranslationsAuthenticationResetPasswordPageTextFieldsEn._(_root);
+	late final TranslationsAuthenticationResetPasswordPageButtonsEn buttons = TranslationsAuthenticationResetPasswordPageButtonsEn._(_root);
 }
 
 // Path: authentication.signUpPage
 class TranslationsAuthenticationSignUpPageEn {
-  TranslationsAuthenticationSignUpPageEn._(this._root);
+	TranslationsAuthenticationSignUpPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Sign Up';
-  late final TranslationsAuthenticationSignUpPageTextFieldsEn textFields =
-      TranslationsAuthenticationSignUpPageTextFieldsEn._(_root);
-  String get button => 'Sign Up';
+	// Translations
+	String get title => 'Sign Up';
+	late final TranslationsAuthenticationSignUpPageTextFieldsEn textFields = TranslationsAuthenticationSignUpPageTextFieldsEn._(_root);
+	String get button => 'Sign Up';
 }
 
 // Path: authentication.emailVerificationPage
 class TranslationsAuthenticationEmailVerificationPageEn {
-  TranslationsAuthenticationEmailVerificationPageEn._(this._root);
+	TranslationsAuthenticationEmailVerificationPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Email Address Verification';
-  String descriptionForDestination({required Object email}) =>
-      'A verification email will be sent to the entered ${email}.';
-  String get descriptionForCoolDown =>
-      'You can resend the verification email once every 60 seconds.';
-  late final TranslationsAuthenticationEmailVerificationPageButtonsEn buttons =
-      TranslationsAuthenticationEmailVerificationPageButtonsEn._(_root);
-  late final TranslationsAuthenticationEmailVerificationPageSnackBarEn
-      snackBar =
-      TranslationsAuthenticationEmailVerificationPageSnackBarEn._(_root);
+	// Translations
+	String get title => 'Email Address Verification';
+	String descriptionForDestination({required Object email}) => 'A verification email will be sent to the entered ${email}.';
+	String get descriptionForCoolDown => 'You can resend the verification email once every 60 seconds.';
+	late final TranslationsAuthenticationEmailVerificationPageButtonsEn buttons = TranslationsAuthenticationEmailVerificationPageButtonsEn._(_root);
+	late final TranslationsAuthenticationEmailVerificationPageSnackBarEn snackBar = TranslationsAuthenticationEmailVerificationPageSnackBarEn._(_root);
 }
 
 // Path: authentication.registerProfilePage
 class TranslationsAuthenticationRegisterProfilePageEn {
-  TranslationsAuthenticationRegisterProfilePageEn._(this._root);
+	TranslationsAuthenticationRegisterProfilePageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Profile Registration';
-  String get textFields => 'Name';
-  late final TranslationsAuthenticationRegisterProfilePageButtonsEn buttons =
-      TranslationsAuthenticationRegisterProfilePageButtonsEn._(_root);
-  late final TranslationsAuthenticationRegisterProfilePageSnackBarEn snackBar =
-      TranslationsAuthenticationRegisterProfilePageSnackBarEn._(_root);
+	// Translations
+	String get title => 'Profile Registration';
+	String get textFields => 'Name';
+	late final TranslationsAuthenticationRegisterProfilePageButtonsEn buttons = TranslationsAuthenticationRegisterProfilePageButtonsEn._(_root);
+	late final TranslationsAuthenticationRegisterProfilePageSnackBarEn snackBar = TranslationsAuthenticationRegisterProfilePageSnackBarEn._(_root);
 }
 
 // Path: authentication.completeSendEmailPage
 class TranslationsAuthenticationCompleteSendEmailPageEn {
-  TranslationsAuthenticationCompleteSendEmailPageEn._(this._root);
+	TranslationsAuthenticationCompleteSendEmailPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Send Complete';
-  String description({required Object email}) =>
-      'A password reset email has been sent to ${email} \n Please log in from the login screen after resetting';
-  String get successResendEmail => 'Confirmation email has been resent';
-  late final TranslationsAuthenticationCompleteSendEmailPageButtonsEn buttons =
-      TranslationsAuthenticationCompleteSendEmailPageButtonsEn._(_root);
+	// Translations
+	String get title => 'Send Complete';
+	String description({required Object email}) => 'A password reset email has been sent to ${email} \n Please log in from the login screen after resetting';
+	String get successResendEmail => 'Confirmation email has been resent';
+	late final TranslationsAuthenticationCompleteSendEmailPageButtonsEn buttons = TranslationsAuthenticationCompleteSendEmailPageButtonsEn._(_root);
 }
 
 // Path: myPage.accountStatus
 class TranslationsMyPageAccountStatusEn {
-  TranslationsMyPageAccountStatusEn._(this._root);
+	TranslationsMyPageAccountStatusEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsMyPageAccountStatusDateTimeEn dateTime =
-      TranslationsMyPageAccountStatusDateTimeEn._(_root);
-  String get premium => 'Premium Member';
-  String get standard => 'Standard Member';
+	// Translations
+	late final TranslationsMyPageAccountStatusDateTimeEn dateTime = TranslationsMyPageAccountStatusDateTimeEn._(_root);
+	String get premium => 'Premium Member';
+	String get standard => 'Standard Member';
 }
 
 // Path: changeLanguagePage.items
 class TranslationsChangeLanguagePageItemsEn {
-  TranslationsChangeLanguagePageItemsEn._(this._root);
+	TranslationsChangeLanguagePageItemsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get japanese => 'Japanese';
-  String get english => 'English';
-  String get simplifiedChinese => 'Chinese (Simplified)';
-  String get traditionalChinese => 'Chinese (Traditional)';
+	// Translations
+	String get japanese => 'Japanese';
+	String get english => 'English';
+	String get simplifiedChinese => 'Chinese (Simplified)';
+	String get traditionalChinese => 'Chinese (Traditional)';
 }
 
 // Path: changeThemePage.items
 class TranslationsChangeThemePageItemsEn {
-  TranslationsChangeThemePageItemsEn._(this._root);
+	TranslationsChangeThemePageItemsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get system => 'System';
-  String get light => 'Light';
-  String get dark => 'Dark';
+	// Translations
+	String get system => 'System';
+	String get light => 'Light';
+	String get dark => 'Dark';
 }
 
 // Path: myPlanPage.tabs
 class TranslationsMyPlanPageTabsEn {
-  TranslationsMyPlanPageTabsEn._(this._root);
+	TranslationsMyPlanPageTabsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get createdPlans => 'Created Plans';
-  String get bookmark => 'Bookmarks';
+	// Translations
+	String get createdPlans => 'Created Plans';
+	String get bookmark => 'Bookmarks';
 }
 
 // Path: myPlanPage.bookmarkItems
 class TranslationsMyPlanPageBookmarkItemsEn {
-  TranslationsMyPlanPageBookmarkItemsEn._(this._root);
+	TranslationsMyPlanPageBookmarkItemsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get nondata => 'No bookmarked plans yet.';
-  String get reloading => 'Reload';
+	// Translations
+	String get nondata => 'No bookmarked plans yet.';
+	String get reloading => 'Reload';
 }
 
 // Path: myPlanPage.createdPlansItems
 class TranslationsMyPlanPageCreatedPlansItemsEn {
-  TranslationsMyPlanPageCreatedPlansItemsEn._(this._root);
+	TranslationsMyPlanPageCreatedPlansItemsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get nondata => 'Let\'s create a plan!';
-  String get createaplan => 'Create a Plan';
+	// Translations
+	String get nondata => 'Let\'s create a plan!';
+	String get createaplan => 'Create a Plan';
 }
 
 // Path: myPlanPage.error
 class TranslationsMyPlanPageErrorEn {
-  TranslationsMyPlanPageErrorEn._(this._root);
+	TranslationsMyPlanPageErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get displayError => 'An error occurred while displaying the plan.';
-  String get failedGetId => 'Failed to retrieve plan ID.';
-  String get failedGetPlanData =>
-      'An error occurred while retrieving plan data.';
-  String get failedUnBookmark => 'Failed to remove bookmark.';
+	// Translations
+	String get displayError => 'An error occurred while displaying the plan.';
+	String get failedGetId => 'Failed to retrieve plan ID.';
+	String get failedGetPlanData => 'An error occurred while retrieving plan data.';
+	String get failedUnBookmark => 'Failed to remove bookmark.';
 }
 
 // Path: buddyChatPage.textFields
 class TranslationsBuddyChatPageTextFieldsEn {
-  TranslationsBuddyChatPageTextFieldsEn._(this._root);
+	TranslationsBuddyChatPageTextFieldsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get message => 'Enter message';
+	// Translations
+	String get message => 'Enter message';
 }
 
 // Path: buddyChatPage.buttons
 class TranslationsBuddyChatPageButtonsEn {
-  TranslationsBuddyChatPageButtonsEn._(this._root);
+	TranslationsBuddyChatPageButtonsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get send => 'Done';
+	// Translations
+	String get send => 'Done';
 }
 
 // Path: buddyChatPage.placeCard
 class TranslationsBuddyChatPagePlaceCardEn {
-  TranslationsBuddyChatPagePlaceCardEn._(this._root);
+	TranslationsBuddyChatPagePlaceCardEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get openingHours => 'Opening Hours';
-  String get averageAmount => 'Average Budget';
-  String get website => 'Website';
+	// Translations
+	String get openingHours => 'Opening Hours';
+	String get averageAmount => 'Average Budget';
+	String get website => 'Website';
 }
 
 // Path: buddyChatPage.snackBar
 class TranslationsBuddyChatPageSnackBarEn {
-  TranslationsBuddyChatPageSnackBarEn._(this._root);
+	TranslationsBuddyChatPageSnackBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsBuddyChatPageSnackBarErrorEn error =
-      TranslationsBuddyChatPageSnackBarErrorEn._(_root);
+	// Translations
+	late final TranslationsBuddyChatPageSnackBarErrorEn error = TranslationsBuddyChatPageSnackBarErrorEn._(_root);
 }
 
 // Path: createPlanPage.label
 class TranslationsCreatePlanPageLabelEn {
-  TranslationsCreatePlanPageLabelEn._(this._root);
+	TranslationsCreatePlanPageLabelEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get location => 'Destination';
-  String get scheduleStart => 'Start Date';
-  String get scheduleEnd => 'End Date';
-  String get numberOfPeople => 'Number of People';
-  String get transport => 'Transportation';
-  String get category => 'Category';
-  String get topics => 'Travel Topics';
+	// Translations
+	String get location => 'Destination';
+	String get scheduleStart => 'Start Date';
+	String get scheduleEnd => 'End Date';
+	String get numberOfPeople => 'Number of People';
+	String get transport => 'Transportation';
+	String get category => 'Category';
+	String get topics => 'Travel Topics';
 }
 
 // Path: createPlanPage.hintText
 class TranslationsCreatePlanPageHintTextEn {
-  TranslationsCreatePlanPageHintTextEn._(this._root);
+	TranslationsCreatePlanPageHintTextEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get location => 'Shibuya';
+	// Translations
+	String get location => 'Shibuya';
 }
 
 // Path: createPlanPage.modal
 class TranslationsCreatePlanPageModalEn {
-  TranslationsCreatePlanPageModalEn._(this._root);
+	TranslationsCreatePlanPageModalEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Select a date';
+	// Translations
+	String get title => 'Select a date';
 }
 
 // Path: createPlanPage.snackBar
 class TranslationsCreatePlanPageSnackBarEn {
-  TranslationsCreatePlanPageSnackBarEn._(this._root);
+	TranslationsCreatePlanPageSnackBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsCreatePlanPageSnackBarErrorEn error =
-      TranslationsCreatePlanPageSnackBarErrorEn._(_root);
+	// Translations
+	late final TranslationsCreatePlanPageSnackBarErrorEn error = TranslationsCreatePlanPageSnackBarErrorEn._(_root);
 }
 
 // Path: editProfilePage.textFields
 class TranslationsEditProfilePageTextFieldsEn {
-  TranslationsEditProfilePageTextFieldsEn._(this._root);
+	TranslationsEditProfilePageTextFieldsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get name => 'Name';
+	// Translations
+	String get name => 'Name';
 }
 
 // Path: editProfilePage.buttons
 class TranslationsEditProfilePageButtonsEn {
-  TranslationsEditProfilePageButtonsEn._(this._root);
+	TranslationsEditProfilePageButtonsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get submit => 'Save';
+	// Translations
+	String get submit => 'Save';
 }
 
 // Path: editProfilePage.snackBar
 class TranslationsEditProfilePageSnackBarEn {
-  TranslationsEditProfilePageSnackBarEn._(this._root);
+	TranslationsEditProfilePageSnackBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get success => 'Updated successfully';
-  late final TranslationsEditProfilePageSnackBarErrorEn error =
-      TranslationsEditProfilePageSnackBarErrorEn._(_root);
+	// Translations
+	String get success => 'Updated successfully';
+	late final TranslationsEditProfilePageSnackBarErrorEn error = TranslationsEditProfilePageSnackBarErrorEn._(_root);
 }
 
 // Path: confirmDialog.answers
 class TranslationsConfirmDialogAnswersEn {
-  TranslationsConfirmDialogAnswersEn._(this._root);
+	TranslationsConfirmDialogAnswersEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get yes => 'Yes';
-  String get no => 'No';
+	// Translations
+	String get yes => 'Yes';
+	String get no => 'No';
 }
 
 // Path: confirmDialog.popPage
 class TranslationsConfirmDialogPopPageEn {
-  TranslationsConfirmDialogPopPageEn._(this._root);
+	TranslationsConfirmDialogPopPageEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Return to the previous page?';
-  String get description => 'Current content will not be saved.';
+	// Translations
+	String get title => 'Return to the previous page?';
+	String get description => 'Current content will not be saved.';
 }
 
 // Path: confirmDialog.completeCreatePlan
 class TranslationsConfirmDialogCompleteCreatePlanEn {
-  TranslationsConfirmDialogCompleteCreatePlanEn._(this._root);
+	TranslationsConfirmDialogCompleteCreatePlanEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Confirm the plan?';
-  String get description => 'The plan in the last message will be saved.';
+	// Translations
+	String get title => 'Confirm the plan?';
+	String get description => 'The plan in the last message will be saved.';
 }
 
 // Path: billDetailsPage.pricingPlan
 class TranslationsBillDetailsPagePricingPlanEn {
-  TranslationsBillDetailsPagePricingPlanEn._(this._root);
+	TranslationsBillDetailsPagePricingPlanEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Pricing Plan';
-  late final TranslationsBillDetailsPagePricingPlanColumnsEn columns =
-      TranslationsBillDetailsPagePricingPlanColumnsEn._(_root);
-  late final TranslationsBillDetailsPagePricingPlanDetailsEn details =
-      TranslationsBillDetailsPagePricingPlanDetailsEn._(_root);
+	// Translations
+	String get title => 'Pricing Plan';
+	late final TranslationsBillDetailsPagePricingPlanColumnsEn columns = TranslationsBillDetailsPagePricingPlanColumnsEn._(_root);
+	late final TranslationsBillDetailsPagePricingPlanDetailsEn details = TranslationsBillDetailsPagePricingPlanDetailsEn._(_root);
 }
 
 // Path: billDetailsPage.features
 class TranslationsBillDetailsPageFeaturesEn {
-  TranslationsBillDetailsPageFeaturesEn._(this._root);
+	TranslationsBillDetailsPageFeaturesEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get title => 'Features by Grade';
-  late final TranslationsBillDetailsPageFeaturesRowsEn rows =
-      TranslationsBillDetailsPageFeaturesRowsEn._(_root);
-  late final TranslationsBillDetailsPageFeaturesColumnsEn columns =
-      TranslationsBillDetailsPageFeaturesColumnsEn._(_root);
+	// Translations
+	String get title => 'Features by Grade';
+	late final TranslationsBillDetailsPageFeaturesRowsEn rows = TranslationsBillDetailsPageFeaturesRowsEn._(_root);
+	late final TranslationsBillDetailsPageFeaturesColumnsEn columns = TranslationsBillDetailsPageFeaturesColumnsEn._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions
 class TranslationsBillDetailsPagePricingOptionsEn {
-  TranslationsBillDetailsPagePricingOptionsEn._(this._root);
+	TranslationsBillDetailsPagePricingOptionsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsBillDetailsPagePricingOptionsOneDayEn oneDay =
-      TranslationsBillDetailsPagePricingOptionsOneDayEn._(_root);
-  late final TranslationsBillDetailsPagePricingOptionsThreeDaysEn threeDays =
-      TranslationsBillDetailsPagePricingOptionsThreeDaysEn._(_root);
-  late final TranslationsBillDetailsPagePricingOptionsFiveDaysEn fiveDays =
-      TranslationsBillDetailsPagePricingOptionsFiveDaysEn._(_root);
-  late final TranslationsBillDetailsPagePricingOptionsSevenDaysEn sevenDays =
-      TranslationsBillDetailsPagePricingOptionsSevenDaysEn._(_root);
-  late final TranslationsBillDetailsPagePricingOptionsLifetimeEn lifetime =
-      TranslationsBillDetailsPagePricingOptionsLifetimeEn._(_root);
+	// Translations
+	late final TranslationsBillDetailsPagePricingOptionsOneDayEn oneDay = TranslationsBillDetailsPagePricingOptionsOneDayEn._(_root);
+	late final TranslationsBillDetailsPagePricingOptionsThreeDaysEn threeDays = TranslationsBillDetailsPagePricingOptionsThreeDaysEn._(_root);
+	late final TranslationsBillDetailsPagePricingOptionsFiveDaysEn fiveDays = TranslationsBillDetailsPagePricingOptionsFiveDaysEn._(_root);
+	late final TranslationsBillDetailsPagePricingOptionsSevenDaysEn sevenDays = TranslationsBillDetailsPagePricingOptionsSevenDaysEn._(_root);
+	late final TranslationsBillDetailsPagePricingOptionsLifetimeEn lifetime = TranslationsBillDetailsPagePricingOptionsLifetimeEn._(_root);
 }
 
 // Path: planDetailsPage.dateTime
 class TranslationsPlanDetailsPageDateTimeEn {
-  TranslationsPlanDetailsPageDateTimeEn._(this._root);
+	TranslationsPlanDetailsPageDateTimeEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String createOn({required Object date}) => 'Plan created on${date}';
-  String get dateFormat => 'MM/dd/yyyy';
+	// Translations
+	String createOn({required Object date}) => 'Plan created on${date}';
+	String get dateFormat => 'MM/dd/yyyy';
 }
 
 // Path: planDetailsPage.item
 class TranslationsPlanDetailsPageItemEn {
-  TranslationsPlanDetailsPageItemEn._(this._root);
+	TranslationsPlanDetailsPageItemEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get viewOnMap => 'View on Map';
+	// Translations
+	String get viewOnMap => 'View on Map';
 }
 
 // Path: planDetailsPage.snackBar
 class TranslationsPlanDetailsPageSnackBarEn {
-  TranslationsPlanDetailsPageSnackBarEn._(this._root);
+	TranslationsPlanDetailsPageSnackBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsPlanDetailsPageSnackBarErrorEn error =
-      TranslationsPlanDetailsPageSnackBarErrorEn._(_root);
+	// Translations
+	late final TranslationsPlanDetailsPageSnackBarErrorEn error = TranslationsPlanDetailsPageSnackBarErrorEn._(_root);
 }
 
 // Path: authentication.signInPage.textFields
 class TranslationsAuthenticationSignInPageTextFieldsEn {
-  TranslationsAuthenticationSignInPageTextFieldsEn._(this._root);
+	TranslationsAuthenticationSignInPageTextFieldsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get email => 'Email Address';
-  String get password => 'Password';
+	// Translations
+	String get email => 'Email Address';
+	String get password => 'Password';
 }
 
 // Path: authentication.signInPage.buttons
 class TranslationsAuthenticationSignInPageButtonsEn {
-  TranslationsAuthenticationSignInPageButtonsEn._(this._root);
+	TranslationsAuthenticationSignInPageButtonsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get signIn => 'Sign In';
-  String get signUp => 'Sign Up';
-  String get resetPassword => 'Forgot Password?';
-  String get appleSignIn => 'Sign in with Apple';
-  String get googleSignIn => 'Sign in with Google';
-  String get signInAfter => 'Register Later';
+	// Translations
+	String get signIn => 'Sign In';
+	String get signUp => 'Sign Up';
+	String get resetPassword => 'Forgot Password?';
+	String get appleSignIn => 'Sign in with Apple';
+	String get googleSignIn => 'Sign in with Google';
+	String get signInAfter => 'Register Later';
 }
 
 // Path: authentication.firebaseAuth.error
 class TranslationsAuthenticationFirebaseAuthErrorEn {
-  TranslationsAuthenticationFirebaseAuthErrorEn._(this._root);
+	TranslationsAuthenticationFirebaseAuthErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get networkRequestFailed =>
-      'Please try again in a good network environment';
-  String get weakPassword =>
-      'Password is too short. Please enter 6 characters or more';
-  String get invalidEmail => 'Email address is not in the correct format';
-  String get userNotFound => 'Account not found';
-  String get wrongPassword => 'Password is incorrect';
-  String get emailAlreadyInUse =>
-      'Email address is already in use. Please log in or create with another email address';
-  String get unexpected =>
-      'An error occurred. Please try again in a good network environment';
+	// Translations
+	String get networkRequestFailed => 'Please try again in a good network environment';
+	String get weakPassword => 'Password is too short. Please enter 6 characters or more';
+	String get invalidEmail => 'Email address is not in the correct format';
+	String get userNotFound => 'Account not found';
+	String get wrongPassword => 'Password is incorrect';
+	String get emailAlreadyInUse => 'Email address is already in use. Please log in or create with another email address';
+	String get unexpected => 'An error occurred. Please try again in a good network environment';
 }
 
 // Path: authentication.resetPasswordPage.textFields
 class TranslationsAuthenticationResetPasswordPageTextFieldsEn {
-  TranslationsAuthenticationResetPasswordPageTextFieldsEn._(this._root);
+	TranslationsAuthenticationResetPasswordPageTextFieldsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get email => 'Email Address';
+	// Translations
+	String get email => 'Email Address';
 }
 
 // Path: authentication.resetPasswordPage.buttons
 class TranslationsAuthenticationResetPasswordPageButtonsEn {
-  TranslationsAuthenticationResetPasswordPageButtonsEn._(this._root);
+	TranslationsAuthenticationResetPasswordPageButtonsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get submit => 'Submit';
+	// Translations
+	String get submit => 'Submit';
 }
 
 // Path: authentication.signUpPage.textFields
 class TranslationsAuthenticationSignUpPageTextFieldsEn {
-  TranslationsAuthenticationSignUpPageTextFieldsEn._(this._root);
+	TranslationsAuthenticationSignUpPageTextFieldsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get email => 'Email Address';
-  String get password => 'Password';
+	// Translations
+	String get email => 'Email Address';
+	String get password => 'Password';
 }
 
 // Path: authentication.emailVerificationPage.buttons
 class TranslationsAuthenticationEmailVerificationPageButtonsEn {
-  TranslationsAuthenticationEmailVerificationPageButtonsEn._(this._root);
+	TranslationsAuthenticationEmailVerificationPageButtonsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get sendEmail => 'Send Verification Email';
-  String get resendEmail => 'Resend Verification Email';
-  String get toNext => 'Next';
-  String get retypeEmail => 'Edit Email Address';
+	// Translations
+	String get sendEmail => 'Send Verification Email';
+	String get resendEmail => 'Resend Verification Email';
+	String get toNext => 'Next';
+	String get retypeEmail => 'Edit Email Address';
 }
 
 // Path: authentication.emailVerificationPage.snackBar
 class TranslationsAuthenticationEmailVerificationPageSnackBarEn {
-  TranslationsAuthenticationEmailVerificationPageSnackBarEn._(this._root);
+	TranslationsAuthenticationEmailVerificationPageSnackBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get success => 'Email sent successfully';
-  late final TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn
-      error =
-      TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn._(_root);
+	// Translations
+	String get success => 'Email sent successfully';
+	late final TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn error = TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn._(_root);
 }
 
 // Path: authentication.registerProfilePage.buttons
 class TranslationsAuthenticationRegisterProfilePageButtonsEn {
-  TranslationsAuthenticationRegisterProfilePageButtonsEn._(this._root);
+	TranslationsAuthenticationRegisterProfilePageButtonsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get submit => 'Complete';
-  String get skip => 'Skip';
+	// Translations
+	String get submit => 'Complete';
+	String get skip => 'Skip';
 }
 
 // Path: authentication.registerProfilePage.snackBar
 class TranslationsAuthenticationRegisterProfilePageSnackBarEn {
-  TranslationsAuthenticationRegisterProfilePageSnackBarEn._(this._root);
+	TranslationsAuthenticationRegisterProfilePageSnackBarEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn
-      error =
-      TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn._(_root);
+	// Translations
+	late final TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn error = TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn._(_root);
 }
 
 // Path: authentication.completeSendEmailPage.buttons
 class TranslationsAuthenticationCompleteSendEmailPageButtonsEn {
-  TranslationsAuthenticationCompleteSendEmailPageButtonsEn._(this._root);
+	TranslationsAuthenticationCompleteSendEmailPageButtonsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get toSignIn => 'To Login Screen';
-  String get resendEmail => 'Resend Confirmation Email';
-  String get changeEmail => 'Change Email Address';
+	// Translations
+	String get toSignIn => 'To Login Screen';
+	String get resendEmail => 'Resend Confirmation Email';
+	String get changeEmail => 'Change Email Address';
 }
 
 // Path: myPage.accountStatus.dateTime
 class TranslationsMyPageAccountStatusDateTimeEn {
-  TranslationsMyPageAccountStatusDateTimeEn._(this._root);
+	TranslationsMyPageAccountStatusDateTimeEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String registeredOn({required Object date}) => 'Registered on ${date}';
-  String get registeredOnFormat => 'MM/dd/yyyy';
-  String validUntil({required Object date}) => 'Valid until${date}';
-  String get validUntilFormat => 'MM/dd/yyyy hh:mm';
+	// Translations
+	String registeredOn({required Object date}) => 'Registered on ${date}';
+	String get registeredOnFormat => 'MM/dd/yyyy';
+	String validUntil({required Object date}) => 'Valid until${date}';
+	String get validUntilFormat => 'MM/dd/yyyy hh:mm';
 }
 
 // Path: buddyChatPage.snackBar.error
 class TranslationsBuddyChatPageSnackBarErrorEn {
-  TranslationsBuddyChatPageSnackBarErrorEn._(this._root);
+	TranslationsBuddyChatPageSnackBarErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get failedRecieveMessage =>
-      'Failed to receive the reply. Please try again later.';
-  String get failedCompleteCreatePlan =>
-      'Failed to complete plan creation. Please try again later.';
+	// Translations
+	String get failedRecieveMessage => 'Failed to receive the reply. Please try again later.';
+	String get failedCompleteCreatePlan => 'Failed to complete plan creation. Please try again later.';
 }
 
 // Path: createPlanPage.snackBar.error
 class TranslationsCreatePlanPageSnackBarErrorEn {
-  TranslationsCreatePlanPageSnackBarErrorEn._(this._root);
+	TranslationsCreatePlanPageSnackBarErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get foundUnSelectedField =>
-      'There are unselected items. Please select all items.';
+	// Translations
+	String get foundUnSelectedField => 'There are unselected items. Please select all items.';
 }
 
 // Path: editProfilePage.snackBar.error
 class TranslationsEditProfilePageSnackBarErrorEn {
-  TranslationsEditProfilePageSnackBarErrorEn._(this._root);
+	TranslationsEditProfilePageSnackBarErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get noChange => 'No changes detected';
-  String get failedToUpdate => 'Failed to update. Please try again later.';
-  String get failedToPickImage =>
-      'Failed to select image. Please try again later.';
+	// Translations
+	String get noChange => 'No changes detected';
+	String get failedToUpdate => 'Failed to update. Please try again later.';
+	String get failedToPickImage => 'Failed to select image. Please try again later.';
 }
 
 // Path: billDetailsPage.pricingPlan.columns
 class TranslationsBillDetailsPagePricingPlanColumnsEn {
-  TranslationsBillDetailsPagePricingPlanColumnsEn._(this._root);
+	TranslationsBillDetailsPagePricingPlanColumnsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get standard => 'Standard';
-  String get premium => 'Premium';
+	// Translations
+	String get standard => 'Standard';
+	String get premium => 'Premium';
 }
 
 // Path: billDetailsPage.pricingPlan.details
 class TranslationsBillDetailsPagePricingPlanDetailsEn {
-  TranslationsBillDetailsPagePricingPlanDetailsEn._(this._root);
+	TranslationsBillDetailsPagePricingPlanDetailsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get free => 'Free 🎉';
-  late final TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn
-      premiumPrice =
-      TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn._(_root);
+	// Translations
+	String get free => 'Free 🎉';
+	late final TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn premiumPrice = TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn._(_root);
 }
 
 // Path: billDetailsPage.features.rows
 class TranslationsBillDetailsPageFeaturesRowsEn {
-  TranslationsBillDetailsPageFeaturesRowsEn._(this._root);
+	TranslationsBillDetailsPageFeaturesRowsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get planCreationLimit => 'Number of plans that can be created';
-  String get chatLimit => 'Number of chats available during plan creation';
-  String get timelineAccess => 'Access to all plan timelines';
-  String get adFree => 'Ad-free';
-  String get exclusiveFeatures => 'Plan authentication features';
+	// Translations
+	String get planCreationLimit => 'Number of plans that can be created';
+	String get chatLimit => 'Number of chats available during plan creation';
+	String get timelineAccess => 'Access to all plan timelines';
+	String get adFree => 'Ad-free';
+	String get exclusiveFeatures => 'Plan authentication features';
 }
 
 // Path: billDetailsPage.features.columns
 class TranslationsBillDetailsPageFeaturesColumnsEn {
-  TranslationsBillDetailsPageFeaturesColumnsEn._(this._root);
+	TranslationsBillDetailsPageFeaturesColumnsEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  late final TranslationsBillDetailsPageFeaturesColumnsStandardEn standard =
-      TranslationsBillDetailsPageFeaturesColumnsStandardEn._(_root);
-  late final TranslationsBillDetailsPageFeaturesColumnsPremiumEn premium =
-      TranslationsBillDetailsPageFeaturesColumnsPremiumEn._(_root);
+	// Translations
+	late final TranslationsBillDetailsPageFeaturesColumnsStandardEn standard = TranslationsBillDetailsPageFeaturesColumnsStandardEn._(_root);
+	late final TranslationsBillDetailsPageFeaturesColumnsPremiumEn premium = TranslationsBillDetailsPageFeaturesColumnsPremiumEn._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions.oneDay
 class TranslationsBillDetailsPagePricingOptionsOneDayEn {
-  TranslationsBillDetailsPagePricingOptionsOneDayEn._(this._root);
+	TranslationsBillDetailsPagePricingOptionsOneDayEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get duration => '1 day';
-  String get discount => '';
-  String get price => '300 yen';
+	// Translations
+	String get duration => '1 day';
+	String get discount => '';
+	String get price => '300 yen';
 }
 
 // Path: billDetailsPage.pricingOptions.threeDays
 class TranslationsBillDetailsPagePricingOptionsThreeDaysEn {
-  TranslationsBillDetailsPagePricingOptionsThreeDaysEn._(this._root);
+	TranslationsBillDetailsPagePricingOptionsThreeDaysEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get duration => '3 days';
-  String get discount => '-5%';
-  String get price => '890 yen';
+	// Translations
+	String get duration => '3 days';
+	String get discount => '-5%';
+	String get price => '890 yen';
 }
 
 // Path: billDetailsPage.pricingOptions.fiveDays
 class TranslationsBillDetailsPagePricingOptionsFiveDaysEn {
-  TranslationsBillDetailsPagePricingOptionsFiveDaysEn._(this._root);
+	TranslationsBillDetailsPagePricingOptionsFiveDaysEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get duration => '5 days';
-  String get discount => '-7.5%';
-  String get price => '1,387 yen';
+	// Translations
+	String get duration => '5 days';
+	String get discount => '-7.5%';
+	String get price => '1,387 yen';
 }
 
 // Path: billDetailsPage.pricingOptions.sevenDays
 class TranslationsBillDetailsPagePricingOptionsSevenDaysEn {
-  TranslationsBillDetailsPagePricingOptionsSevenDaysEn._(this._root);
+	TranslationsBillDetailsPagePricingOptionsSevenDaysEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get duration => '7 days';
-  String get discount => '-10%';
-  String get price => '2,070 yen';
+	// Translations
+	String get duration => '7 days';
+	String get discount => '-10%';
+	String get price => '2,070 yen';
 }
 
 // Path: billDetailsPage.pricingOptions.lifetime
 class TranslationsBillDetailsPagePricingOptionsLifetimeEn {
-  TranslationsBillDetailsPagePricingOptionsLifetimeEn._(this._root);
+	TranslationsBillDetailsPagePricingOptionsLifetimeEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get duration => 'Lifetime';
-  String get discount => '';
-  String get price => '25,800 yen';
+	// Translations
+	String get duration => 'Lifetime';
+	String get discount => '';
+	String get price => '25,800 yen';
 }
 
 // Path: planDetailsPage.snackBar.error
 class TranslationsPlanDetailsPageSnackBarErrorEn {
-  TranslationsPlanDetailsPageSnackBarErrorEn._(this._root);
+	TranslationsPlanDetailsPageSnackBarErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get failedToUpdateBookmark =>
-      'Failed to update the bookmark. Please try again later.';
+	// Translations
+	String get failedToUpdateBookmark => 'Failed to update the bookmark. Please try again later.';
 }
 
 // Path: authentication.emailVerificationPage.snackBar.error
 class TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn {
-  TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn._(this._root);
+	TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get unexpected => 'An error occurred. Please try again later.';
+	// Translations
+	String get unexpected => 'An error occurred. Please try again later.';
 }
 
 // Path: authentication.registerProfilePage.snackBar.error
 class TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn {
-  TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn._(this._root);
+	TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get submitIfAllEmpty => 'Please enter the information';
-  String get unexpected => 'An error occurred. Please try again later.';
+	// Translations
+	String get submitIfAllEmpty => 'Please enter the information';
+	String get unexpected => 'An error occurred. Please try again later.';
 }
 
 // Path: billDetailsPage.pricingPlan.details.premiumPrice
 class TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn {
-  TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn._(this._root);
+	TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get days => 'Purchase by duration';
-  String get daily => '・1 day 300 yen';
-  String get threeDays => '・3 days 855 yen';
-  String get fiveDays => '・5 days 1,480 yen';
-  String get sevenDays => '・7 days 2,070 yen';
-  String get or => 'or';
-  String get lifetime => 'Lifetime';
-  String get lifetimePrice => '25,800 yen';
+	// Translations
+	String get days => 'Purchase by duration';
+	String get daily => '・1 day 300 yen';
+	String get threeDays => '・3 days 855 yen';
+	String get fiveDays => '・5 days 1,480 yen';
+	String get sevenDays => '・7 days 2,070 yen';
+	String get or => 'or';
+	String get lifetime => 'Lifetime';
+	String get lifetimePrice => '25,800 yen';
 }
 
 // Path: billDetailsPage.features.columns.standard
 class TranslationsBillDetailsPageFeaturesColumnsStandardEn {
-  TranslationsBillDetailsPageFeaturesColumnsStandardEn._(this._root);
+	TranslationsBillDetailsPageFeaturesColumnsStandardEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get label => 'Standard';
-  String get planCreationLimit => '2 times';
-  String get chatLimit => '3 times';
+	// Translations
+	String get label => 'Standard';
+	String get planCreationLimit => '2 times';
+	String get chatLimit => '3 times';
 }
 
 // Path: billDetailsPage.features.columns.premium
 class TranslationsBillDetailsPageFeaturesColumnsPremiumEn {
-  TranslationsBillDetailsPageFeaturesColumnsPremiumEn._(this._root);
+	TranslationsBillDetailsPageFeaturesColumnsPremiumEn._(this._root);
 
-  final Translations _root; // ignore: unused_field
+	final Translations _root; // ignore: unused_field
 
-  // Translations
-  String get label => 'Premium';
-  String get planCreationLimit => 'Unlimited';
-  String get chatLimit => 'Unlimited';
+	// Translations
+	String get label => 'Premium';
+	String get planCreationLimit => 'Unlimited';
+	String get chatLimit => 'Unlimited';
 }
 
 /// Flat map(s) containing all translations.
 /// Only for edge cases! For simple maps, use the map function of this library.
 extension on Translations {
-  dynamic _flatMapFunction(String path) {
-    switch (path) {
-      case 'navigationBar.items.home':
-        return 'Home';
-      case 'navigationBar.items.myPlan':
-        return 'My Plan';
-      case 'navigationBar.items.myPage':
-        return 'My Page';
-      case 'homePage.popularPlans.title':
-        return 'Popular Plans';
-      case 'homePage.popularTopics.title':
-        return 'Popular Topics';
-      case 'homePage.popularTopics.numberOfTopics':
-        return ({required Object number}) => '${number} items~';
-      case 'homePage.recentPlans.title':
-        return 'Recently Created Plans';
-      case 'accountPage.title':
-        return 'Account';
-      case 'accountPage.items.signOut':
-        return 'Sign Out';
-      case 'accountPage.items.linkedWithGoogle':
-        return 'Linked with Google';
-      case 'accountPage.items.linkedWithApple':
-        return 'Linked with Apple';
-      case 'accountPage.items.alreadyLinkedGoogle':
-        return 'Already Linked with Google';
-      case 'accountPage.items.alreadyLinkedApple':
-        return 'Already Linked with Apple';
-      case 'accountPage.snackBar.signOut':
-        return 'You have been logged out.';
-      case 'accountPage.snackBar.signOutFailure':
-        return 'An error occurred while signing out.';
-      case 'accountPage.snackBar.successfulLinkage':
-        return 'Account linked successfully.';
-      case 'accountPage.snackBar.linkageFailure':
-        return 'Failed to link account.';
-      case 'accountPage.snackBar.providerAlreadyLinked':
-        return 'This account is already linked.';
-      case 'accountPage.snackBar.accountDeactivation':
-        return 'Account linkage has been removed.';
-      case 'accountPage.snackBar.invalidCredential':
-        return 'Please try logging in again.';
-      case 'accountPage.snackBar.linkageCancelled':
-        return 'Account linking was cancelled.';
-      case 'accountPage.snackBar.unlinkageFailure':
-        return 'Failed to remove account linkage.';
-      case 'accountPage.snackBar.operationNotAllowed':
-        return 'Provider is invalid. Please contact the developer.';
-      case 'accountPage.snackBar.unknownError':
-        return 'An unknown error occurred.';
-      case 'accountPage.diaLog.yes':
-        return 'Yes';
-      case 'accountPage.diaLog.no':
-        return 'No';
-      case 'accountPage.diaLog.title':
-        return 'Confirm Account Unlinking';
-      case 'accountPage.diaLog.googleText':
-        return 'Do you want to unlink the current account from your Google account?';
-      case 'accountPage.diaLog.appleText':
-        return 'Do you want to unlink the current account from your Apple account?';
-      case 'authentication.signInPage.title':
-        return 'Sign In';
-      case 'authentication.signInPage.optionText':
-        return ' or ';
-      case 'authentication.signInPage.textFields.email':
-        return 'Email Address';
-      case 'authentication.signInPage.textFields.password':
-        return 'Password';
-      case 'authentication.signInPage.buttons.signIn':
-        return 'Sign In';
-      case 'authentication.signInPage.buttons.signUp':
-        return 'Sign Up';
-      case 'authentication.signInPage.buttons.resetPassword':
-        return 'Forgot Password?';
-      case 'authentication.signInPage.buttons.appleSignIn':
-        return 'Sign in with Apple';
-      case 'authentication.signInPage.buttons.googleSignIn':
-        return 'Sign in with Google';
-      case 'authentication.signInPage.buttons.signInAfter':
-        return 'Register Later';
-      case 'authentication.firebaseAuth.error.networkRequestFailed':
-        return 'Please try again in a good network environment';
-      case 'authentication.firebaseAuth.error.weakPassword':
-        return 'Password is too short. Please enter 6 characters or more';
-      case 'authentication.firebaseAuth.error.invalidEmail':
-        return 'Email address is not in the correct format';
-      case 'authentication.firebaseAuth.error.userNotFound':
-        return 'Account not found';
-      case 'authentication.firebaseAuth.error.wrongPassword':
-        return 'Password is incorrect';
-      case 'authentication.firebaseAuth.error.emailAlreadyInUse':
-        return 'Email address is already in use. Please log in or create with another email address';
-      case 'authentication.firebaseAuth.error.unexpected':
-        return 'An error occurred. Please try again in a good network environment';
-      case 'authentication.resetPasswordPage.title':
-        return 'Reset Password';
-      case 'authentication.resetPasswordPage.description':
-        return 'A password reset email will be sent to the entered email address';
-      case 'authentication.resetPasswordPage.textFields.email':
-        return 'Email Address';
-      case 'authentication.resetPasswordPage.buttons.submit':
-        return 'Submit';
-      case 'authentication.signUpPage.title':
-        return 'Sign Up';
-      case 'authentication.signUpPage.textFields.email':
-        return 'Email Address';
-      case 'authentication.signUpPage.textFields.password':
-        return 'Password';
-      case 'authentication.signUpPage.button':
-        return 'Sign Up';
-      case 'authentication.emailVerificationPage.title':
-        return 'Email Address Verification';
-      case 'authentication.emailVerificationPage.descriptionForDestination':
-        return ({required Object email}) =>
-            'A verification email will be sent to the entered ${email}.';
-      case 'authentication.emailVerificationPage.descriptionForCoolDown':
-        return 'You can resend the verification email once every 60 seconds.';
-      case 'authentication.emailVerificationPage.buttons.sendEmail':
-        return 'Send Verification Email';
-      case 'authentication.emailVerificationPage.buttons.resendEmail':
-        return 'Resend Verification Email';
-      case 'authentication.emailVerificationPage.buttons.toNext':
-        return 'Next';
-      case 'authentication.emailVerificationPage.buttons.retypeEmail':
-        return 'Edit Email Address';
-      case 'authentication.emailVerificationPage.snackBar.success':
-        return 'Email sent successfully';
-      case 'authentication.emailVerificationPage.snackBar.error.unexpected':
-        return 'An error occurred. Please try again later.';
-      case 'authentication.registerProfilePage.title':
-        return 'Profile Registration';
-      case 'authentication.registerProfilePage.textFields':
-        return 'Name';
-      case 'authentication.registerProfilePage.buttons.submit':
-        return 'Complete';
-      case 'authentication.registerProfilePage.buttons.skip':
-        return 'Skip';
-      case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty':
-        return 'Please enter the information';
-      case 'authentication.registerProfilePage.snackBar.error.unexpected':
-        return 'An error occurred. Please try again later.';
-      case 'authentication.completeSendEmailPage.title':
-        return 'Send Complete';
-      case 'authentication.completeSendEmailPage.description':
-        return ({required Object email}) =>
-            'A password reset email has been sent to ${email} \n Please log in from the login screen after resetting';
-      case 'authentication.completeSendEmailPage.successResendEmail':
-        return 'Confirmation email has been resent';
-      case 'authentication.completeSendEmailPage.buttons.toSignIn':
-        return 'To Login Screen';
-      case 'authentication.completeSendEmailPage.buttons.resendEmail':
-        return 'Resend Confirmation Email';
-      case 'authentication.completeSendEmailPage.buttons.changeEmail':
-        return 'Change Email Address';
-      case 'validation.emailRequired':
-        return 'Please enter your email address';
-      case 'validation.emailInvalid':
-        return 'The email address format is incorrect';
-      case 'validation.passwordRequired':
-        return 'Please enter your password';
-      case 'validation.passwordShort':
-        return 'The password must be at least 8 characters long';
-      case 'validation.passwordWeak':
-        return 'Please combine alphanumeric characters for the password';
-      case 'validation.passwordMatch':
-        return 'Passwords do not match';
-      case 'validation.informationRequired':
-        return 'Please enter the information';
-      case 'validation.urlInvalid':
-        return 'The URL format is incorrect';
-      case 'myPage.unregisteredUserName':
-        return 'Unregistered';
-      case 'myPage.editProfile':
-        return 'Edit Profile';
-      case 'myPage.premiumPlan':
-        return 'Premium Plan';
-      case 'myPage.details':
-        return 'Details';
-      case 'myPage.settings':
-        return 'Settings';
-      case 'myPage.account':
-        return 'Account';
-      case 'myPage.language':
-        return 'Language';
-      case 'myPage.theme':
-        return 'Theme';
-      case 'myPage.termsOfUsePrivacyPolicy':
-        return 'Terms of Use & Privacy Policy';
-      case 'myPage.aboutThisApp':
-        return 'About This App';
-      case 'myPage.aboutTheDeveloper':
-        return 'About the Developer';
-      case 'myPage.accountStatus.dateTime.registeredOn':
-        return ({required Object date}) => 'Registered on ${date}';
-      case 'myPage.accountStatus.dateTime.registeredOnFormat':
-        return 'MM/dd/yyyy';
-      case 'myPage.accountStatus.dateTime.validUntil':
-        return ({required Object date}) => 'Valid until${date}';
-      case 'myPage.accountStatus.dateTime.validUntilFormat':
-        return 'MM/dd/yyyy hh:mm';
-      case 'myPage.accountStatus.premium':
-        return 'Premium Member';
-      case 'myPage.accountStatus.standard':
-        return 'Standard Member';
-      case 'changeLanguagePage.title':
-        return 'Language';
-      case 'changeLanguagePage.items.japanese':
-        return 'Japanese';
-      case 'changeLanguagePage.items.english':
-        return 'English';
-      case 'changeLanguagePage.items.simplifiedChinese':
-        return 'Chinese (Simplified)';
-      case 'changeLanguagePage.items.traditionalChinese':
-        return 'Chinese (Traditional)';
-      case 'changeThemePage.title':
-        return 'Theme';
-      case 'changeThemePage.items.system':
-        return 'System';
-      case 'changeThemePage.items.light':
-        return 'Light';
-      case 'changeThemePage.items.dark':
-        return 'Dark';
-      case 'myPlanPage.title':
-        return 'My Plans';
-      case 'myPlanPage.tabs.createdPlans':
-        return 'Created Plans';
-      case 'myPlanPage.tabs.bookmark':
-        return 'Bookmarks';
-      case 'myPlanPage.bookmarkItems.nondata':
-        return 'No bookmarked plans yet.';
-      case 'myPlanPage.bookmarkItems.reloading':
-        return 'Reload';
-      case 'myPlanPage.createdPlansItems.nondata':
-        return 'Let\'s create a plan!';
-      case 'myPlanPage.createdPlansItems.createaplan':
-        return 'Create a Plan';
-      case 'myPlanPage.error.displayError':
-        return 'An error occurred while displaying the plan.';
-      case 'myPlanPage.error.failedGetId':
-        return 'Failed to retrieve plan ID.';
-      case 'myPlanPage.error.failedGetPlanData':
-        return 'An error occurred while retrieving plan data.';
-      case 'myPlanPage.error.failedUnBookmark':
-        return 'Failed to remove bookmark.';
-      case 'buddyChatPage.title':
-        return 'Buddy\'s Suggestions';
-      case 'buddyChatPage.possibleChatCount':
-        return ({required Object possibleChatCount}) =>
-            'You can send ${possibleChatCount} more messages';
-      case 'buddyChatPage.textFields.message':
-        return 'Enter message';
-      case 'buddyChatPage.buttons.send':
-        return 'Done';
-      case 'buddyChatPage.placeCard.openingHours':
-        return 'Opening Hours';
-      case 'buddyChatPage.placeCard.averageAmount':
-        return 'Average Budget';
-      case 'buddyChatPage.placeCard.website':
-        return 'Website';
-      case 'buddyChatPage.snackBar.error.failedRecieveMessage':
-        return 'Failed to receive the reply. Please try again later.';
-      case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan':
-        return 'Failed to complete plan creation. Please try again later.';
-      case 'popularTopics.sectionName':
-        return 'Popular Topics';
-      case 'createPlanPage.title':
-        return 'Create Plan';
-      case 'createPlanPage.label.location':
-        return 'Destination';
-      case 'createPlanPage.label.scheduleStart':
-        return 'Start Date';
-      case 'createPlanPage.label.scheduleEnd':
-        return 'End Date';
-      case 'createPlanPage.label.numberOfPeople':
-        return 'Number of People';
-      case 'createPlanPage.label.transport':
-        return 'Transportation';
-      case 'createPlanPage.label.category':
-        return 'Category';
-      case 'createPlanPage.label.topics':
-        return 'Travel Topics';
-      case 'createPlanPage.hintText.location':
-        return 'Shibuya';
-      case 'createPlanPage.modal.title':
-        return 'Select a date';
-      case 'createPlanPage.numberOfPeopleOptions.0':
-        return '1 person';
-      case 'createPlanPage.numberOfPeopleOptions.1':
-        return '2 people';
-      case 'createPlanPage.numberOfPeopleOptions.2':
-        return '3 people';
-      case 'createPlanPage.numberOfPeopleOptions.3':
-        return '4 people';
-      case 'createPlanPage.numberOfPeopleOptions.4':
-        return '5 people';
-      case 'createPlanPage.numberOfPeopleOptions.5':
-        return '6 or more';
-      case 'createPlanPage.transportOptions.0':
-        return 'Train';
-      case 'createPlanPage.transportOptions.1':
-        return 'Walking';
-      case 'createPlanPage.transportOptions.2':
-        return 'Car';
-      case 'createPlanPage.transportOptions.3':
-        return 'Bus';
-      case 'createPlanPage.categoryOptions.0':
-        return 'Family-friendly';
-      case 'createPlanPage.categoryOptions.1':
-        return 'Adult';
-      case 'createPlanPage.categoryOptions.2':
-        return 'Entertainment';
-      case 'createPlanPage.categoryOptions.3':
-        return 'Activity';
-      case 'createPlanPage.categoryOptions.4':
-        return 'History';
-      case 'createPlanPage.defaultTopics.0':
-        return 'Gourmet';
-      case 'createPlanPage.defaultTopics.1':
-        return 'Shopping';
-      case 'createPlanPage.defaultTopics.2':
-        return 'Activities';
-      case 'createPlanPage.defaultTopics.3':
-        return 'Movies';
-      case 'createPlanPage.submitButton':
-        return 'Submit Plan to AI';
-      case 'createPlanPage.snackBar.error.foundUnSelectedField':
-        return 'There are unselected items. Please select all items.';
-      case 'editProfilePage.title':
-        return 'Edit Profile';
-      case 'editProfilePage.textFields.name':
-        return 'Name';
-      case 'editProfilePage.buttons.submit':
-        return 'Save';
-      case 'editProfilePage.snackBar.success':
-        return 'Updated successfully';
-      case 'editProfilePage.snackBar.error.noChange':
-        return 'No changes detected';
-      case 'editProfilePage.snackBar.error.failedToUpdate':
-        return 'Failed to update. Please try again later.';
-      case 'editProfilePage.snackBar.error.failedToPickImage':
-        return 'Failed to select image. Please try again later.';
-      case 'confirmDialog.answers.yes':
-        return 'Yes';
-      case 'confirmDialog.answers.no':
-        return 'No';
-      case 'confirmDialog.popPage.title':
-        return 'Return to the previous page?';
-      case 'confirmDialog.popPage.description':
-        return 'Current content will not be saved.';
-      case 'confirmDialog.completeCreatePlan.title':
-        return 'Confirm the plan?';
-      case 'confirmDialog.completeCreatePlan.description':
-        return 'The plan in the last message will be saved.';
-      case 'prompt.planProposalMessage':
-        return 'I’ve come up with this plan! What do you think?';
-      case 'billDetailsPage.title':
-        return 'Premium Plan';
-      case 'billDetailsPage.description':
-        return 'By subscribing to the Premium Plan, you can enjoy a more comfortable sightseeing experience in Shibuya.';
-      case 'billDetailsPage.pricingPlan.title':
-        return 'Pricing Plan';
-      case 'billDetailsPage.pricingPlan.columns.standard':
-        return 'Standard';
-      case 'billDetailsPage.pricingPlan.columns.premium':
-        return 'Premium';
-      case 'billDetailsPage.pricingPlan.details.free':
-        return 'Free 🎉';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.days':
-        return 'Purchase by duration';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.daily':
-        return '・1 day 300 yen';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays':
-        return '・3 days 855 yen';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays':
-        return '・5 days 1,480 yen';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays':
-        return '・7 days 2,070 yen';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.or':
-        return 'or';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime':
-        return 'Lifetime';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice':
-        return '25,800 yen';
-      case 'billDetailsPage.features.title':
-        return 'Features by Grade';
-      case 'billDetailsPage.features.rows.planCreationLimit':
-        return 'Number of plans that can be created';
-      case 'billDetailsPage.features.rows.chatLimit':
-        return 'Number of chats available during plan creation';
-      case 'billDetailsPage.features.rows.timelineAccess':
-        return 'Access to all plan timelines';
-      case 'billDetailsPage.features.rows.adFree':
-        return 'Ad-free';
-      case 'billDetailsPage.features.rows.exclusiveFeatures':
-        return 'Plan authentication features';
-      case 'billDetailsPage.features.columns.standard.label':
-        return 'Standard';
-      case 'billDetailsPage.features.columns.standard.planCreationLimit':
-        return '2 times';
-      case 'billDetailsPage.features.columns.standard.chatLimit':
-        return '3 times';
-      case 'billDetailsPage.features.columns.premium.label':
-        return 'Premium';
-      case 'billDetailsPage.features.columns.premium.planCreationLimit':
-        return 'Unlimited';
-      case 'billDetailsPage.features.columns.premium.chatLimit':
-        return 'Unlimited';
-      case 'billDetailsPage.pricingOptions.oneDay.duration':
-        return '1 day';
-      case 'billDetailsPage.pricingOptions.oneDay.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.oneDay.price':
-        return '300 yen';
-      case 'billDetailsPage.pricingOptions.threeDays.duration':
-        return '3 days';
-      case 'billDetailsPage.pricingOptions.threeDays.discount':
-        return '-5%';
-      case 'billDetailsPage.pricingOptions.threeDays.price':
-        return '890 yen';
-      case 'billDetailsPage.pricingOptions.fiveDays.duration':
-        return '5 days';
-      case 'billDetailsPage.pricingOptions.fiveDays.discount':
-        return '-7.5%';
-      case 'billDetailsPage.pricingOptions.fiveDays.price':
-        return '1,387 yen';
-      case 'billDetailsPage.pricingOptions.sevenDays.duration':
-        return '7 days';
-      case 'billDetailsPage.pricingOptions.sevenDays.discount':
-        return '-10%';
-      case 'billDetailsPage.pricingOptions.sevenDays.price':
-        return '2,070 yen';
-      case 'billDetailsPage.pricingOptions.lifetime.duration':
-        return 'Lifetime';
-      case 'billDetailsPage.pricingOptions.lifetime.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.lifetime.price':
-        return '25,800 yen';
-      case 'billDetailsPage.upgradeButton':
-        return 'Upgrade to Premium';
-      case 'planDetailsPage.dateTime.createOn':
-        return ({required Object date}) => 'Plan created on${date}';
-      case 'planDetailsPage.dateTime.dateFormat':
-        return 'MM/dd/yyyy';
-      case 'planDetailsPage.item.viewOnMap':
-        return 'View on Map';
-      case 'planDetailsPage.snackBar.error.failedToUpdateBookmark':
-        return 'Failed to update the bookmark. Please try again later.';
-      case 'locales.en':
-        return 'English';
-      case 'locales.ja':
-        return 'Japanese';
-      case 'locales.zh':
-        return 'Chinese';
-      case 'errorPage.title':
-        return 'An error occurred...';
-      case 'errorPage.message':
-        return 'Please check your network connection and try again.';
-      case 'errorPage.retryButton':
-        return 'Retry';
-      case 'mapPage.title':
-        return 'Map';
-      default:
-        return null;
-    }
-  }
+	dynamic _flatMapFunction(String path) {
+		switch (path) {
+			case 'navigationBar.items.home': return 'Home';
+			case 'navigationBar.items.myPlan': return 'My Plan';
+			case 'navigationBar.items.myPage': return 'My Page';
+			case 'homePage.popularPlans.title': return 'Popular Plans';
+			case 'homePage.popularTopics.title': return 'Popular Topics';
+			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number} items~';
+			case 'homePage.recentPlans.title': return 'Recently Created Plans';
+			case 'accountPage.title': return 'Account';
+			case 'accountPage.items.signOut': return 'Sign Out';
+			case 'accountPage.items.linkedWithGoogle': return 'Linked with Google';
+			case 'accountPage.items.linkedWithApple': return 'Linked with Apple';
+			case 'accountPage.items.alreadyLinkedGoogle': return 'Already Linked with Google';
+			case 'accountPage.items.alreadyLinkedApple': return 'Already Linked with Apple';
+			case 'accountPage.snackBar.signOut': return 'You have been logged out.';
+			case 'accountPage.snackBar.signOutFailure': return 'An error occurred while signing out.';
+			case 'accountPage.snackBar.successfulLinkage': return 'Account linked successfully.';
+			case 'accountPage.snackBar.linkageFailure': return 'Failed to link account.';
+			case 'accountPage.snackBar.providerAlreadyLinked': return 'This account is already linked.';
+			case 'accountPage.snackBar.accountDeactivation': return 'Account linkage has been removed.';
+			case 'accountPage.snackBar.invalidCredential': return 'Please try logging in again.';
+			case 'accountPage.snackBar.linkageCancelled': return 'Account linking was cancelled.';
+			case 'accountPage.snackBar.unlinkageFailure': return 'Failed to remove account linkage.';
+			case 'accountPage.snackBar.operationNotAllowed': return 'Provider is invalid. Please contact the developer.';
+			case 'accountPage.snackBar.unknownError': return 'An unknown error occurred.';
+			case 'accountPage.diaLog.yes': return 'Yes';
+			case 'accountPage.diaLog.no': return 'No';
+			case 'accountPage.diaLog.title': return 'Confirm Account Unlinking';
+			case 'accountPage.diaLog.googleText': return 'Do you want to unlink the current account from your Google account?';
+			case 'accountPage.diaLog.appleText': return 'Do you want to unlink the current account from your Apple account?';
+			case 'authentication.signInPage.title': return 'Sign In';
+			case 'authentication.signInPage.optionText': return ' or ';
+			case 'authentication.signInPage.textFields.email': return 'Email Address';
+			case 'authentication.signInPage.textFields.password': return 'Password';
+			case 'authentication.signInPage.buttons.signIn': return 'Sign In';
+			case 'authentication.signInPage.buttons.signUp': return 'Sign Up';
+			case 'authentication.signInPage.buttons.resetPassword': return 'Forgot Password?';
+			case 'authentication.signInPage.buttons.appleSignIn': return 'Sign in with Apple';
+			case 'authentication.signInPage.buttons.googleSignIn': return 'Sign in with Google';
+			case 'authentication.signInPage.buttons.signInAfter': return 'Register Later';
+			case 'authentication.firebaseAuth.error.networkRequestFailed': return 'Please try again in a good network environment';
+			case 'authentication.firebaseAuth.error.weakPassword': return 'Password is too short. Please enter 6 characters or more';
+			case 'authentication.firebaseAuth.error.invalidEmail': return 'Email address is not in the correct format';
+			case 'authentication.firebaseAuth.error.userNotFound': return 'Account not found';
+			case 'authentication.firebaseAuth.error.wrongPassword': return 'Password is incorrect';
+			case 'authentication.firebaseAuth.error.emailAlreadyInUse': return 'Email address is already in use. Please log in or create with another email address';
+			case 'authentication.firebaseAuth.error.unexpected': return 'An error occurred. Please try again in a good network environment';
+			case 'authentication.resetPasswordPage.title': return 'Reset Password';
+			case 'authentication.resetPasswordPage.description': return 'A password reset email will be sent to the entered email address';
+			case 'authentication.resetPasswordPage.textFields.email': return 'Email Address';
+			case 'authentication.resetPasswordPage.buttons.submit': return 'Submit';
+			case 'authentication.signUpPage.title': return 'Sign Up';
+			case 'authentication.signUpPage.textFields.email': return 'Email Address';
+			case 'authentication.signUpPage.textFields.password': return 'Password';
+			case 'authentication.signUpPage.button': return 'Sign Up';
+			case 'authentication.emailVerificationPage.title': return 'Email Address Verification';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => 'A verification email will be sent to the entered ${email}.';
+			case 'authentication.emailVerificationPage.descriptionForCoolDown': return 'You can resend the verification email once every 60 seconds.';
+			case 'authentication.emailVerificationPage.buttons.sendEmail': return 'Send Verification Email';
+			case 'authentication.emailVerificationPage.buttons.resendEmail': return 'Resend Verification Email';
+			case 'authentication.emailVerificationPage.buttons.toNext': return 'Next';
+			case 'authentication.emailVerificationPage.buttons.retypeEmail': return 'Edit Email Address';
+			case 'authentication.emailVerificationPage.snackBar.success': return 'Email sent successfully';
+			case 'authentication.emailVerificationPage.snackBar.error.unexpected': return 'An error occurred. Please try again later.';
+			case 'authentication.registerProfilePage.title': return 'Profile Registration';
+			case 'authentication.registerProfilePage.textFields': return 'Name';
+			case 'authentication.registerProfilePage.buttons.submit': return 'Complete';
+			case 'authentication.registerProfilePage.buttons.skip': return 'Skip';
+			case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty': return 'Please enter the information';
+			case 'authentication.registerProfilePage.snackBar.error.unexpected': return 'An error occurred. Please try again later.';
+			case 'authentication.completeSendEmailPage.title': return 'Send Complete';
+			case 'authentication.completeSendEmailPage.description': return ({required Object email}) => 'A password reset email has been sent to ${email} \n Please log in from the login screen after resetting';
+			case 'authentication.completeSendEmailPage.successResendEmail': return 'Confirmation email has been resent';
+			case 'authentication.completeSendEmailPage.buttons.toSignIn': return 'To Login Screen';
+			case 'authentication.completeSendEmailPage.buttons.resendEmail': return 'Resend Confirmation Email';
+			case 'authentication.completeSendEmailPage.buttons.changeEmail': return 'Change Email Address';
+			case 'validation.emailRequired': return 'Please enter your email address';
+			case 'validation.emailInvalid': return 'The email address format is incorrect';
+			case 'validation.passwordRequired': return 'Please enter your password';
+			case 'validation.passwordShort': return 'The password must be at least 8 characters long';
+			case 'validation.passwordWeak': return 'Please combine alphanumeric characters for the password';
+			case 'validation.passwordMatch': return 'Passwords do not match';
+			case 'validation.informationRequired': return 'Please enter the information';
+			case 'validation.urlInvalid': return 'The URL format is incorrect';
+			case 'validation.usernameRequired': return 'Please enter your username';
+			case 'validation.userNameMaxLength': return 'The username must be 16 characters or fewer';
+			case 'myPage.unregisteredUserName': return 'Unregistered';
+			case 'myPage.editProfile': return 'Edit Profile';
+			case 'myPage.premiumPlan': return 'Premium Plan';
+			case 'myPage.details': return 'Details';
+			case 'myPage.settings': return 'Settings';
+			case 'myPage.account': return 'Account';
+			case 'myPage.language': return 'Language';
+			case 'myPage.theme': return 'Theme';
+			case 'myPage.termsOfUsePrivacyPolicy': return 'Terms of Use & Privacy Policy';
+			case 'myPage.aboutThisApp': return 'About This App';
+			case 'myPage.aboutTheDeveloper': return 'About the Developer';
+			case 'myPage.accountStatus.dateTime.registeredOn': return ({required Object date}) => 'Registered on ${date}';
+			case 'myPage.accountStatus.dateTime.registeredOnFormat': return 'MM/dd/yyyy';
+			case 'myPage.accountStatus.dateTime.validUntil': return ({required Object date}) => 'Valid until${date}';
+			case 'myPage.accountStatus.dateTime.validUntilFormat': return 'MM/dd/yyyy hh:mm';
+			case 'myPage.accountStatus.premium': return 'Premium Member';
+			case 'myPage.accountStatus.standard': return 'Standard Member';
+			case 'changeLanguagePage.title': return 'Language';
+			case 'changeLanguagePage.items.japanese': return 'Japanese';
+			case 'changeLanguagePage.items.english': return 'English';
+			case 'changeLanguagePage.items.simplifiedChinese': return 'Chinese (Simplified)';
+			case 'changeLanguagePage.items.traditionalChinese': return 'Chinese (Traditional)';
+			case 'changeThemePage.title': return 'Theme';
+			case 'changeThemePage.items.system': return 'System';
+			case 'changeThemePage.items.light': return 'Light';
+			case 'changeThemePage.items.dark': return 'Dark';
+			case 'myPlanPage.title': return 'My Plans';
+			case 'myPlanPage.tabs.createdPlans': return 'Created Plans';
+			case 'myPlanPage.tabs.bookmark': return 'Bookmarks';
+			case 'myPlanPage.bookmarkItems.nondata': return 'No bookmarked plans yet.';
+			case 'myPlanPage.bookmarkItems.reloading': return 'Reload';
+			case 'myPlanPage.createdPlansItems.nondata': return 'Let\'s create a plan!';
+			case 'myPlanPage.createdPlansItems.createaplan': return 'Create a Plan';
+			case 'myPlanPage.error.displayError': return 'An error occurred while displaying the plan.';
+			case 'myPlanPage.error.failedGetId': return 'Failed to retrieve plan ID.';
+			case 'myPlanPage.error.failedGetPlanData': return 'An error occurred while retrieving plan data.';
+			case 'myPlanPage.error.failedUnBookmark': return 'Failed to remove bookmark.';
+			case 'buddyChatPage.title': return 'Buddy\'s Suggestions';
+			case 'buddyChatPage.possibleChatCount': return ({required Object possibleChatCount}) => 'You can send ${possibleChatCount} more messages';
+			case 'buddyChatPage.textFields.message': return 'Enter message';
+			case 'buddyChatPage.buttons.send': return 'Done';
+			case 'buddyChatPage.placeCard.openingHours': return 'Opening Hours';
+			case 'buddyChatPage.placeCard.averageAmount': return 'Average Budget';
+			case 'buddyChatPage.placeCard.website': return 'Website';
+			case 'buddyChatPage.snackBar.error.failedRecieveMessage': return 'Failed to receive the reply. Please try again later.';
+			case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan': return 'Failed to complete plan creation. Please try again later.';
+			case 'popularTopics.sectionName': return 'Popular Topics';
+			case 'createPlanPage.title': return 'Create Plan';
+			case 'createPlanPage.label.location': return 'Destination';
+			case 'createPlanPage.label.scheduleStart': return 'Start Date';
+			case 'createPlanPage.label.scheduleEnd': return 'End Date';
+			case 'createPlanPage.label.numberOfPeople': return 'Number of People';
+			case 'createPlanPage.label.transport': return 'Transportation';
+			case 'createPlanPage.label.category': return 'Category';
+			case 'createPlanPage.label.topics': return 'Travel Topics';
+			case 'createPlanPage.hintText.location': return 'Shibuya';
+			case 'createPlanPage.modal.title': return 'Select a date';
+			case 'createPlanPage.numberOfPeopleOptions.0': return '1 person';
+			case 'createPlanPage.numberOfPeopleOptions.1': return '2 people';
+			case 'createPlanPage.numberOfPeopleOptions.2': return '3 people';
+			case 'createPlanPage.numberOfPeopleOptions.3': return '4 people';
+			case 'createPlanPage.numberOfPeopleOptions.4': return '5 people';
+			case 'createPlanPage.numberOfPeopleOptions.5': return '6 or more';
+			case 'createPlanPage.transportOptions.0': return 'Train';
+			case 'createPlanPage.transportOptions.1': return 'Walking';
+			case 'createPlanPage.transportOptions.2': return 'Car';
+			case 'createPlanPage.transportOptions.3': return 'Bus';
+			case 'createPlanPage.categoryOptions.0': return 'Family-friendly';
+			case 'createPlanPage.categoryOptions.1': return 'Adult';
+			case 'createPlanPage.categoryOptions.2': return 'Entertainment';
+			case 'createPlanPage.categoryOptions.3': return 'Activity';
+			case 'createPlanPage.categoryOptions.4': return 'History';
+			case 'createPlanPage.defaultTopics.0': return 'Gourmet';
+			case 'createPlanPage.defaultTopics.1': return 'Shopping';
+			case 'createPlanPage.defaultTopics.2': return 'Activities';
+			case 'createPlanPage.defaultTopics.3': return 'Movies';
+			case 'createPlanPage.submitButton': return 'Submit Plan to AI';
+			case 'createPlanPage.snackBar.error.foundUnSelectedField': return 'There are unselected items. Please select all items.';
+			case 'editProfilePage.title': return 'Edit Profile';
+			case 'editProfilePage.textFields.name': return 'Name';
+			case 'editProfilePage.buttons.submit': return 'Save';
+			case 'editProfilePage.snackBar.success': return 'Updated successfully';
+			case 'editProfilePage.snackBar.error.noChange': return 'No changes detected';
+			case 'editProfilePage.snackBar.error.failedToUpdate': return 'Failed to update. Please try again later.';
+			case 'editProfilePage.snackBar.error.failedToPickImage': return 'Failed to select image. Please try again later.';
+			case 'confirmDialog.answers.yes': return 'Yes';
+			case 'confirmDialog.answers.no': return 'No';
+			case 'confirmDialog.popPage.title': return 'Return to the previous page?';
+			case 'confirmDialog.popPage.description': return 'Current content will not be saved.';
+			case 'confirmDialog.completeCreatePlan.title': return 'Confirm the plan?';
+			case 'confirmDialog.completeCreatePlan.description': return 'The plan in the last message will be saved.';
+			case 'prompt.planProposalMessage': return 'I’ve come up with this plan! What do you think?';
+			case 'billDetailsPage.title': return 'Premium Plan';
+			case 'billDetailsPage.description': return 'By subscribing to the Premium Plan, you can enjoy a more comfortable sightseeing experience in Shibuya.';
+			case 'billDetailsPage.pricingPlan.title': return 'Pricing Plan';
+			case 'billDetailsPage.pricingPlan.columns.standard': return 'Standard';
+			case 'billDetailsPage.pricingPlan.columns.premium': return 'Premium';
+			case 'billDetailsPage.pricingPlan.details.free': return 'Free 🎉';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.days': return 'Purchase by duration';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.daily': return '・1 day 300 yen';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays': return '・3 days 855 yen';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays': return '・5 days 1,480 yen';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays': return '・7 days 2,070 yen';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.or': return 'or';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime': return 'Lifetime';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice': return '25,800 yen';
+			case 'billDetailsPage.features.title': return 'Features by Grade';
+			case 'billDetailsPage.features.rows.planCreationLimit': return 'Number of plans that can be created';
+			case 'billDetailsPage.features.rows.chatLimit': return 'Number of chats available during plan creation';
+			case 'billDetailsPage.features.rows.timelineAccess': return 'Access to all plan timelines';
+			case 'billDetailsPage.features.rows.adFree': return 'Ad-free';
+			case 'billDetailsPage.features.rows.exclusiveFeatures': return 'Plan authentication features';
+			case 'billDetailsPage.features.columns.standard.label': return 'Standard';
+			case 'billDetailsPage.features.columns.standard.planCreationLimit': return '2 times';
+			case 'billDetailsPage.features.columns.standard.chatLimit': return '3 times';
+			case 'billDetailsPage.features.columns.premium.label': return 'Premium';
+			case 'billDetailsPage.features.columns.premium.planCreationLimit': return 'Unlimited';
+			case 'billDetailsPage.features.columns.premium.chatLimit': return 'Unlimited';
+			case 'billDetailsPage.pricingOptions.oneDay.duration': return '1 day';
+			case 'billDetailsPage.pricingOptions.oneDay.discount': return '';
+			case 'billDetailsPage.pricingOptions.oneDay.price': return '300 yen';
+			case 'billDetailsPage.pricingOptions.threeDays.duration': return '3 days';
+			case 'billDetailsPage.pricingOptions.threeDays.discount': return '-5%';
+			case 'billDetailsPage.pricingOptions.threeDays.price': return '890 yen';
+			case 'billDetailsPage.pricingOptions.fiveDays.duration': return '5 days';
+			case 'billDetailsPage.pricingOptions.fiveDays.discount': return '-7.5%';
+			case 'billDetailsPage.pricingOptions.fiveDays.price': return '1,387 yen';
+			case 'billDetailsPage.pricingOptions.sevenDays.duration': return '7 days';
+			case 'billDetailsPage.pricingOptions.sevenDays.discount': return '-10%';
+			case 'billDetailsPage.pricingOptions.sevenDays.price': return '2,070 yen';
+			case 'billDetailsPage.pricingOptions.lifetime.duration': return 'Lifetime';
+			case 'billDetailsPage.pricingOptions.lifetime.discount': return '';
+			case 'billDetailsPage.pricingOptions.lifetime.price': return '25,800 yen';
+			case 'billDetailsPage.upgradeButton': return 'Upgrade to Premium';
+			case 'planDetailsPage.dateTime.createOn': return ({required Object date}) => 'Plan created on${date}';
+			case 'planDetailsPage.dateTime.dateFormat': return 'MM/dd/yyyy';
+			case 'planDetailsPage.item.viewOnMap': return 'View on Map';
+			case 'planDetailsPage.snackBar.error.failedToUpdateBookmark': return 'Failed to update the bookmark. Please try again later.';
+			case 'locales.en': return 'English';
+			case 'locales.ja': return 'Japanese';
+			case 'locales.zh': return 'Chinese';
+			case 'errorPage.title': return 'An error occurred...';
+			case 'errorPage.message': return 'Please check your network connection and try again.';
+			case 'errorPage.retryButton': return 'Retry';
+			case 'mapPage.title': return 'Map';
+			default: return null;
+		}
+	}
 }
+

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -11,2109 +11,1407 @@ import 'strings.g.dart';
 
 // Path: <root>
 class TranslationsJa implements Translations {
-  /// You can call this constructor and build your own translation instance of this locale.
-  /// Constructing via the enum [AppLocale.build] is preferred.
-  TranslationsJa(
-      {Map<String, Node>? overrides,
-      PluralResolver? cardinalResolver,
-      PluralResolver? ordinalResolver})
-      : assert(overrides == null,
-            'Set "translation_overrides: true" in order to enable this feature.'),
-        $meta = TranslationMetadata(
-          locale: AppLocale.ja,
-          overrides: overrides ?? {},
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        ) {
-    $meta.setFlatMapFunction(_flatMapFunction);
-  }
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsJa({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = TranslationMetadata(
+		    locale: AppLocale.ja,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
 
-  /// Metadata for the translations of <ja>.
-  @override
-  final TranslationMetadata<AppLocale, Translations> $meta;
+	/// Metadata for the translations of <ja>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
 
-  /// Access flat map
-  @override
-  dynamic operator [](String key) => $meta.getTranslation(key);
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key);
 
-  late final TranslationsJa _root = this; // ignore: unused_field
+	late final TranslationsJa _root = this; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsNavigationBarJa navigationBar =
-      _TranslationsNavigationBarJa._(_root);
-  @override
-  late final _TranslationsHomePageJa homePage =
-      _TranslationsHomePageJa._(_root);
-  @override
-  late final _TranslationsAccountPageJa accountPage =
-      _TranslationsAccountPageJa._(_root);
-  @override
-  late final _TranslationsAuthenticationJa authentication =
-      _TranslationsAuthenticationJa._(_root);
-  @override
-  late final _TranslationsValidationJa validation =
-      _TranslationsValidationJa._(_root);
-  @override
-  late final _TranslationsMyPageJa myPage = _TranslationsMyPageJa._(_root);
-  @override
-  late final _TranslationsChangeLanguagePageJa changeLanguagePage =
-      _TranslationsChangeLanguagePageJa._(_root);
-  @override
-  late final _TranslationsChangeThemePageJa changeThemePage =
-      _TranslationsChangeThemePageJa._(_root);
-  @override
-  late final _TranslationsMyPlanPageJa myPlanPage =
-      _TranslationsMyPlanPageJa._(_root);
-  @override
-  late final _TranslationsBuddyChatPageJa buddyChatPage =
-      _TranslationsBuddyChatPageJa._(_root);
-  @override
-  late final _TranslationsPopularTopicsJa popularTopics =
-      _TranslationsPopularTopicsJa._(_root);
-  @override
-  late final _TranslationsCreatePlanPageJa createPlanPage =
-      _TranslationsCreatePlanPageJa._(_root);
-  @override
-  late final _TranslationsEditProfilePageJa editProfilePage =
-      _TranslationsEditProfilePageJa._(_root);
-  @override
-  late final _TranslationsConfirmDialogJa confirmDialog =
-      _TranslationsConfirmDialogJa._(_root);
-  @override
-  late final _TranslationsPromptJa prompt = _TranslationsPromptJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPageJa billDetailsPage =
-      _TranslationsBillDetailsPageJa._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageJa planDetailsPage =
-      _TranslationsPlanDetailsPageJa._(_root);
-  @override
-  Map<String, String> get locales => {
-        'en': '英語',
-        'ja': '日本語',
-        'zh': '中国語',
-      };
-  @override
-  late final _TranslationsErrorPageJa errorPage =
-      _TranslationsErrorPageJa._(_root);
-  @override
-  late final _TranslationsMapPageJa mapPage = _TranslationsMapPageJa._(_root);
+	// Translations
+	@override late final _TranslationsNavigationBarJa navigationBar = _TranslationsNavigationBarJa._(_root);
+	@override late final _TranslationsHomePageJa homePage = _TranslationsHomePageJa._(_root);
+	@override late final _TranslationsAccountPageJa accountPage = _TranslationsAccountPageJa._(_root);
+	@override late final _TranslationsAuthenticationJa authentication = _TranslationsAuthenticationJa._(_root);
+	@override late final _TranslationsValidationJa validation = _TranslationsValidationJa._(_root);
+	@override late final _TranslationsMyPageJa myPage = _TranslationsMyPageJa._(_root);
+	@override late final _TranslationsChangeLanguagePageJa changeLanguagePage = _TranslationsChangeLanguagePageJa._(_root);
+	@override late final _TranslationsChangeThemePageJa changeThemePage = _TranslationsChangeThemePageJa._(_root);
+	@override late final _TranslationsMyPlanPageJa myPlanPage = _TranslationsMyPlanPageJa._(_root);
+	@override late final _TranslationsBuddyChatPageJa buddyChatPage = _TranslationsBuddyChatPageJa._(_root);
+	@override late final _TranslationsPopularTopicsJa popularTopics = _TranslationsPopularTopicsJa._(_root);
+	@override late final _TranslationsCreatePlanPageJa createPlanPage = _TranslationsCreatePlanPageJa._(_root);
+	@override late final _TranslationsEditProfilePageJa editProfilePage = _TranslationsEditProfilePageJa._(_root);
+	@override late final _TranslationsConfirmDialogJa confirmDialog = _TranslationsConfirmDialogJa._(_root);
+	@override late final _TranslationsPromptJa prompt = _TranslationsPromptJa._(_root);
+	@override late final _TranslationsBillDetailsPageJa billDetailsPage = _TranslationsBillDetailsPageJa._(_root);
+	@override late final _TranslationsPlanDetailsPageJa planDetailsPage = _TranslationsPlanDetailsPageJa._(_root);
+	@override Map<String, String> get locales => {
+		'en': '英語',
+		'ja': '日本語',
+		'zh': '中国語',
+	};
+	@override late final _TranslationsErrorPageJa errorPage = _TranslationsErrorPageJa._(_root);
+	@override late final _TranslationsMapPageJa mapPage = _TranslationsMapPageJa._(_root);
 }
 
 // Path: navigationBar
 class _TranslationsNavigationBarJa implements TranslationsNavigationBarEn {
-  _TranslationsNavigationBarJa._(this._root);
+	_TranslationsNavigationBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsNavigationBarItemsJa items =
-      _TranslationsNavigationBarItemsJa._(_root);
+	// Translations
+	@override late final _TranslationsNavigationBarItemsJa items = _TranslationsNavigationBarItemsJa._(_root);
 }
 
 // Path: homePage
 class _TranslationsHomePageJa implements TranslationsHomePageEn {
-  _TranslationsHomePageJa._(this._root);
+	_TranslationsHomePageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsHomePagePopularPlansJa popularPlans =
-      _TranslationsHomePagePopularPlansJa._(_root);
-  @override
-  late final _TranslationsHomePagePopularTopicsJa popularTopics =
-      _TranslationsHomePagePopularTopicsJa._(_root);
-  @override
-  late final _TranslationsHomePageRecentPlansJa recentPlans =
-      _TranslationsHomePageRecentPlansJa._(_root);
+	// Translations
+	@override late final _TranslationsHomePagePopularPlansJa popularPlans = _TranslationsHomePagePopularPlansJa._(_root);
+	@override late final _TranslationsHomePagePopularTopicsJa popularTopics = _TranslationsHomePagePopularTopicsJa._(_root);
+	@override late final _TranslationsHomePageRecentPlansJa recentPlans = _TranslationsHomePageRecentPlansJa._(_root);
 }
 
 // Path: accountPage
 class _TranslationsAccountPageJa implements TranslationsAccountPageEn {
-  _TranslationsAccountPageJa._(this._root);
+	_TranslationsAccountPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'アカウント';
-  @override
-  late final _TranslationsAccountPageItemsJa items =
-      _TranslationsAccountPageItemsJa._(_root);
-  @override
-  late final _TranslationsAccountPageSnackBarJa snackBar =
-      _TranslationsAccountPageSnackBarJa._(_root);
-  @override
-  late final _TranslationsAccountPageDiaLogJa diaLog =
-      _TranslationsAccountPageDiaLogJa._(_root);
+	// Translations
+	@override String get title => 'アカウント';
+	@override late final _TranslationsAccountPageItemsJa items = _TranslationsAccountPageItemsJa._(_root);
+	@override late final _TranslationsAccountPageSnackBarJa snackBar = _TranslationsAccountPageSnackBarJa._(_root);
+	@override late final _TranslationsAccountPageDiaLogJa diaLog = _TranslationsAccountPageDiaLogJa._(_root);
 }
 
 // Path: authentication
 class _TranslationsAuthenticationJa implements TranslationsAuthenticationEn {
-  _TranslationsAuthenticationJa._(this._root);
+	_TranslationsAuthenticationJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationSignInPageJa signInPage =
-      _TranslationsAuthenticationSignInPageJa._(_root);
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageJa resetPasswordPage =
-      _TranslationsAuthenticationResetPasswordPageJa._(_root);
-  @override
-  late final _TranslationsAuthenticationSignUpPageJa signUpPage =
-      _TranslationsAuthenticationSignUpPageJa._(_root);
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageJa
-      emailVerificationPage =
-      _TranslationsAuthenticationEmailVerificationPageJa._(_root);
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageJa
-      registerProfilePage =
-      _TranslationsAuthenticationRegisterProfilePageJa._(_root);
-  @override
-  late final _TranslationsAuthenticationCompleteSendEmailPageJa
-      completeSendEmailPage =
-      _TranslationsAuthenticationCompleteSendEmailPageJa._(_root);
-  @override
-  late final _TranslationsAuthenticationFirebaseAuthJa firebaseAuth =
-      _TranslationsAuthenticationFirebaseAuthJa._(_root);
+	// Translations
+	@override late final _TranslationsAuthenticationSignInPageJa signInPage = _TranslationsAuthenticationSignInPageJa._(_root);
+	@override late final _TranslationsAuthenticationResetPasswordPageJa resetPasswordPage = _TranslationsAuthenticationResetPasswordPageJa._(_root);
+	@override late final _TranslationsAuthenticationSignUpPageJa signUpPage = _TranslationsAuthenticationSignUpPageJa._(_root);
+	@override late final _TranslationsAuthenticationEmailVerificationPageJa emailVerificationPage = _TranslationsAuthenticationEmailVerificationPageJa._(_root);
+	@override late final _TranslationsAuthenticationRegisterProfilePageJa registerProfilePage = _TranslationsAuthenticationRegisterProfilePageJa._(_root);
+	@override late final _TranslationsAuthenticationCompleteSendEmailPageJa completeSendEmailPage = _TranslationsAuthenticationCompleteSendEmailPageJa._(_root);
+	@override late final _TranslationsAuthenticationFirebaseAuthJa firebaseAuth = _TranslationsAuthenticationFirebaseAuthJa._(_root);
 }
 
 // Path: validation
 class _TranslationsValidationJa implements TranslationsValidationEn {
-  _TranslationsValidationJa._(this._root);
+	_TranslationsValidationJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get emailRequired => 'メールアドレスを入力してください';
-  @override
-  String get emailInvalid => 'メールアドレスの形式が正しくありません';
-  @override
-  String get passwordRequired => 'パスワードを入力してください';
-  @override
-  String get passwordShort => 'パスワードは少なくとも8文字以上である必要があります';
-  @override
-  String get passwordWeak => 'パスワードは半角英数字を組み合わせてください';
-  @override
-  String get passwordMatch => 'パスワードが一致しません';
-  @override
-  String get informationRequired => '情報を入力してください';
-  @override
-  String get urlInvalid => 'URLの形式が正しくありません';
+	// Translations
+	@override String get emailRequired => 'メールアドレスを入力してください';
+	@override String get emailInvalid => 'メールアドレスの形式が正しくありません';
+	@override String get passwordRequired => 'パスワードを入力してください';
+	@override String get passwordShort => 'パスワードは少なくとも8文字以上である必要があります';
+	@override String get passwordWeak => 'パスワードは半角英数字を組み合わせてください';
+	@override String get passwordMatch => 'パスワードが一致しません';
+	@override String get informationRequired => '情報を入力してください';
+	@override String get urlInvalid => 'URLの形式が正しくありません';
+	@override String get userNameRequired => 'ユーザーネームを入力してください';
+	@override String get userNameMaxLength => 'ユーザーネームは8文字以内である必要があります';
 }
 
 // Path: myPage
 class _TranslationsMyPageJa implements TranslationsMyPageEn {
-  _TranslationsMyPageJa._(this._root);
+	_TranslationsMyPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get unregisteredUserName => '未登録';
-  @override
-  String get editProfile => 'プロフィール編集';
-  @override
-  String get premiumPlan => 'プレミアムプラン';
-  @override
-  String get details => '詳細';
-  @override
-  String get settings => '設定';
-  @override
-  String get account => 'アカウント';
-  @override
-  String get language => '言語';
-  @override
-  String get theme => 'テーマ';
-  @override
-  String get termsOfUsePrivacyPolicy => '利用規約・プライバシーポリシー';
-  @override
-  String get aboutThisApp => 'このアプリについて';
-  @override
-  String get aboutTheDeveloper => '開発者について';
-  @override
-  late final _TranslationsMyPageAccountStatusJa accountStatus =
-      _TranslationsMyPageAccountStatusJa._(_root);
+	// Translations
+	@override String get unregisteredUserName => '未登録';
+	@override String get editProfile => 'プロフィール編集';
+	@override String get premiumPlan => 'プレミアムプラン';
+	@override String get details => '詳細';
+	@override String get settings => '設定';
+	@override String get account => 'アカウント';
+	@override String get language => '言語';
+	@override String get theme => 'テーマ';
+	@override String get termsOfUsePrivacyPolicy => '利用規約・プライバシーポリシー';
+	@override String get aboutThisApp => 'このアプリについて';
+	@override String get aboutTheDeveloper => '開発者について';
+	@override late final _TranslationsMyPageAccountStatusJa accountStatus = _TranslationsMyPageAccountStatusJa._(_root);
 }
 
 // Path: changeLanguagePage
-class _TranslationsChangeLanguagePageJa
-    implements TranslationsChangeLanguagePageEn {
-  _TranslationsChangeLanguagePageJa._(this._root);
+class _TranslationsChangeLanguagePageJa implements TranslationsChangeLanguagePageEn {
+	_TranslationsChangeLanguagePageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '言語';
-  @override
-  late final _TranslationsChangeLanguagePageItemsJa items =
-      _TranslationsChangeLanguagePageItemsJa._(_root);
+	// Translations
+	@override String get title => '言語';
+	@override late final _TranslationsChangeLanguagePageItemsJa items = _TranslationsChangeLanguagePageItemsJa._(_root);
 }
 
 // Path: changeThemePage
 class _TranslationsChangeThemePageJa implements TranslationsChangeThemePageEn {
-  _TranslationsChangeThemePageJa._(this._root);
+	_TranslationsChangeThemePageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'テーマ';
-  @override
-  late final _TranslationsChangeThemePageItemsJa items =
-      _TranslationsChangeThemePageItemsJa._(_root);
+	// Translations
+	@override String get title => 'テーマ';
+	@override late final _TranslationsChangeThemePageItemsJa items = _TranslationsChangeThemePageItemsJa._(_root);
 }
 
 // Path: myPlanPage
 class _TranslationsMyPlanPageJa implements TranslationsMyPlanPageEn {
-  _TranslationsMyPlanPageJa._(this._root);
+	_TranslationsMyPlanPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'マイプラン';
-  @override
-  late final _TranslationsMyPlanPageTabsJa tabs =
-      _TranslationsMyPlanPageTabsJa._(_root);
-  @override
-  late final _TranslationsMyPlanPageBookmarkItemsJa bookmarkItems =
-      _TranslationsMyPlanPageBookmarkItemsJa._(_root);
-  @override
-  late final _TranslationsMyPlanPageCreatedPlansItemsJa createdPlansItems =
-      _TranslationsMyPlanPageCreatedPlansItemsJa._(_root);
-  @override
-  late final _TranslationsMyPlanPageErrorJa error =
-      _TranslationsMyPlanPageErrorJa._(_root);
+	// Translations
+	@override String get title => 'マイプラン';
+	@override late final _TranslationsMyPlanPageTabsJa tabs = _TranslationsMyPlanPageTabsJa._(_root);
+	@override late final _TranslationsMyPlanPageBookmarkItemsJa bookmarkItems = _TranslationsMyPlanPageBookmarkItemsJa._(_root);
+	@override late final _TranslationsMyPlanPageCreatedPlansItemsJa createdPlansItems = _TranslationsMyPlanPageCreatedPlansItemsJa._(_root);
+	@override late final _TranslationsMyPlanPageErrorJa error = _TranslationsMyPlanPageErrorJa._(_root);
 }
 
 // Path: buddyChatPage
 class _TranslationsBuddyChatPageJa implements TranslationsBuddyChatPageEn {
-  _TranslationsBuddyChatPageJa._(this._root);
+	_TranslationsBuddyChatPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'Buddyの提案';
-  @override
-  String possibleChatCount({required Object possibleChatCount}) =>
-      'メッセージは残り${possibleChatCount}回送信可能です';
-  @override
-  late final _TranslationsBuddyChatPageTextFieldsJa textFields =
-      _TranslationsBuddyChatPageTextFieldsJa._(_root);
-  @override
-  late final _TranslationsBuddyChatPageButtonsJa buttons =
-      _TranslationsBuddyChatPageButtonsJa._(_root);
-  @override
-  late final _TranslationsBuddyChatPagePlaceCardJa placeCard =
-      _TranslationsBuddyChatPagePlaceCardJa._(_root);
-  @override
-  late final _TranslationsBuddyChatPageSnackBarJa snackBar =
-      _TranslationsBuddyChatPageSnackBarJa._(_root);
+	// Translations
+	@override String get title => 'Buddyの提案';
+	@override String possibleChatCount({required Object possibleChatCount}) => 'メッセージは残り${possibleChatCount}回送信可能です';
+	@override late final _TranslationsBuddyChatPageTextFieldsJa textFields = _TranslationsBuddyChatPageTextFieldsJa._(_root);
+	@override late final _TranslationsBuddyChatPageButtonsJa buttons = _TranslationsBuddyChatPageButtonsJa._(_root);
+	@override late final _TranslationsBuddyChatPagePlaceCardJa placeCard = _TranslationsBuddyChatPagePlaceCardJa._(_root);
+	@override late final _TranslationsBuddyChatPageSnackBarJa snackBar = _TranslationsBuddyChatPageSnackBarJa._(_root);
 }
 
 // Path: popularTopics
 class _TranslationsPopularTopicsJa implements TranslationsPopularTopicsEn {
-  _TranslationsPopularTopicsJa._(this._root);
+	_TranslationsPopularTopicsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get sectionName => '人気のトピック';
+	// Translations
+	@override String get sectionName => '人気のトピック';
 }
 
 // Path: createPlanPage
 class _TranslationsCreatePlanPageJa implements TranslationsCreatePlanPageEn {
-  _TranslationsCreatePlanPageJa._(this._root);
+	_TranslationsCreatePlanPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'プランの作成';
-  @override
-  late final _TranslationsCreatePlanPageLabelJa label =
-      _TranslationsCreatePlanPageLabelJa._(_root);
-  @override
-  late final _TranslationsCreatePlanPageHintTextJa hintText =
-      _TranslationsCreatePlanPageHintTextJa._(_root);
-  @override
-  late final _TranslationsCreatePlanPageModalJa modal =
-      _TranslationsCreatePlanPageModalJa._(_root);
-  @override
-  List<String> get numberOfPeopleOptions => [
-        '1人',
-        '2人',
-        '3人',
-        '4人',
-        '5人',
-        '6人以上',
-      ];
-  @override
-  List<String> get transportOptions => [
-        '電車',
-        '徒歩',
-        '車',
-        'バス',
-      ];
-  @override
-  List<String> get categoryOptions => [
-        '子連れ向け',
-        '大人向け',
-        'エンタメ',
-        'アクティビティ',
-        '歴史',
-      ];
-  @override
-  List<String> get defaultTopics => [
-        'グルメ',
-        'ショッピング',
-        'アクティビティ',
-        '映画',
-      ];
-  @override
-  String get submitButton => 'プランをAIに伝える';
-  @override
-  late final _TranslationsCreatePlanPageSnackBarJa snackBar =
-      _TranslationsCreatePlanPageSnackBarJa._(_root);
+	// Translations
+	@override String get title => 'プランの作成';
+	@override late final _TranslationsCreatePlanPageLabelJa label = _TranslationsCreatePlanPageLabelJa._(_root);
+	@override late final _TranslationsCreatePlanPageHintTextJa hintText = _TranslationsCreatePlanPageHintTextJa._(_root);
+	@override late final _TranslationsCreatePlanPageModalJa modal = _TranslationsCreatePlanPageModalJa._(_root);
+	@override List<String> get numberOfPeopleOptions => [
+		'1人',
+		'2人',
+		'3人',
+		'4人',
+		'5人',
+		'6人以上',
+	];
+	@override List<String> get transportOptions => [
+		'電車',
+		'徒歩',
+		'車',
+		'バス',
+	];
+	@override List<String> get categoryOptions => [
+		'子連れ向け',
+		'大人向け',
+		'エンタメ',
+		'アクティビティ',
+		'歴史',
+	];
+	@override List<String> get defaultTopics => [
+		'グルメ',
+		'ショッピング',
+		'アクティビティ',
+		'映画',
+	];
+	@override String get submitButton => 'プランをAIに伝える';
+	@override late final _TranslationsCreatePlanPageSnackBarJa snackBar = _TranslationsCreatePlanPageSnackBarJa._(_root);
 }
 
 // Path: editProfilePage
 class _TranslationsEditProfilePageJa implements TranslationsEditProfilePageEn {
-  _TranslationsEditProfilePageJa._(this._root);
+	_TranslationsEditProfilePageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '編集';
-  @override
-  late final _TranslationsEditProfilePageTextFieldsJa textFields =
-      _TranslationsEditProfilePageTextFieldsJa._(_root);
-  @override
-  late final _TranslationsEditProfilePageButtonsJa buttons =
-      _TranslationsEditProfilePageButtonsJa._(_root);
-  @override
-  late final _TranslationsEditProfilePageSnackBarJa snackBar =
-      _TranslationsEditProfilePageSnackBarJa._(_root);
+	// Translations
+	@override String get title => '編集';
+	@override late final _TranslationsEditProfilePageTextFieldsJa textFields = _TranslationsEditProfilePageTextFieldsJa._(_root);
+	@override late final _TranslationsEditProfilePageButtonsJa buttons = _TranslationsEditProfilePageButtonsJa._(_root);
+	@override late final _TranslationsEditProfilePageSnackBarJa snackBar = _TranslationsEditProfilePageSnackBarJa._(_root);
 }
 
 // Path: confirmDialog
 class _TranslationsConfirmDialogJa implements TranslationsConfirmDialogEn {
-  _TranslationsConfirmDialogJa._(this._root);
+	_TranslationsConfirmDialogJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsConfirmDialogAnswersJa answers =
-      _TranslationsConfirmDialogAnswersJa._(_root);
-  @override
-  late final _TranslationsConfirmDialogPopPageJa popPage =
-      _TranslationsConfirmDialogPopPageJa._(_root);
-  @override
-  late final _TranslationsConfirmDialogCompleteCreatePlanJa completeCreatePlan =
-      _TranslationsConfirmDialogCompleteCreatePlanJa._(_root);
+	// Translations
+	@override late final _TranslationsConfirmDialogAnswersJa answers = _TranslationsConfirmDialogAnswersJa._(_root);
+	@override late final _TranslationsConfirmDialogPopPageJa popPage = _TranslationsConfirmDialogPopPageJa._(_root);
+	@override late final _TranslationsConfirmDialogCompleteCreatePlanJa completeCreatePlan = _TranslationsConfirmDialogCompleteCreatePlanJa._(_root);
 }
 
 // Path: prompt
 class _TranslationsPromptJa implements TranslationsPromptEn {
-  _TranslationsPromptJa._(this._root);
+	_TranslationsPromptJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get planProposalMessage => 'こんなプランを考えてみました！いかがですか？';
+	// Translations
+	@override String get planProposalMessage => 'こんなプランを考えてみました！いかがですか？';
 }
 
 // Path: billDetailsPage
 class _TranslationsBillDetailsPageJa implements TranslationsBillDetailsPageEn {
-  _TranslationsBillDetailsPageJa._(this._root);
+	_TranslationsBillDetailsPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'プレミアムプラン';
-  @override
-  String get description => 'プレミアムプランに加入することで、より快適に渋谷観光をお楽しみいただけます。';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanJa pricingPlan =
-      _TranslationsBillDetailsPagePricingPlanJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesJa features =
-      _TranslationsBillDetailsPageFeaturesJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsJa pricingOptions =
-      _TranslationsBillDetailsPagePricingOptionsJa._(_root);
-  @override
-  String get upgradeButton => 'プレミアムにアップグレード';
+	// Translations
+	@override String get title => 'プレミアムプラン';
+	@override String get description => 'プレミアムプランに加入することで、より快適に渋谷観光をお楽しみいただけます。';
+	@override late final _TranslationsBillDetailsPagePricingPlanJa pricingPlan = _TranslationsBillDetailsPagePricingPlanJa._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesJa features = _TranslationsBillDetailsPageFeaturesJa._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsJa pricingOptions = _TranslationsBillDetailsPagePricingOptionsJa._(_root);
+	@override String get upgradeButton => 'プレミアムにアップグレード';
 }
 
 // Path: planDetailsPage
 class _TranslationsPlanDetailsPageJa implements TranslationsPlanDetailsPageEn {
-  _TranslationsPlanDetailsPageJa._(this._root);
+	_TranslationsPlanDetailsPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsPlanDetailsPageDateTimeJa dateTime =
-      _TranslationsPlanDetailsPageDateTimeJa._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageItemJa item =
-      _TranslationsPlanDetailsPageItemJa._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageSnackBarJa snackBar =
-      _TranslationsPlanDetailsPageSnackBarJa._(_root);
+	// Translations
+	@override late final _TranslationsPlanDetailsPageDateTimeJa dateTime = _TranslationsPlanDetailsPageDateTimeJa._(_root);
+	@override late final _TranslationsPlanDetailsPageItemJa item = _TranslationsPlanDetailsPageItemJa._(_root);
+	@override late final _TranslationsPlanDetailsPageSnackBarJa snackBar = _TranslationsPlanDetailsPageSnackBarJa._(_root);
 }
 
 // Path: errorPage
 class _TranslationsErrorPageJa implements TranslationsErrorPageEn {
-  _TranslationsErrorPageJa._(this._root);
+	_TranslationsErrorPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'エラーが発生しました...';
-  @override
-  String get message => '通信環境を確認し、もう一度お試しください';
-  @override
-  String get retryButton => 'もう一度読み込む';
+	// Translations
+	@override String get title => 'エラーが発生しました...';
+	@override String get message => '通信環境を確認し、もう一度お試しください';
+	@override String get retryButton => 'もう一度読み込む';
 }
 
 // Path: mapPage
 class _TranslationsMapPageJa implements TranslationsMapPageEn {
-  _TranslationsMapPageJa._(this._root);
+	_TranslationsMapPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'マップ';
+	// Translations
+	@override String get title => 'マップ';
 }
 
 // Path: navigationBar.items
-class _TranslationsNavigationBarItemsJa
-    implements TranslationsNavigationBarItemsEn {
-  _TranslationsNavigationBarItemsJa._(this._root);
+class _TranslationsNavigationBarItemsJa implements TranslationsNavigationBarItemsEn {
+	_TranslationsNavigationBarItemsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get home => 'ホーム';
-  @override
-  String get myPlan => 'マイプラン';
-  @override
-  String get myPage => 'マイページ';
+	// Translations
+	@override String get home => 'ホーム';
+	@override String get myPlan => 'マイプラン';
+	@override String get myPage => 'マイページ';
 }
 
 // Path: homePage.popularPlans
-class _TranslationsHomePagePopularPlansJa
-    implements TranslationsHomePagePopularPlansEn {
-  _TranslationsHomePagePopularPlansJa._(this._root);
+class _TranslationsHomePagePopularPlansJa implements TranslationsHomePagePopularPlansEn {
+	_TranslationsHomePagePopularPlansJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '人気のプラン';
+	// Translations
+	@override String get title => '人気のプラン';
 }
 
 // Path: homePage.popularTopics
-class _TranslationsHomePagePopularTopicsJa
-    implements TranslationsHomePagePopularTopicsEn {
-  _TranslationsHomePagePopularTopicsJa._(this._root);
+class _TranslationsHomePagePopularTopicsJa implements TranslationsHomePagePopularTopicsEn {
+	_TranslationsHomePagePopularTopicsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '人気のトピック';
-  @override
-  String numberOfTopics({required Object number}) => '${number}件~';
+	// Translations
+	@override String get title => '人気のトピック';
+	@override String numberOfTopics({required Object number}) => '${number}件~';
 }
 
 // Path: homePage.recentPlans
-class _TranslationsHomePageRecentPlansJa
-    implements TranslationsHomePageRecentPlansEn {
-  _TranslationsHomePageRecentPlansJa._(this._root);
+class _TranslationsHomePageRecentPlansJa implements TranslationsHomePageRecentPlansEn {
+	_TranslationsHomePageRecentPlansJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '最近作成したプラン';
+	// Translations
+	@override String get title => '最近作成したプラン';
 }
 
 // Path: accountPage.items
-class _TranslationsAccountPageItemsJa
-    implements TranslationsAccountPageItemsEn {
-  _TranslationsAccountPageItemsJa._(this._root);
+class _TranslationsAccountPageItemsJa implements TranslationsAccountPageItemsEn {
+	_TranslationsAccountPageItemsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signOut => 'ログアウト';
-  @override
-  String get linkedWithGoogle => 'Googleで連携';
-  @override
-  String get linkedWithApple => 'Appleで連携';
-  @override
-  String get alreadyLinkedGoogle => 'Google連携済み';
-  @override
-  String get alreadyLinkedApple => 'Appleで連携済み';
+	// Translations
+	@override String get signOut => 'ログアウト';
+	@override String get linkedWithGoogle => 'Googleで連携';
+	@override String get linkedWithApple => 'Appleで連携';
+	@override String get alreadyLinkedGoogle => 'Google連携済み';
+	@override String get alreadyLinkedApple => 'Appleで連携済み';
 }
 
 // Path: accountPage.snackBar
-class _TranslationsAccountPageSnackBarJa
-    implements TranslationsAccountPageSnackBarEn {
-  _TranslationsAccountPageSnackBarJa._(this._root);
+class _TranslationsAccountPageSnackBarJa implements TranslationsAccountPageSnackBarEn {
+	_TranslationsAccountPageSnackBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signOut => 'ログアウトしました。';
-  @override
-  String get signOutFailure => 'ログアウト時にエラーが発生しました。';
-  @override
-  String get successfulLinkage => 'アカウント連携に成功しました。';
-  @override
-  String get linkageFailure => 'アカウント連携に失敗しました。';
-  @override
-  String get providerAlreadyLinked => 'このアカウントはすでに連携済みです。';
-  @override
-  String get accountDeactivation => 'アカウントの連携を解除しました。';
-  @override
-  String get invalidCredential => '再度ログインをやり直してください。';
-  @override
-  String get linkageCancelled => 'アカウントの連携をキャンセルしました。';
-  @override
-  String get unlinkageFailure => 'アカウントの連携解除に失敗しました。';
-  @override
-  String get operationNotAllowed => 'プロパイダーが無効です。開発者にお問い合わせください。';
-  @override
-  String get unknownError => '不明なエラーが発生しました。';
+	// Translations
+	@override String get signOut => 'ログアウトしました。';
+	@override String get signOutFailure => 'ログアウト時にエラーが発生しました。';
+	@override String get successfulLinkage => 'アカウント連携に成功しました。';
+	@override String get linkageFailure => 'アカウント連携に失敗しました。';
+	@override String get providerAlreadyLinked => 'このアカウントはすでに連携済みです。';
+	@override String get accountDeactivation => 'アカウントの連携を解除しました。';
+	@override String get invalidCredential => '再度ログインをやり直してください。';
+	@override String get linkageCancelled => 'アカウントの連携をキャンセルしました。';
+	@override String get unlinkageFailure => 'アカウントの連携解除に失敗しました。';
+	@override String get operationNotAllowed => 'プロパイダーが無効です。開発者にお問い合わせください。';
+	@override String get unknownError => '不明なエラーが発生しました。';
 }
 
 // Path: accountPage.diaLog
-class _TranslationsAccountPageDiaLogJa
-    implements TranslationsAccountPageDiaLogEn {
-  _TranslationsAccountPageDiaLogJa._(this._root);
+class _TranslationsAccountPageDiaLogJa implements TranslationsAccountPageDiaLogEn {
+	_TranslationsAccountPageDiaLogJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get yes => 'はい';
-  @override
-  String get no => 'いいえ';
-  @override
-  String get title => 'アカウント連携解除の確認';
-  @override
-  String get googleText => '現在のアカウントとGoogleアカウントの連携を解除しますか？';
-  @override
-  String get appleText => '現在のアカウントとAppleアカウントの連携を解除しますか？';
+	// Translations
+	@override String get yes => 'はい';
+	@override String get no => 'いいえ';
+	@override String get title => 'アカウント連携解除の確認';
+	@override String get googleText => '現在のアカウントとGoogleアカウントの連携を解除しますか？';
+	@override String get appleText => '現在のアカウントとAppleアカウントの連携を解除しますか？';
 }
 
 // Path: authentication.signInPage
-class _TranslationsAuthenticationSignInPageJa
-    implements TranslationsAuthenticationSignInPageEn {
-  _TranslationsAuthenticationSignInPageJa._(this._root);
+class _TranslationsAuthenticationSignInPageJa implements TranslationsAuthenticationSignInPageEn {
+	_TranslationsAuthenticationSignInPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'ログイン';
-  @override
-  String get optionText => ' または ';
-  @override
-  late final _TranslationsAuthenticationSignInPageTextFieldsJa textFields =
-      _TranslationsAuthenticationSignInPageTextFieldsJa._(_root);
-  @override
-  late final _TranslationsAuthenticationSignInPageButtonsJa buttons =
-      _TranslationsAuthenticationSignInPageButtonsJa._(_root);
+	// Translations
+	@override String get title => 'ログイン';
+	@override String get optionText => ' または ';
+	@override late final _TranslationsAuthenticationSignInPageTextFieldsJa textFields = _TranslationsAuthenticationSignInPageTextFieldsJa._(_root);
+	@override late final _TranslationsAuthenticationSignInPageButtonsJa buttons = _TranslationsAuthenticationSignInPageButtonsJa._(_root);
 }
 
 // Path: authentication.resetPasswordPage
-class _TranslationsAuthenticationResetPasswordPageJa
-    implements TranslationsAuthenticationResetPasswordPageEn {
-  _TranslationsAuthenticationResetPasswordPageJa._(this._root);
+class _TranslationsAuthenticationResetPasswordPageJa implements TranslationsAuthenticationResetPasswordPageEn {
+	_TranslationsAuthenticationResetPasswordPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'パスワードのリセット';
-  @override
-  String get description => '入力されたメールアドレスにパスワードリセットのメールを送信します';
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageTextFieldsJa
-      textFields =
-      _TranslationsAuthenticationResetPasswordPageTextFieldsJa._(_root);
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageButtonsJa buttons =
-      _TranslationsAuthenticationResetPasswordPageButtonsJa._(_root);
+	// Translations
+	@override String get title => 'パスワードのリセット';
+	@override String get description => '入力されたメールアドレスにパスワードリセットのメールを送信します';
+	@override late final _TranslationsAuthenticationResetPasswordPageTextFieldsJa textFields = _TranslationsAuthenticationResetPasswordPageTextFieldsJa._(_root);
+	@override late final _TranslationsAuthenticationResetPasswordPageButtonsJa buttons = _TranslationsAuthenticationResetPasswordPageButtonsJa._(_root);
 }
 
 // Path: authentication.signUpPage
-class _TranslationsAuthenticationSignUpPageJa
-    implements TranslationsAuthenticationSignUpPageEn {
-  _TranslationsAuthenticationSignUpPageJa._(this._root);
+class _TranslationsAuthenticationSignUpPageJa implements TranslationsAuthenticationSignUpPageEn {
+	_TranslationsAuthenticationSignUpPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '新規登録';
-  @override
-  late final _TranslationsAuthenticationSignUpPageTextFieldsJa textFields =
-      _TranslationsAuthenticationSignUpPageTextFieldsJa._(_root);
-  @override
-  String get button => '新規登録';
+	// Translations
+	@override String get title => '新規登録';
+	@override late final _TranslationsAuthenticationSignUpPageTextFieldsJa textFields = _TranslationsAuthenticationSignUpPageTextFieldsJa._(_root);
+	@override String get button => '新規登録';
 }
 
 // Path: authentication.emailVerificationPage
-class _TranslationsAuthenticationEmailVerificationPageJa
-    implements TranslationsAuthenticationEmailVerificationPageEn {
-  _TranslationsAuthenticationEmailVerificationPageJa._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageJa implements TranslationsAuthenticationEmailVerificationPageEn {
+	_TranslationsAuthenticationEmailVerificationPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'メールアドレスの確認';
-  @override
-  String descriptionForDestination({required Object email}) =>
-      '入力された${email}に確認メールを送信します';
-  @override
-  String get descriptionForCoolDown => '確認メールの再送信は、60秒ごとに1回可能です。';
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageButtonsJa buttons =
-      _TranslationsAuthenticationEmailVerificationPageButtonsJa._(_root);
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageSnackBarJa
-      snackBar =
-      _TranslationsAuthenticationEmailVerificationPageSnackBarJa._(_root);
+	// Translations
+	@override String get title => 'メールアドレスの確認';
+	@override String descriptionForDestination({required Object email}) => '入力された${email}に確認メールを送信します';
+	@override String get descriptionForCoolDown => '確認メールの再送信は、60秒ごとに1回可能です。';
+	@override late final _TranslationsAuthenticationEmailVerificationPageButtonsJa buttons = _TranslationsAuthenticationEmailVerificationPageButtonsJa._(_root);
+	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarJa snackBar = _TranslationsAuthenticationEmailVerificationPageSnackBarJa._(_root);
 }
 
 // Path: authentication.registerProfilePage
-class _TranslationsAuthenticationRegisterProfilePageJa
-    implements TranslationsAuthenticationRegisterProfilePageEn {
-  _TranslationsAuthenticationRegisterProfilePageJa._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageJa implements TranslationsAuthenticationRegisterProfilePageEn {
+	_TranslationsAuthenticationRegisterProfilePageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'プロフィールの登録';
-  @override
-  String get textFields => '名前';
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageButtonsJa buttons =
-      _TranslationsAuthenticationRegisterProfilePageButtonsJa._(_root);
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageSnackBarJa snackBar =
-      _TranslationsAuthenticationRegisterProfilePageSnackBarJa._(_root);
+	// Translations
+	@override String get title => 'プロフィールの登録';
+	@override String get textFields => '名前';
+	@override late final _TranslationsAuthenticationRegisterProfilePageButtonsJa buttons = _TranslationsAuthenticationRegisterProfilePageButtonsJa._(_root);
+	@override late final _TranslationsAuthenticationRegisterProfilePageSnackBarJa snackBar = _TranslationsAuthenticationRegisterProfilePageSnackBarJa._(_root);
 }
 
 // Path: authentication.completeSendEmailPage
-class _TranslationsAuthenticationCompleteSendEmailPageJa
-    implements TranslationsAuthenticationCompleteSendEmailPageEn {
-  _TranslationsAuthenticationCompleteSendEmailPageJa._(this._root);
+class _TranslationsAuthenticationCompleteSendEmailPageJa implements TranslationsAuthenticationCompleteSendEmailPageEn {
+	_TranslationsAuthenticationCompleteSendEmailPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '送信完了';
-  @override
-  String description({required Object email}) =>
-      'パスワードリセット用のメールが${email}に送信されました \n リセット後にログイン画面からログインしてください';
-  @override
-  String get successResendEmail => '確認メールを再送信しました';
-  @override
-  late final _TranslationsAuthenticationCompleteSendEmailPageButtonsJa buttons =
-      _TranslationsAuthenticationCompleteSendEmailPageButtonsJa._(_root);
+	// Translations
+	@override String get title => '送信完了';
+	@override String description({required Object email}) => 'パスワードリセット用のメールが${email}に送信されました \n リセット後にログイン画面からログインしてください';
+	@override String get successResendEmail => '確認メールを再送信しました';
+	@override late final _TranslationsAuthenticationCompleteSendEmailPageButtonsJa buttons = _TranslationsAuthenticationCompleteSendEmailPageButtonsJa._(_root);
 }
 
 // Path: authentication.firebaseAuth
-class _TranslationsAuthenticationFirebaseAuthJa
-    implements TranslationsAuthenticationFirebaseAuthEn {
-  _TranslationsAuthenticationFirebaseAuthJa._(this._root);
+class _TranslationsAuthenticationFirebaseAuthJa implements TranslationsAuthenticationFirebaseAuthEn {
+	_TranslationsAuthenticationFirebaseAuthJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationFirebaseAuthErrorJa error =
-      _TranslationsAuthenticationFirebaseAuthErrorJa._(_root);
+	// Translations
+	@override late final _TranslationsAuthenticationFirebaseAuthErrorJa error = _TranslationsAuthenticationFirebaseAuthErrorJa._(_root);
 }
 
 // Path: myPage.accountStatus
-class _TranslationsMyPageAccountStatusJa
-    implements TranslationsMyPageAccountStatusEn {
-  _TranslationsMyPageAccountStatusJa._(this._root);
+class _TranslationsMyPageAccountStatusJa implements TranslationsMyPageAccountStatusEn {
+	_TranslationsMyPageAccountStatusJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsMyPageAccountStatusDateTimeJa dateTime =
-      _TranslationsMyPageAccountStatusDateTimeJa._(_root);
-  @override
-  String get premium => 'プレミアム会員';
-  @override
-  String get standard => 'スタンダード会員';
+	// Translations
+	@override late final _TranslationsMyPageAccountStatusDateTimeJa dateTime = _TranslationsMyPageAccountStatusDateTimeJa._(_root);
+	@override String get premium => 'プレミアム会員';
+	@override String get standard => 'スタンダード会員';
 }
 
 // Path: changeLanguagePage.items
-class _TranslationsChangeLanguagePageItemsJa
-    implements TranslationsChangeLanguagePageItemsEn {
-  _TranslationsChangeLanguagePageItemsJa._(this._root);
+class _TranslationsChangeLanguagePageItemsJa implements TranslationsChangeLanguagePageItemsEn {
+	_TranslationsChangeLanguagePageItemsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get japanese => '日本語';
-  @override
-  String get english => '英語';
-  @override
-  String get simplifiedChinese => '中国語（簡体字）';
-  @override
-  String get traditionalChinese => '中国語（繁体字）';
+	// Translations
+	@override String get japanese => '日本語';
+	@override String get english => '英語';
+	@override String get simplifiedChinese => '中国語（簡体字）';
+	@override String get traditionalChinese => '中国語（繁体字）';
 }
 
 // Path: changeThemePage.items
-class _TranslationsChangeThemePageItemsJa
-    implements TranslationsChangeThemePageItemsEn {
-  _TranslationsChangeThemePageItemsJa._(this._root);
+class _TranslationsChangeThemePageItemsJa implements TranslationsChangeThemePageItemsEn {
+	_TranslationsChangeThemePageItemsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get system => 'システム';
-  @override
-  String get light => 'ライト';
-  @override
-  String get dark => 'ダーク';
+	// Translations
+	@override String get system => 'システム';
+	@override String get light => 'ライト';
+	@override String get dark => 'ダーク';
 }
 
 // Path: myPlanPage.tabs
 class _TranslationsMyPlanPageTabsJa implements TranslationsMyPlanPageTabsEn {
-  _TranslationsMyPlanPageTabsJa._(this._root);
+	_TranslationsMyPlanPageTabsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get createdPlans => '作成したプラン';
-  @override
-  String get bookmark => 'ブックマーク';
+	// Translations
+	@override String get createdPlans => '作成したプラン';
+	@override String get bookmark => 'ブックマーク';
 }
 
 // Path: myPlanPage.bookmarkItems
-class _TranslationsMyPlanPageBookmarkItemsJa
-    implements TranslationsMyPlanPageBookmarkItemsEn {
-  _TranslationsMyPlanPageBookmarkItemsJa._(this._root);
+class _TranslationsMyPlanPageBookmarkItemsJa implements TranslationsMyPlanPageBookmarkItemsEn {
+	_TranslationsMyPlanPageBookmarkItemsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get nondata => 'ブックマークしているプランはありません。';
-  @override
-  String get reloading => '再読み込み';
+	// Translations
+	@override String get nondata => 'ブックマークしているプランはありません。';
+	@override String get reloading => '再読み込み';
 }
 
 // Path: myPlanPage.createdPlansItems
-class _TranslationsMyPlanPageCreatedPlansItemsJa
-    implements TranslationsMyPlanPageCreatedPlansItemsEn {
-  _TranslationsMyPlanPageCreatedPlansItemsJa._(this._root);
+class _TranslationsMyPlanPageCreatedPlansItemsJa implements TranslationsMyPlanPageCreatedPlansItemsEn {
+	_TranslationsMyPlanPageCreatedPlansItemsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get nondata => 'プランを作成してみよう!';
-  @override
-  String get createaplan => 'プランを作成する';
+	// Translations
+	@override String get nondata => 'プランを作成してみよう!';
+	@override String get createaplan => 'プランを作成する';
 }
 
 // Path: myPlanPage.error
 class _TranslationsMyPlanPageErrorJa implements TranslationsMyPlanPageErrorEn {
-  _TranslationsMyPlanPageErrorJa._(this._root);
+	_TranslationsMyPlanPageErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get displayError => 'プラン表示時に問題が発生しました。';
-  @override
-  String get failedGetId => 'プランIDの取得に失敗しました。';
-  @override
-  String get failedGetPlanData => 'プランデータ取得時に問題が発生しました。';
-  @override
-  String get failedUnBookmark => 'ブックマーク解除時に問題が発生しました。';
+	// Translations
+	@override String get displayError => 'プラン表示時に問題が発生しました。';
+	@override String get failedGetId => 'プランIDの取得に失敗しました。';
+	@override String get failedGetPlanData => 'プランデータ取得時に問題が発生しました。';
+	@override String get failedUnBookmark => 'ブックマーク解除時に問題が発生しました。';
 }
 
 // Path: buddyChatPage.textFields
-class _TranslationsBuddyChatPageTextFieldsJa
-    implements TranslationsBuddyChatPageTextFieldsEn {
-  _TranslationsBuddyChatPageTextFieldsJa._(this._root);
+class _TranslationsBuddyChatPageTextFieldsJa implements TranslationsBuddyChatPageTextFieldsEn {
+	_TranslationsBuddyChatPageTextFieldsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get message => 'メッセージを入力';
+	// Translations
+	@override String get message => 'メッセージを入力';
 }
 
 // Path: buddyChatPage.buttons
-class _TranslationsBuddyChatPageButtonsJa
-    implements TranslationsBuddyChatPageButtonsEn {
-  _TranslationsBuddyChatPageButtonsJa._(this._root);
+class _TranslationsBuddyChatPageButtonsJa implements TranslationsBuddyChatPageButtonsEn {
+	_TranslationsBuddyChatPageButtonsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get send => '完了';
+	// Translations
+	@override String get send => '完了';
 }
 
 // Path: buddyChatPage.placeCard
-class _TranslationsBuddyChatPagePlaceCardJa
-    implements TranslationsBuddyChatPagePlaceCardEn {
-  _TranslationsBuddyChatPagePlaceCardJa._(this._root);
+class _TranslationsBuddyChatPagePlaceCardJa implements TranslationsBuddyChatPagePlaceCardEn {
+	_TranslationsBuddyChatPagePlaceCardJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get openingHours => '営業時間';
-  @override
-  String get averageAmount => '平均予算';
-  @override
-  String get website => 'Webサイト';
+	// Translations
+	@override String get openingHours => '営業時間';
+	@override String get averageAmount => '平均予算';
+	@override String get website => 'Webサイト';
 }
 
 // Path: buddyChatPage.snackBar
-class _TranslationsBuddyChatPageSnackBarJa
-    implements TranslationsBuddyChatPageSnackBarEn {
-  _TranslationsBuddyChatPageSnackBarJa._(this._root);
+class _TranslationsBuddyChatPageSnackBarJa implements TranslationsBuddyChatPageSnackBarEn {
+	_TranslationsBuddyChatPageSnackBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBuddyChatPageSnackBarErrorJa error =
-      _TranslationsBuddyChatPageSnackBarErrorJa._(_root);
+	// Translations
+	@override late final _TranslationsBuddyChatPageSnackBarErrorJa error = _TranslationsBuddyChatPageSnackBarErrorJa._(_root);
 }
 
 // Path: createPlanPage.label
-class _TranslationsCreatePlanPageLabelJa
-    implements TranslationsCreatePlanPageLabelEn {
-  _TranslationsCreatePlanPageLabelJa._(this._root);
+class _TranslationsCreatePlanPageLabelJa implements TranslationsCreatePlanPageLabelEn {
+	_TranslationsCreatePlanPageLabelJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get location => '目的地';
-  @override
-  String get scheduleStart => '開始日';
-  @override
-  String get scheduleEnd => '終了日';
-  @override
-  String get numberOfPeople => '人数';
-  @override
-  String get transport => '交通手段';
-  @override
-  String get category => 'カテゴリ';
-  @override
-  String get topics => '旅のトピック';
+	// Translations
+	@override String get location => '目的地';
+	@override String get scheduleStart => '開始日';
+	@override String get scheduleEnd => '終了日';
+	@override String get numberOfPeople => '人数';
+	@override String get transport => '交通手段';
+	@override String get category => 'カテゴリ';
+	@override String get topics => '旅のトピック';
 }
 
 // Path: createPlanPage.hintText
-class _TranslationsCreatePlanPageHintTextJa
-    implements TranslationsCreatePlanPageHintTextEn {
-  _TranslationsCreatePlanPageHintTextJa._(this._root);
+class _TranslationsCreatePlanPageHintTextJa implements TranslationsCreatePlanPageHintTextEn {
+	_TranslationsCreatePlanPageHintTextJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get location => '渋谷';
+	// Translations
+	@override String get location => '渋谷';
 }
 
 // Path: createPlanPage.modal
-class _TranslationsCreatePlanPageModalJa
-    implements TranslationsCreatePlanPageModalEn {
-  _TranslationsCreatePlanPageModalJa._(this._root);
+class _TranslationsCreatePlanPageModalJa implements TranslationsCreatePlanPageModalEn {
+	_TranslationsCreatePlanPageModalJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '日付を選択';
+	// Translations
+	@override String get title => '日付を選択';
 }
 
 // Path: createPlanPage.snackBar
-class _TranslationsCreatePlanPageSnackBarJa
-    implements TranslationsCreatePlanPageSnackBarEn {
-  _TranslationsCreatePlanPageSnackBarJa._(this._root);
+class _TranslationsCreatePlanPageSnackBarJa implements TranslationsCreatePlanPageSnackBarEn {
+	_TranslationsCreatePlanPageSnackBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsCreatePlanPageSnackBarErrorJa error =
-      _TranslationsCreatePlanPageSnackBarErrorJa._(_root);
+	// Translations
+	@override late final _TranslationsCreatePlanPageSnackBarErrorJa error = _TranslationsCreatePlanPageSnackBarErrorJa._(_root);
 }
 
 // Path: editProfilePage.textFields
-class _TranslationsEditProfilePageTextFieldsJa
-    implements TranslationsEditProfilePageTextFieldsEn {
-  _TranslationsEditProfilePageTextFieldsJa._(this._root);
+class _TranslationsEditProfilePageTextFieldsJa implements TranslationsEditProfilePageTextFieldsEn {
+	_TranslationsEditProfilePageTextFieldsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get name => '名前';
+	// Translations
+	@override String get name => '名前';
 }
 
 // Path: editProfilePage.buttons
-class _TranslationsEditProfilePageButtonsJa
-    implements TranslationsEditProfilePageButtonsEn {
-  _TranslationsEditProfilePageButtonsJa._(this._root);
+class _TranslationsEditProfilePageButtonsJa implements TranslationsEditProfilePageButtonsEn {
+	_TranslationsEditProfilePageButtonsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '保存';
+	// Translations
+	@override String get submit => '保存';
 }
 
 // Path: editProfilePage.snackBar
-class _TranslationsEditProfilePageSnackBarJa
-    implements TranslationsEditProfilePageSnackBarEn {
-  _TranslationsEditProfilePageSnackBarJa._(this._root);
+class _TranslationsEditProfilePageSnackBarJa implements TranslationsEditProfilePageSnackBarEn {
+	_TranslationsEditProfilePageSnackBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get success => '更新しました';
-  @override
-  late final _TranslationsEditProfilePageSnackBarErrorJa error =
-      _TranslationsEditProfilePageSnackBarErrorJa._(_root);
+	// Translations
+	@override String get success => '更新しました';
+	@override late final _TranslationsEditProfilePageSnackBarErrorJa error = _TranslationsEditProfilePageSnackBarErrorJa._(_root);
 }
 
 // Path: confirmDialog.answers
-class _TranslationsConfirmDialogAnswersJa
-    implements TranslationsConfirmDialogAnswersEn {
-  _TranslationsConfirmDialogAnswersJa._(this._root);
+class _TranslationsConfirmDialogAnswersJa implements TranslationsConfirmDialogAnswersEn {
+	_TranslationsConfirmDialogAnswersJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get yes => 'はい';
-  @override
-  String get no => 'いいえ';
+	// Translations
+	@override String get yes => 'はい';
+	@override String get no => 'いいえ';
 }
 
 // Path: confirmDialog.popPage
-class _TranslationsConfirmDialogPopPageJa
-    implements TranslationsConfirmDialogPopPageEn {
-  _TranslationsConfirmDialogPopPageJa._(this._root);
+class _TranslationsConfirmDialogPopPageJa implements TranslationsConfirmDialogPopPageEn {
+	_TranslationsConfirmDialogPopPageJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '前の画面に戻りますか？';
-  @override
-  String get description => '現在の内容は保存されません';
+	// Translations
+	@override String get title => '前の画面に戻りますか？';
+	@override String get description => '現在の内容は保存されません';
 }
 
 // Path: confirmDialog.completeCreatePlan
-class _TranslationsConfirmDialogCompleteCreatePlanJa
-    implements TranslationsConfirmDialogCompleteCreatePlanEn {
-  _TranslationsConfirmDialogCompleteCreatePlanJa._(this._root);
+class _TranslationsConfirmDialogCompleteCreatePlanJa implements TranslationsConfirmDialogCompleteCreatePlanEn {
+	_TranslationsConfirmDialogCompleteCreatePlanJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'プランを確定しますか？';
-  @override
-  String get description => '一番最後のメッセージに含まれるプランが保存されます';
+	// Translations
+	@override String get title => 'プランを確定しますか？';
+	@override String get description => '一番最後のメッセージに含まれるプランが保存されます';
 }
 
 // Path: billDetailsPage.pricingPlan
-class _TranslationsBillDetailsPagePricingPlanJa
-    implements TranslationsBillDetailsPagePricingPlanEn {
-  _TranslationsBillDetailsPagePricingPlanJa._(this._root);
+class _TranslationsBillDetailsPagePricingPlanJa implements TranslationsBillDetailsPagePricingPlanEn {
+	_TranslationsBillDetailsPagePricingPlanJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '料金プラン';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanColumnsJa columns =
-      _TranslationsBillDetailsPagePricingPlanColumnsJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanDetailsJa details =
-      _TranslationsBillDetailsPagePricingPlanDetailsJa._(_root);
+	// Translations
+	@override String get title => '料金プラン';
+	@override late final _TranslationsBillDetailsPagePricingPlanColumnsJa columns = _TranslationsBillDetailsPagePricingPlanColumnsJa._(_root);
+	@override late final _TranslationsBillDetailsPagePricingPlanDetailsJa details = _TranslationsBillDetailsPagePricingPlanDetailsJa._(_root);
 }
 
 // Path: billDetailsPage.features
-class _TranslationsBillDetailsPageFeaturesJa
-    implements TranslationsBillDetailsPageFeaturesEn {
-  _TranslationsBillDetailsPageFeaturesJa._(this._root);
+class _TranslationsBillDetailsPageFeaturesJa implements TranslationsBillDetailsPageFeaturesEn {
+	_TranslationsBillDetailsPageFeaturesJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'グレードごとの機能';
-  @override
-  late final _TranslationsBillDetailsPageFeaturesRowsJa rows =
-      _TranslationsBillDetailsPageFeaturesRowsJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsJa columns =
-      _TranslationsBillDetailsPageFeaturesColumnsJa._(_root);
+	// Translations
+	@override String get title => 'グレードごとの機能';
+	@override late final _TranslationsBillDetailsPageFeaturesRowsJa rows = _TranslationsBillDetailsPageFeaturesRowsJa._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsJa columns = _TranslationsBillDetailsPageFeaturesColumnsJa._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions
-class _TranslationsBillDetailsPagePricingOptionsJa
-    implements TranslationsBillDetailsPagePricingOptionsEn {
-  _TranslationsBillDetailsPagePricingOptionsJa._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsJa implements TranslationsBillDetailsPagePricingOptionsEn {
+	_TranslationsBillDetailsPagePricingOptionsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsOneDayJa oneDay =
-      _TranslationsBillDetailsPagePricingOptionsOneDayJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsThreeDaysJa threeDays =
-      _TranslationsBillDetailsPagePricingOptionsThreeDaysJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsFiveDaysJa fiveDays =
-      _TranslationsBillDetailsPagePricingOptionsFiveDaysJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsSevenDaysJa sevenDays =
-      _TranslationsBillDetailsPagePricingOptionsSevenDaysJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsLifetimeJa lifetime =
-      _TranslationsBillDetailsPagePricingOptionsLifetimeJa._(_root);
+	// Translations
+	@override late final _TranslationsBillDetailsPagePricingOptionsOneDayJa oneDay = _TranslationsBillDetailsPagePricingOptionsOneDayJa._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsThreeDaysJa threeDays = _TranslationsBillDetailsPagePricingOptionsThreeDaysJa._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsFiveDaysJa fiveDays = _TranslationsBillDetailsPagePricingOptionsFiveDaysJa._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsSevenDaysJa sevenDays = _TranslationsBillDetailsPagePricingOptionsSevenDaysJa._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsLifetimeJa lifetime = _TranslationsBillDetailsPagePricingOptionsLifetimeJa._(_root);
 }
 
 // Path: planDetailsPage.dateTime
-class _TranslationsPlanDetailsPageDateTimeJa
-    implements TranslationsPlanDetailsPageDateTimeEn {
-  _TranslationsPlanDetailsPageDateTimeJa._(this._root);
+class _TranslationsPlanDetailsPageDateTimeJa implements TranslationsPlanDetailsPageDateTimeEn {
+	_TranslationsPlanDetailsPageDateTimeJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String createOn({required Object date}) => '${date}に作られたプラン';
-  @override
-  String get dateFormat => 'yyyy年MM月dd日';
+	// Translations
+	@override String createOn({required Object date}) => '${date}に作られたプラン';
+	@override String get dateFormat => 'yyyy年MM月dd日';
 }
 
 // Path: planDetailsPage.item
-class _TranslationsPlanDetailsPageItemJa
-    implements TranslationsPlanDetailsPageItemEn {
-  _TranslationsPlanDetailsPageItemJa._(this._root);
+class _TranslationsPlanDetailsPageItemJa implements TranslationsPlanDetailsPageItemEn {
+	_TranslationsPlanDetailsPageItemJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get viewOnMap => '地図で見る';
+	// Translations
+	@override String get viewOnMap => '地図で見る';
 }
 
 // Path: planDetailsPage.snackBar
-class _TranslationsPlanDetailsPageSnackBarJa
-    implements TranslationsPlanDetailsPageSnackBarEn {
-  _TranslationsPlanDetailsPageSnackBarJa._(this._root);
+class _TranslationsPlanDetailsPageSnackBarJa implements TranslationsPlanDetailsPageSnackBarEn {
+	_TranslationsPlanDetailsPageSnackBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsPlanDetailsPageSnackBarErrorJa error =
-      _TranslationsPlanDetailsPageSnackBarErrorJa._(_root);
+	// Translations
+	@override late final _TranslationsPlanDetailsPageSnackBarErrorJa error = _TranslationsPlanDetailsPageSnackBarErrorJa._(_root);
 }
 
 // Path: authentication.signInPage.textFields
-class _TranslationsAuthenticationSignInPageTextFieldsJa
-    implements TranslationsAuthenticationSignInPageTextFieldsEn {
-  _TranslationsAuthenticationSignInPageTextFieldsJa._(this._root);
+class _TranslationsAuthenticationSignInPageTextFieldsJa implements TranslationsAuthenticationSignInPageTextFieldsEn {
+	_TranslationsAuthenticationSignInPageTextFieldsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => 'メールアドレス';
-  @override
-  String get password => 'パスワード';
+	// Translations
+	@override String get email => 'メールアドレス';
+	@override String get password => 'パスワード';
 }
 
 // Path: authentication.signInPage.buttons
-class _TranslationsAuthenticationSignInPageButtonsJa
-    implements TranslationsAuthenticationSignInPageButtonsEn {
-  _TranslationsAuthenticationSignInPageButtonsJa._(this._root);
+class _TranslationsAuthenticationSignInPageButtonsJa implements TranslationsAuthenticationSignInPageButtonsEn {
+	_TranslationsAuthenticationSignInPageButtonsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signIn => 'ログイン';
-  @override
-  String get signUp => '新規登録';
-  @override
-  String get resetPassword => 'パスワードを忘れた方はこちら';
-  @override
-  String get appleSignIn => 'Appleでログイン';
-  @override
-  String get googleSignIn => 'Googleでログイン';
-  @override
-  String get signInAfter => '後で登録';
+	// Translations
+	@override String get signIn => 'ログイン';
+	@override String get signUp => '新規登録';
+	@override String get resetPassword => 'パスワードを忘れた方はこちら';
+	@override String get appleSignIn => 'Appleでログイン';
+	@override String get googleSignIn => 'Googleでログイン';
+	@override String get signInAfter => '後で登録';
 }
 
 // Path: authentication.resetPasswordPage.textFields
-class _TranslationsAuthenticationResetPasswordPageTextFieldsJa
-    implements TranslationsAuthenticationResetPasswordPageTextFieldsEn {
-  _TranslationsAuthenticationResetPasswordPageTextFieldsJa._(this._root);
+class _TranslationsAuthenticationResetPasswordPageTextFieldsJa implements TranslationsAuthenticationResetPasswordPageTextFieldsEn {
+	_TranslationsAuthenticationResetPasswordPageTextFieldsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => 'メールアドレス';
+	// Translations
+	@override String get email => 'メールアドレス';
 }
 
 // Path: authentication.resetPasswordPage.buttons
-class _TranslationsAuthenticationResetPasswordPageButtonsJa
-    implements TranslationsAuthenticationResetPasswordPageButtonsEn {
-  _TranslationsAuthenticationResetPasswordPageButtonsJa._(this._root);
+class _TranslationsAuthenticationResetPasswordPageButtonsJa implements TranslationsAuthenticationResetPasswordPageButtonsEn {
+	_TranslationsAuthenticationResetPasswordPageButtonsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '送信';
+	// Translations
+	@override String get submit => '送信';
 }
 
 // Path: authentication.signUpPage.textFields
-class _TranslationsAuthenticationSignUpPageTextFieldsJa
-    implements TranslationsAuthenticationSignUpPageTextFieldsEn {
-  _TranslationsAuthenticationSignUpPageTextFieldsJa._(this._root);
+class _TranslationsAuthenticationSignUpPageTextFieldsJa implements TranslationsAuthenticationSignUpPageTextFieldsEn {
+	_TranslationsAuthenticationSignUpPageTextFieldsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => 'メールアドレス';
-  @override
-  String get password => 'パスワード';
+	// Translations
+	@override String get email => 'メールアドレス';
+	@override String get password => 'パスワード';
 }
 
 // Path: authentication.emailVerificationPage.buttons
-class _TranslationsAuthenticationEmailVerificationPageButtonsJa
-    implements TranslationsAuthenticationEmailVerificationPageButtonsEn {
-  _TranslationsAuthenticationEmailVerificationPageButtonsJa._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageButtonsJa implements TranslationsAuthenticationEmailVerificationPageButtonsEn {
+	_TranslationsAuthenticationEmailVerificationPageButtonsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get sendEmail => '確認メールを送信';
-  @override
-  String get resendEmail => '確認メールを再送信';
-  @override
-  String get toNext => '次へ';
-  @override
-  String get retypeEmail => 'メールアドレスの修正';
+	// Translations
+	@override String get sendEmail => '確認メールを送信';
+	@override String get resendEmail => '確認メールを再送信';
+	@override String get toNext => '次へ';
+	@override String get retypeEmail => 'メールアドレスの修正';
 }
 
 // Path: authentication.emailVerificationPage.snackBar
-class _TranslationsAuthenticationEmailVerificationPageSnackBarJa
-    implements TranslationsAuthenticationEmailVerificationPageSnackBarEn {
-  _TranslationsAuthenticationEmailVerificationPageSnackBarJa._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageSnackBarJa implements TranslationsAuthenticationEmailVerificationPageSnackBarEn {
+	_TranslationsAuthenticationEmailVerificationPageSnackBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get success => '送信が完了しました';
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa
-      error =
-      _TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa._(_root);
+	// Translations
+	@override String get success => '送信が完了しました';
+	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa error = _TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa._(_root);
 }
 
 // Path: authentication.registerProfilePage.buttons
-class _TranslationsAuthenticationRegisterProfilePageButtonsJa
-    implements TranslationsAuthenticationRegisterProfilePageButtonsEn {
-  _TranslationsAuthenticationRegisterProfilePageButtonsJa._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageButtonsJa implements TranslationsAuthenticationRegisterProfilePageButtonsEn {
+	_TranslationsAuthenticationRegisterProfilePageButtonsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '完了';
-  @override
-  String get skip => 'スキップ';
+	// Translations
+	@override String get submit => '完了';
+	@override String get skip => 'スキップ';
 }
 
 // Path: authentication.registerProfilePage.snackBar
-class _TranslationsAuthenticationRegisterProfilePageSnackBarJa
-    implements TranslationsAuthenticationRegisterProfilePageSnackBarEn {
-  _TranslationsAuthenticationRegisterProfilePageSnackBarJa._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageSnackBarJa implements TranslationsAuthenticationRegisterProfilePageSnackBarEn {
+	_TranslationsAuthenticationRegisterProfilePageSnackBarJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa
-      error =
-      _TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa._(_root);
+	// Translations
+	@override late final _TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa error = _TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa._(_root);
 }
 
 // Path: authentication.completeSendEmailPage.buttons
-class _TranslationsAuthenticationCompleteSendEmailPageButtonsJa
-    implements TranslationsAuthenticationCompleteSendEmailPageButtonsEn {
-  _TranslationsAuthenticationCompleteSendEmailPageButtonsJa._(this._root);
+class _TranslationsAuthenticationCompleteSendEmailPageButtonsJa implements TranslationsAuthenticationCompleteSendEmailPageButtonsEn {
+	_TranslationsAuthenticationCompleteSendEmailPageButtonsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get toSignIn => 'ログイン画面へ';
-  @override
-  String get resendEmail => '確認メールを再送信';
-  @override
-  String get changeEmail => 'メールアドレスの変更';
+	// Translations
+	@override String get toSignIn => 'ログイン画面へ';
+	@override String get resendEmail => '確認メールを再送信';
+	@override String get changeEmail => 'メールアドレスの変更';
 }
 
 // Path: authentication.firebaseAuth.error
-class _TranslationsAuthenticationFirebaseAuthErrorJa
-    implements TranslationsAuthenticationFirebaseAuthErrorEn {
-  _TranslationsAuthenticationFirebaseAuthErrorJa._(this._root);
+class _TranslationsAuthenticationFirebaseAuthErrorJa implements TranslationsAuthenticationFirebaseAuthErrorEn {
+	_TranslationsAuthenticationFirebaseAuthErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get networkRequestFailed => '通信環境がいい所で再度やり直してください';
-  @override
-  String get weakPassword => 'パスワードが短すぎます。6文字以上を入力してください';
-  @override
-  String get invalidEmail => 'メールアドレスの形式が正しくありません';
-  @override
-  String get userNotFound => 'アカウントが見つかりません';
-  @override
-  String get wrongPassword => 'パスワードが正しくありません';
-  @override
-  String get emailAlreadyInUse =>
-      'メールアドレスがすでに使用されています。ログインするか別のメールアドレスで作成してください';
-  @override
-  String get unexpected => 'エラーが発生しました。通信環境がいい所で再度やり直してください。';
+	// Translations
+	@override String get networkRequestFailed => '通信環境がいい所で再度やり直してください';
+	@override String get weakPassword => 'パスワードが短すぎます。6文字以上を入力してください';
+	@override String get invalidEmail => 'メールアドレスの形式が正しくありません';
+	@override String get userNotFound => 'アカウントが見つかりません';
+	@override String get wrongPassword => 'パスワードが正しくありません';
+	@override String get emailAlreadyInUse => 'メールアドレスがすでに使用されています。ログインするか別のメールアドレスで作成してください';
+	@override String get unexpected => 'エラーが発生しました。通信環境がいい所で再度やり直してください。';
 }
 
 // Path: myPage.accountStatus.dateTime
-class _TranslationsMyPageAccountStatusDateTimeJa
-    implements TranslationsMyPageAccountStatusDateTimeEn {
-  _TranslationsMyPageAccountStatusDateTimeJa._(this._root);
+class _TranslationsMyPageAccountStatusDateTimeJa implements TranslationsMyPageAccountStatusDateTimeEn {
+	_TranslationsMyPageAccountStatusDateTimeJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String registeredOn({required Object date}) => '${date}に登録';
-  @override
-  String get registeredOnFormat => 'yyyy年MM月dd日';
-  @override
-  String validUntil({required Object date}) => '${date}まで';
-  @override
-  String get validUntilFormat => 'yyyy年MM月dd日 HH時mm分';
+	// Translations
+	@override String registeredOn({required Object date}) => '${date}に登録';
+	@override String get registeredOnFormat => 'yyyy年MM月dd日';
+	@override String validUntil({required Object date}) => '${date}まで';
+	@override String get validUntilFormat => 'yyyy年MM月dd日 HH時mm分';
 }
 
 // Path: buddyChatPage.snackBar.error
-class _TranslationsBuddyChatPageSnackBarErrorJa
-    implements TranslationsBuddyChatPageSnackBarErrorEn {
-  _TranslationsBuddyChatPageSnackBarErrorJa._(this._root);
+class _TranslationsBuddyChatPageSnackBarErrorJa implements TranslationsBuddyChatPageSnackBarErrorEn {
+	_TranslationsBuddyChatPageSnackBarErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get failedRecieveMessage => '返信の受信に失敗しました。時間をおいて再度お試しください';
-  @override
-  String get failedCompleteCreatePlan => 'プランの作成に失敗しました。時間をおいて再度お試しください';
+	// Translations
+	@override String get failedRecieveMessage => '返信の受信に失敗しました。時間をおいて再度お試しください';
+	@override String get failedCompleteCreatePlan => 'プランの作成に失敗しました。時間をおいて再度お試しください';
 }
 
 // Path: createPlanPage.snackBar.error
-class _TranslationsCreatePlanPageSnackBarErrorJa
-    implements TranslationsCreatePlanPageSnackBarErrorEn {
-  _TranslationsCreatePlanPageSnackBarErrorJa._(this._root);
+class _TranslationsCreatePlanPageSnackBarErrorJa implements TranslationsCreatePlanPageSnackBarErrorEn {
+	_TranslationsCreatePlanPageSnackBarErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get foundUnSelectedField => '選択されていない項目があります 全ての項目を選択してください';
+	// Translations
+	@override String get foundUnSelectedField => '選択されていない項目があります 全ての項目を選択してください';
 }
 
 // Path: editProfilePage.snackBar.error
-class _TranslationsEditProfilePageSnackBarErrorJa
-    implements TranslationsEditProfilePageSnackBarErrorEn {
-  _TranslationsEditProfilePageSnackBarErrorJa._(this._root);
+class _TranslationsEditProfilePageSnackBarErrorJa implements TranslationsEditProfilePageSnackBarErrorEn {
+	_TranslationsEditProfilePageSnackBarErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get noChange => '変更がありません';
-  @override
-  String get failedToUpdate => '更新に失敗しました しばらくしてから再度お試しください';
-  @override
-  String get failedToPickImage => '画像の選択に失敗しました しばらくしてから再度お試しください';
+	// Translations
+	@override String get noChange => '変更がありません';
+	@override String get failedToUpdate => '更新に失敗しました しばらくしてから再度お試しください';
+	@override String get failedToPickImage => '画像の選択に失敗しました しばらくしてから再度お試しください';
 }
 
 // Path: billDetailsPage.pricingPlan.columns
-class _TranslationsBillDetailsPagePricingPlanColumnsJa
-    implements TranslationsBillDetailsPagePricingPlanColumnsEn {
-  _TranslationsBillDetailsPagePricingPlanColumnsJa._(this._root);
+class _TranslationsBillDetailsPagePricingPlanColumnsJa implements TranslationsBillDetailsPagePricingPlanColumnsEn {
+	_TranslationsBillDetailsPagePricingPlanColumnsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get standard => 'スタンダード';
-  @override
-  String get premium => 'プレミアム';
+	// Translations
+	@override String get standard => 'スタンダード';
+	@override String get premium => 'プレミアム';
 }
 
 // Path: billDetailsPage.pricingPlan.details
-class _TranslationsBillDetailsPagePricingPlanDetailsJa
-    implements TranslationsBillDetailsPagePricingPlanDetailsEn {
-  _TranslationsBillDetailsPagePricingPlanDetailsJa._(this._root);
+class _TranslationsBillDetailsPagePricingPlanDetailsJa implements TranslationsBillDetailsPagePricingPlanDetailsEn {
+	_TranslationsBillDetailsPagePricingPlanDetailsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get free => '無料 🎉';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa
-      premiumPrice =
-      _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa._(_root);
+	// Translations
+	@override String get free => '無料 🎉';
+	@override late final _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa premiumPrice = _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa._(_root);
 }
 
 // Path: billDetailsPage.features.rows
-class _TranslationsBillDetailsPageFeaturesRowsJa
-    implements TranslationsBillDetailsPageFeaturesRowsEn {
-  _TranslationsBillDetailsPageFeaturesRowsJa._(this._root);
+class _TranslationsBillDetailsPageFeaturesRowsJa implements TranslationsBillDetailsPageFeaturesRowsEn {
+	_TranslationsBillDetailsPageFeaturesRowsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get planCreationLimit => 'プランの作成可能回数';
-  @override
-  String get chatLimit => 'プラン作成中のチャット可能回数';
-  @override
-  String get timelineAccess => '全プラン一覧のタイムライン閲覧';
-  @override
-  String get adFree => '広告の非表示';
-  @override
-  String get exclusiveFeatures => 'プランの認証機能';
+	// Translations
+	@override String get planCreationLimit => 'プランの作成可能回数';
+	@override String get chatLimit => 'プラン作成中のチャット可能回数';
+	@override String get timelineAccess => '全プラン一覧のタイムライン閲覧';
+	@override String get adFree => '広告の非表示';
+	@override String get exclusiveFeatures => 'プランの認証機能';
 }
 
 // Path: billDetailsPage.features.columns
-class _TranslationsBillDetailsPageFeaturesColumnsJa
-    implements TranslationsBillDetailsPageFeaturesColumnsEn {
-  _TranslationsBillDetailsPageFeaturesColumnsJa._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsJa implements TranslationsBillDetailsPageFeaturesColumnsEn {
+	_TranslationsBillDetailsPageFeaturesColumnsJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsStandardJa standard =
-      _TranslationsBillDetailsPageFeaturesColumnsStandardJa._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsPremiumJa premium =
-      _TranslationsBillDetailsPageFeaturesColumnsPremiumJa._(_root);
+	// Translations
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsStandardJa standard = _TranslationsBillDetailsPageFeaturesColumnsStandardJa._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsPremiumJa premium = _TranslationsBillDetailsPageFeaturesColumnsPremiumJa._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions.oneDay
-class _TranslationsBillDetailsPagePricingOptionsOneDayJa
-    implements TranslationsBillDetailsPagePricingOptionsOneDayEn {
-  _TranslationsBillDetailsPagePricingOptionsOneDayJa._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsOneDayJa implements TranslationsBillDetailsPagePricingOptionsOneDayEn {
+	_TranslationsBillDetailsPagePricingOptionsOneDayJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '1日';
-  @override
-  String get discount => '';
-  @override
-  String get price => '300円';
+	// Translations
+	@override String get duration => '1日';
+	@override String get discount => '';
+	@override String get price => '300円';
 }
 
 // Path: billDetailsPage.pricingOptions.threeDays
-class _TranslationsBillDetailsPagePricingOptionsThreeDaysJa
-    implements TranslationsBillDetailsPagePricingOptionsThreeDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsThreeDaysJa._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsThreeDaysJa implements TranslationsBillDetailsPagePricingOptionsThreeDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsThreeDaysJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '3日';
-  @override
-  String get discount => '-5%';
-  @override
-  String get price => '890円';
+	// Translations
+	@override String get duration => '3日';
+	@override String get discount => '-5%';
+	@override String get price => '890円';
 }
 
 // Path: billDetailsPage.pricingOptions.fiveDays
-class _TranslationsBillDetailsPagePricingOptionsFiveDaysJa
-    implements TranslationsBillDetailsPagePricingOptionsFiveDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsFiveDaysJa._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsFiveDaysJa implements TranslationsBillDetailsPagePricingOptionsFiveDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsFiveDaysJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '5日';
-  @override
-  String get discount => '-7.5%';
-  @override
-  String get price => '1,387円';
+	// Translations
+	@override String get duration => '5日';
+	@override String get discount => '-7.5%';
+	@override String get price => '1,387円';
 }
 
 // Path: billDetailsPage.pricingOptions.sevenDays
-class _TranslationsBillDetailsPagePricingOptionsSevenDaysJa
-    implements TranslationsBillDetailsPagePricingOptionsSevenDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsSevenDaysJa._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsSevenDaysJa implements TranslationsBillDetailsPagePricingOptionsSevenDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsSevenDaysJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '7日';
-  @override
-  String get discount => '-10%';
-  @override
-  String get price => '2,070円';
+	// Translations
+	@override String get duration => '7日';
+	@override String get discount => '-10%';
+	@override String get price => '2,070円';
 }
 
 // Path: billDetailsPage.pricingOptions.lifetime
-class _TranslationsBillDetailsPagePricingOptionsLifetimeJa
-    implements TranslationsBillDetailsPagePricingOptionsLifetimeEn {
-  _TranslationsBillDetailsPagePricingOptionsLifetimeJa._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsLifetimeJa implements TranslationsBillDetailsPagePricingOptionsLifetimeEn {
+	_TranslationsBillDetailsPagePricingOptionsLifetimeJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '永年分';
-  @override
-  String get discount => '';
-  @override
-  String get price => '25,800円';
+	// Translations
+	@override String get duration => '永年分';
+	@override String get discount => '';
+	@override String get price => '25,800円';
 }
 
 // Path: planDetailsPage.snackBar.error
-class _TranslationsPlanDetailsPageSnackBarErrorJa
-    implements TranslationsPlanDetailsPageSnackBarErrorEn {
-  _TranslationsPlanDetailsPageSnackBarErrorJa._(this._root);
+class _TranslationsPlanDetailsPageSnackBarErrorJa implements TranslationsPlanDetailsPageSnackBarErrorEn {
+	_TranslationsPlanDetailsPageSnackBarErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get failedToUpdateBookmark => 'ブックマークの更新に失敗しました しばらくしてから再度お試しください';
+	// Translations
+	@override String get failedToUpdateBookmark => 'ブックマークの更新に失敗しました しばらくしてから再度お試しください';
 }
 
 // Path: authentication.emailVerificationPage.snackBar.error
-class _TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa
-    implements TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn {
-  _TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa implements TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn {
+	_TranslationsAuthenticationEmailVerificationPageSnackBarErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get unexpected => 'エラーが発生しました。時間をおいて再度お試しください';
+	// Translations
+	@override String get unexpected => 'エラーが発生しました。時間をおいて再度お試しください';
 }
 
 // Path: authentication.registerProfilePage.snackBar.error
-class _TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa
-    implements TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn {
-  _TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa implements TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn {
+	_TranslationsAuthenticationRegisterProfilePageSnackBarErrorJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submitIfAllEmpty => '入力してください';
-  @override
-  String get unexpected => 'エラーが発生しました。時間をおいて再度お試しください';
+	// Translations
+	@override String get submitIfAllEmpty => '入力してください';
+	@override String get unexpected => 'エラーが発生しました。時間をおいて再度お試しください';
 }
 
 // Path: billDetailsPage.pricingPlan.details.premiumPrice
-class _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa
-    implements TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn {
-  _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa._(this._root);
+class _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa implements TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn {
+	_TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get days => '日数分購入';
-  @override
-  String get daily => '・1日 300円';
-  @override
-  String get threeDays => '・3日 855円';
-  @override
-  String get fiveDays => '・5日 1,480円';
-  @override
-  String get sevenDays => '・7日 2,070円';
-  @override
-  String get or => 'または';
-  @override
-  String get lifetime => '永年分';
-  @override
-  String get lifetimePrice => '25,800円';
+	// Translations
+	@override String get days => '日数分購入';
+	@override String get daily => '・1日 300円';
+	@override String get threeDays => '・3日 855円';
+	@override String get fiveDays => '・5日 1,480円';
+	@override String get sevenDays => '・7日 2,070円';
+	@override String get or => 'または';
+	@override String get lifetime => '永年分';
+	@override String get lifetimePrice => '25,800円';
 }
 
 // Path: billDetailsPage.features.columns.standard
-class _TranslationsBillDetailsPageFeaturesColumnsStandardJa
-    implements TranslationsBillDetailsPageFeaturesColumnsStandardEn {
-  _TranslationsBillDetailsPageFeaturesColumnsStandardJa._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsStandardJa implements TranslationsBillDetailsPageFeaturesColumnsStandardEn {
+	_TranslationsBillDetailsPageFeaturesColumnsStandardJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get label => 'スタンダード';
-  @override
-  String get planCreationLimit => '2回';
-  @override
-  String get chatLimit => '3回';
+	// Translations
+	@override String get label => 'スタンダード';
+	@override String get planCreationLimit => '2回';
+	@override String get chatLimit => '3回';
 }
 
 // Path: billDetailsPage.features.columns.premium
-class _TranslationsBillDetailsPageFeaturesColumnsPremiumJa
-    implements TranslationsBillDetailsPageFeaturesColumnsPremiumEn {
-  _TranslationsBillDetailsPageFeaturesColumnsPremiumJa._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsPremiumJa implements TranslationsBillDetailsPageFeaturesColumnsPremiumEn {
+	_TranslationsBillDetailsPageFeaturesColumnsPremiumJa._(this._root);
 
-  final TranslationsJa _root; // ignore: unused_field
+	final TranslationsJa _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get label => 'プレミアム';
-  @override
-  String get planCreationLimit => '無制限';
-  @override
-  String get chatLimit => '無制限';
+	// Translations
+	@override String get label => 'プレミアム';
+	@override String get planCreationLimit => '無制限';
+	@override String get chatLimit => '無制限';
 }
 
 /// Flat map(s) containing all translations.
 /// Only for edge cases! For simple maps, use the map function of this library.
 extension on TranslationsJa {
-  dynamic _flatMapFunction(String path) {
-    switch (path) {
-      case 'navigationBar.items.home':
-        return 'ホーム';
-      case 'navigationBar.items.myPlan':
-        return 'マイプラン';
-      case 'navigationBar.items.myPage':
-        return 'マイページ';
-      case 'homePage.popularPlans.title':
-        return '人気のプラン';
-      case 'homePage.popularTopics.title':
-        return '人気のトピック';
-      case 'homePage.popularTopics.numberOfTopics':
-        return ({required Object number}) => '${number}件~';
-      case 'homePage.recentPlans.title':
-        return '最近作成したプラン';
-      case 'accountPage.title':
-        return 'アカウント';
-      case 'accountPage.items.signOut':
-        return 'ログアウト';
-      case 'accountPage.items.linkedWithGoogle':
-        return 'Googleで連携';
-      case 'accountPage.items.linkedWithApple':
-        return 'Appleで連携';
-      case 'accountPage.items.alreadyLinkedGoogle':
-        return 'Google連携済み';
-      case 'accountPage.items.alreadyLinkedApple':
-        return 'Appleで連携済み';
-      case 'accountPage.snackBar.signOut':
-        return 'ログアウトしました。';
-      case 'accountPage.snackBar.signOutFailure':
-        return 'ログアウト時にエラーが発生しました。';
-      case 'accountPage.snackBar.successfulLinkage':
-        return 'アカウント連携に成功しました。';
-      case 'accountPage.snackBar.linkageFailure':
-        return 'アカウント連携に失敗しました。';
-      case 'accountPage.snackBar.providerAlreadyLinked':
-        return 'このアカウントはすでに連携済みです。';
-      case 'accountPage.snackBar.accountDeactivation':
-        return 'アカウントの連携を解除しました。';
-      case 'accountPage.snackBar.invalidCredential':
-        return '再度ログインをやり直してください。';
-      case 'accountPage.snackBar.linkageCancelled':
-        return 'アカウントの連携をキャンセルしました。';
-      case 'accountPage.snackBar.unlinkageFailure':
-        return 'アカウントの連携解除に失敗しました。';
-      case 'accountPage.snackBar.operationNotAllowed':
-        return 'プロパイダーが無効です。開発者にお問い合わせください。';
-      case 'accountPage.snackBar.unknownError':
-        return '不明なエラーが発生しました。';
-      case 'accountPage.diaLog.yes':
-        return 'はい';
-      case 'accountPage.diaLog.no':
-        return 'いいえ';
-      case 'accountPage.diaLog.title':
-        return 'アカウント連携解除の確認';
-      case 'accountPage.diaLog.googleText':
-        return '現在のアカウントとGoogleアカウントの連携を解除しますか？';
-      case 'accountPage.diaLog.appleText':
-        return '現在のアカウントとAppleアカウントの連携を解除しますか？';
-      case 'authentication.signInPage.title':
-        return 'ログイン';
-      case 'authentication.signInPage.optionText':
-        return ' または ';
-      case 'authentication.signInPage.textFields.email':
-        return 'メールアドレス';
-      case 'authentication.signInPage.textFields.password':
-        return 'パスワード';
-      case 'authentication.signInPage.buttons.signIn':
-        return 'ログイン';
-      case 'authentication.signInPage.buttons.signUp':
-        return '新規登録';
-      case 'authentication.signInPage.buttons.resetPassword':
-        return 'パスワードを忘れた方はこちら';
-      case 'authentication.signInPage.buttons.appleSignIn':
-        return 'Appleでログイン';
-      case 'authentication.signInPage.buttons.googleSignIn':
-        return 'Googleでログイン';
-      case 'authentication.signInPage.buttons.signInAfter':
-        return '後で登録';
-      case 'authentication.resetPasswordPage.title':
-        return 'パスワードのリセット';
-      case 'authentication.resetPasswordPage.description':
-        return '入力されたメールアドレスにパスワードリセットのメールを送信します';
-      case 'authentication.resetPasswordPage.textFields.email':
-        return 'メールアドレス';
-      case 'authentication.resetPasswordPage.buttons.submit':
-        return '送信';
-      case 'authentication.signUpPage.title':
-        return '新規登録';
-      case 'authentication.signUpPage.textFields.email':
-        return 'メールアドレス';
-      case 'authentication.signUpPage.textFields.password':
-        return 'パスワード';
-      case 'authentication.signUpPage.button':
-        return '新規登録';
-      case 'authentication.emailVerificationPage.title':
-        return 'メールアドレスの確認';
-      case 'authentication.emailVerificationPage.descriptionForDestination':
-        return ({required Object email}) => '入力された${email}に確認メールを送信します';
-      case 'authentication.emailVerificationPage.descriptionForCoolDown':
-        return '確認メールの再送信は、60秒ごとに1回可能です。';
-      case 'authentication.emailVerificationPage.buttons.sendEmail':
-        return '確認メールを送信';
-      case 'authentication.emailVerificationPage.buttons.resendEmail':
-        return '確認メールを再送信';
-      case 'authentication.emailVerificationPage.buttons.toNext':
-        return '次へ';
-      case 'authentication.emailVerificationPage.buttons.retypeEmail':
-        return 'メールアドレスの修正';
-      case 'authentication.emailVerificationPage.snackBar.success':
-        return '送信が完了しました';
-      case 'authentication.emailVerificationPage.snackBar.error.unexpected':
-        return 'エラーが発生しました。時間をおいて再度お試しください';
-      case 'authentication.registerProfilePage.title':
-        return 'プロフィールの登録';
-      case 'authentication.registerProfilePage.textFields':
-        return '名前';
-      case 'authentication.registerProfilePage.buttons.submit':
-        return '完了';
-      case 'authentication.registerProfilePage.buttons.skip':
-        return 'スキップ';
-      case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty':
-        return '入力してください';
-      case 'authentication.registerProfilePage.snackBar.error.unexpected':
-        return 'エラーが発生しました。時間をおいて再度お試しください';
-      case 'authentication.completeSendEmailPage.title':
-        return '送信完了';
-      case 'authentication.completeSendEmailPage.description':
-        return ({required Object email}) =>
-            'パスワードリセット用のメールが${email}に送信されました \n リセット後にログイン画面からログインしてください';
-      case 'authentication.completeSendEmailPage.successResendEmail':
-        return '確認メールを再送信しました';
-      case 'authentication.completeSendEmailPage.buttons.toSignIn':
-        return 'ログイン画面へ';
-      case 'authentication.completeSendEmailPage.buttons.resendEmail':
-        return '確認メールを再送信';
-      case 'authentication.completeSendEmailPage.buttons.changeEmail':
-        return 'メールアドレスの変更';
-      case 'authentication.firebaseAuth.error.networkRequestFailed':
-        return '通信環境がいい所で再度やり直してください';
-      case 'authentication.firebaseAuth.error.weakPassword':
-        return 'パスワードが短すぎます。6文字以上を入力してください';
-      case 'authentication.firebaseAuth.error.invalidEmail':
-        return 'メールアドレスの形式が正しくありません';
-      case 'authentication.firebaseAuth.error.userNotFound':
-        return 'アカウントが見つかりません';
-      case 'authentication.firebaseAuth.error.wrongPassword':
-        return 'パスワードが正しくありません';
-      case 'authentication.firebaseAuth.error.emailAlreadyInUse':
-        return 'メールアドレスがすでに使用されています。ログインするか別のメールアドレスで作成してください';
-      case 'authentication.firebaseAuth.error.unexpected':
-        return 'エラーが発生しました。通信環境がいい所で再度やり直してください。';
-      case 'validation.emailRequired':
-        return 'メールアドレスを入力してください';
-      case 'validation.emailInvalid':
-        return 'メールアドレスの形式が正しくありません';
-      case 'validation.passwordRequired':
-        return 'パスワードを入力してください';
-      case 'validation.passwordShort':
-        return 'パスワードは少なくとも8文字以上である必要があります';
-      case 'validation.passwordWeak':
-        return 'パスワードは半角英数字を組み合わせてください';
-      case 'validation.passwordMatch':
-        return 'パスワードが一致しません';
-      case 'validation.informationRequired':
-        return '情報を入力してください';
-      case 'validation.urlInvalid':
-        return 'URLの形式が正しくありません';
-      case 'myPage.unregisteredUserName':
-        return '未登録';
-      case 'myPage.editProfile':
-        return 'プロフィール編集';
-      case 'myPage.premiumPlan':
-        return 'プレミアムプラン';
-      case 'myPage.details':
-        return '詳細';
-      case 'myPage.settings':
-        return '設定';
-      case 'myPage.account':
-        return 'アカウント';
-      case 'myPage.language':
-        return '言語';
-      case 'myPage.theme':
-        return 'テーマ';
-      case 'myPage.termsOfUsePrivacyPolicy':
-        return '利用規約・プライバシーポリシー';
-      case 'myPage.aboutThisApp':
-        return 'このアプリについて';
-      case 'myPage.aboutTheDeveloper':
-        return '開発者について';
-      case 'myPage.accountStatus.dateTime.registeredOn':
-        return ({required Object date}) => '${date}に登録';
-      case 'myPage.accountStatus.dateTime.registeredOnFormat':
-        return 'yyyy年MM月dd日';
-      case 'myPage.accountStatus.dateTime.validUntil':
-        return ({required Object date}) => '${date}まで';
-      case 'myPage.accountStatus.dateTime.validUntilFormat':
-        return 'yyyy年MM月dd日 HH時mm分';
-      case 'myPage.accountStatus.premium':
-        return 'プレミアム会員';
-      case 'myPage.accountStatus.standard':
-        return 'スタンダード会員';
-      case 'changeLanguagePage.title':
-        return '言語';
-      case 'changeLanguagePage.items.japanese':
-        return '日本語';
-      case 'changeLanguagePage.items.english':
-        return '英語';
-      case 'changeLanguagePage.items.simplifiedChinese':
-        return '中国語（簡体字）';
-      case 'changeLanguagePage.items.traditionalChinese':
-        return '中国語（繁体字）';
-      case 'changeThemePage.title':
-        return 'テーマ';
-      case 'changeThemePage.items.system':
-        return 'システム';
-      case 'changeThemePage.items.light':
-        return 'ライト';
-      case 'changeThemePage.items.dark':
-        return 'ダーク';
-      case 'myPlanPage.title':
-        return 'マイプラン';
-      case 'myPlanPage.tabs.createdPlans':
-        return '作成したプラン';
-      case 'myPlanPage.tabs.bookmark':
-        return 'ブックマーク';
-      case 'myPlanPage.bookmarkItems.nondata':
-        return 'ブックマークしているプランはありません。';
-      case 'myPlanPage.bookmarkItems.reloading':
-        return '再読み込み';
-      case 'myPlanPage.createdPlansItems.nondata':
-        return 'プランを作成してみよう!';
-      case 'myPlanPage.createdPlansItems.createaplan':
-        return 'プランを作成する';
-      case 'myPlanPage.error.displayError':
-        return 'プラン表示時に問題が発生しました。';
-      case 'myPlanPage.error.failedGetId':
-        return 'プランIDの取得に失敗しました。';
-      case 'myPlanPage.error.failedGetPlanData':
-        return 'プランデータ取得時に問題が発生しました。';
-      case 'myPlanPage.error.failedUnBookmark':
-        return 'ブックマーク解除時に問題が発生しました。';
-      case 'buddyChatPage.title':
-        return 'Buddyの提案';
-      case 'buddyChatPage.possibleChatCount':
-        return ({required Object possibleChatCount}) =>
-            'メッセージは残り${possibleChatCount}回送信可能です';
-      case 'buddyChatPage.textFields.message':
-        return 'メッセージを入力';
-      case 'buddyChatPage.buttons.send':
-        return '完了';
-      case 'buddyChatPage.placeCard.openingHours':
-        return '営業時間';
-      case 'buddyChatPage.placeCard.averageAmount':
-        return '平均予算';
-      case 'buddyChatPage.placeCard.website':
-        return 'Webサイト';
-      case 'buddyChatPage.snackBar.error.failedRecieveMessage':
-        return '返信の受信に失敗しました。時間をおいて再度お試しください';
-      case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan':
-        return 'プランの作成に失敗しました。時間をおいて再度お試しください';
-      case 'popularTopics.sectionName':
-        return '人気のトピック';
-      case 'createPlanPage.title':
-        return 'プランの作成';
-      case 'createPlanPage.label.location':
-        return '目的地';
-      case 'createPlanPage.label.scheduleStart':
-        return '開始日';
-      case 'createPlanPage.label.scheduleEnd':
-        return '終了日';
-      case 'createPlanPage.label.numberOfPeople':
-        return '人数';
-      case 'createPlanPage.label.transport':
-        return '交通手段';
-      case 'createPlanPage.label.category':
-        return 'カテゴリ';
-      case 'createPlanPage.label.topics':
-        return '旅のトピック';
-      case 'createPlanPage.hintText.location':
-        return '渋谷';
-      case 'createPlanPage.modal.title':
-        return '日付を選択';
-      case 'createPlanPage.numberOfPeopleOptions.0':
-        return '1人';
-      case 'createPlanPage.numberOfPeopleOptions.1':
-        return '2人';
-      case 'createPlanPage.numberOfPeopleOptions.2':
-        return '3人';
-      case 'createPlanPage.numberOfPeopleOptions.3':
-        return '4人';
-      case 'createPlanPage.numberOfPeopleOptions.4':
-        return '5人';
-      case 'createPlanPage.numberOfPeopleOptions.5':
-        return '6人以上';
-      case 'createPlanPage.transportOptions.0':
-        return '電車';
-      case 'createPlanPage.transportOptions.1':
-        return '徒歩';
-      case 'createPlanPage.transportOptions.2':
-        return '車';
-      case 'createPlanPage.transportOptions.3':
-        return 'バス';
-      case 'createPlanPage.categoryOptions.0':
-        return '子連れ向け';
-      case 'createPlanPage.categoryOptions.1':
-        return '大人向け';
-      case 'createPlanPage.categoryOptions.2':
-        return 'エンタメ';
-      case 'createPlanPage.categoryOptions.3':
-        return 'アクティビティ';
-      case 'createPlanPage.categoryOptions.4':
-        return '歴史';
-      case 'createPlanPage.defaultTopics.0':
-        return 'グルメ';
-      case 'createPlanPage.defaultTopics.1':
-        return 'ショッピング';
-      case 'createPlanPage.defaultTopics.2':
-        return 'アクティビティ';
-      case 'createPlanPage.defaultTopics.3':
-        return '映画';
-      case 'createPlanPage.submitButton':
-        return 'プランをAIに伝える';
-      case 'createPlanPage.snackBar.error.foundUnSelectedField':
-        return '選択されていない項目があります 全ての項目を選択してください';
-      case 'editProfilePage.title':
-        return '編集';
-      case 'editProfilePage.textFields.name':
-        return '名前';
-      case 'editProfilePage.buttons.submit':
-        return '保存';
-      case 'editProfilePage.snackBar.success':
-        return '更新しました';
-      case 'editProfilePage.snackBar.error.noChange':
-        return '変更がありません';
-      case 'editProfilePage.snackBar.error.failedToUpdate':
-        return '更新に失敗しました しばらくしてから再度お試しください';
-      case 'editProfilePage.snackBar.error.failedToPickImage':
-        return '画像の選択に失敗しました しばらくしてから再度お試しください';
-      case 'confirmDialog.answers.yes':
-        return 'はい';
-      case 'confirmDialog.answers.no':
-        return 'いいえ';
-      case 'confirmDialog.popPage.title':
-        return '前の画面に戻りますか？';
-      case 'confirmDialog.popPage.description':
-        return '現在の内容は保存されません';
-      case 'confirmDialog.completeCreatePlan.title':
-        return 'プランを確定しますか？';
-      case 'confirmDialog.completeCreatePlan.description':
-        return '一番最後のメッセージに含まれるプランが保存されます';
-      case 'prompt.planProposalMessage':
-        return 'こんなプランを考えてみました！いかがですか？';
-      case 'billDetailsPage.title':
-        return 'プレミアムプラン';
-      case 'billDetailsPage.description':
-        return 'プレミアムプランに加入することで、より快適に渋谷観光をお楽しみいただけます。';
-      case 'billDetailsPage.pricingPlan.title':
-        return '料金プラン';
-      case 'billDetailsPage.pricingPlan.columns.standard':
-        return 'スタンダード';
-      case 'billDetailsPage.pricingPlan.columns.premium':
-        return 'プレミアム';
-      case 'billDetailsPage.pricingPlan.details.free':
-        return '無料 🎉';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.days':
-        return '日数分購入';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.daily':
-        return '・1日 300円';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays':
-        return '・3日 855円';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays':
-        return '・5日 1,480円';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays':
-        return '・7日 2,070円';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.or':
-        return 'または';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime':
-        return '永年分';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice':
-        return '25,800円';
-      case 'billDetailsPage.features.title':
-        return 'グレードごとの機能';
-      case 'billDetailsPage.features.rows.planCreationLimit':
-        return 'プランの作成可能回数';
-      case 'billDetailsPage.features.rows.chatLimit':
-        return 'プラン作成中のチャット可能回数';
-      case 'billDetailsPage.features.rows.timelineAccess':
-        return '全プラン一覧のタイムライン閲覧';
-      case 'billDetailsPage.features.rows.adFree':
-        return '広告の非表示';
-      case 'billDetailsPage.features.rows.exclusiveFeatures':
-        return 'プランの認証機能';
-      case 'billDetailsPage.features.columns.standard.label':
-        return 'スタンダード';
-      case 'billDetailsPage.features.columns.standard.planCreationLimit':
-        return '2回';
-      case 'billDetailsPage.features.columns.standard.chatLimit':
-        return '3回';
-      case 'billDetailsPage.features.columns.premium.label':
-        return 'プレミアム';
-      case 'billDetailsPage.features.columns.premium.planCreationLimit':
-        return '無制限';
-      case 'billDetailsPage.features.columns.premium.chatLimit':
-        return '無制限';
-      case 'billDetailsPage.pricingOptions.oneDay.duration':
-        return '1日';
-      case 'billDetailsPage.pricingOptions.oneDay.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.oneDay.price':
-        return '300円';
-      case 'billDetailsPage.pricingOptions.threeDays.duration':
-        return '3日';
-      case 'billDetailsPage.pricingOptions.threeDays.discount':
-        return '-5%';
-      case 'billDetailsPage.pricingOptions.threeDays.price':
-        return '890円';
-      case 'billDetailsPage.pricingOptions.fiveDays.duration':
-        return '5日';
-      case 'billDetailsPage.pricingOptions.fiveDays.discount':
-        return '-7.5%';
-      case 'billDetailsPage.pricingOptions.fiveDays.price':
-        return '1,387円';
-      case 'billDetailsPage.pricingOptions.sevenDays.duration':
-        return '7日';
-      case 'billDetailsPage.pricingOptions.sevenDays.discount':
-        return '-10%';
-      case 'billDetailsPage.pricingOptions.sevenDays.price':
-        return '2,070円';
-      case 'billDetailsPage.pricingOptions.lifetime.duration':
-        return '永年分';
-      case 'billDetailsPage.pricingOptions.lifetime.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.lifetime.price':
-        return '25,800円';
-      case 'billDetailsPage.upgradeButton':
-        return 'プレミアムにアップグレード';
-      case 'planDetailsPage.dateTime.createOn':
-        return ({required Object date}) => '${date}に作られたプラン';
-      case 'planDetailsPage.dateTime.dateFormat':
-        return 'yyyy年MM月dd日';
-      case 'planDetailsPage.item.viewOnMap':
-        return '地図で見る';
-      case 'planDetailsPage.snackBar.error.failedToUpdateBookmark':
-        return 'ブックマークの更新に失敗しました しばらくしてから再度お試しください';
-      case 'locales.en':
-        return '英語';
-      case 'locales.ja':
-        return '日本語';
-      case 'locales.zh':
-        return '中国語';
-      case 'errorPage.title':
-        return 'エラーが発生しました...';
-      case 'errorPage.message':
-        return '通信環境を確認し、もう一度お試しください';
-      case 'errorPage.retryButton':
-        return 'もう一度読み込む';
-      case 'mapPage.title':
-        return 'マップ';
-      default:
-        return null;
-    }
-  }
+	dynamic _flatMapFunction(String path) {
+		switch (path) {
+			case 'navigationBar.items.home': return 'ホーム';
+			case 'navigationBar.items.myPlan': return 'マイプラン';
+			case 'navigationBar.items.myPage': return 'マイページ';
+			case 'homePage.popularPlans.title': return '人気のプラン';
+			case 'homePage.popularTopics.title': return '人気のトピック';
+			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number}件~';
+			case 'homePage.recentPlans.title': return '最近作成したプラン';
+			case 'accountPage.title': return 'アカウント';
+			case 'accountPage.items.signOut': return 'ログアウト';
+			case 'accountPage.items.linkedWithGoogle': return 'Googleで連携';
+			case 'accountPage.items.linkedWithApple': return 'Appleで連携';
+			case 'accountPage.items.alreadyLinkedGoogle': return 'Google連携済み';
+			case 'accountPage.items.alreadyLinkedApple': return 'Appleで連携済み';
+			case 'accountPage.snackBar.signOut': return 'ログアウトしました。';
+			case 'accountPage.snackBar.signOutFailure': return 'ログアウト時にエラーが発生しました。';
+			case 'accountPage.snackBar.successfulLinkage': return 'アカウント連携に成功しました。';
+			case 'accountPage.snackBar.linkageFailure': return 'アカウント連携に失敗しました。';
+			case 'accountPage.snackBar.providerAlreadyLinked': return 'このアカウントはすでに連携済みです。';
+			case 'accountPage.snackBar.accountDeactivation': return 'アカウントの連携を解除しました。';
+			case 'accountPage.snackBar.invalidCredential': return '再度ログインをやり直してください。';
+			case 'accountPage.snackBar.linkageCancelled': return 'アカウントの連携をキャンセルしました。';
+			case 'accountPage.snackBar.unlinkageFailure': return 'アカウントの連携解除に失敗しました。';
+			case 'accountPage.snackBar.operationNotAllowed': return 'プロパイダーが無効です。開発者にお問い合わせください。';
+			case 'accountPage.snackBar.unknownError': return '不明なエラーが発生しました。';
+			case 'accountPage.diaLog.yes': return 'はい';
+			case 'accountPage.diaLog.no': return 'いいえ';
+			case 'accountPage.diaLog.title': return 'アカウント連携解除の確認';
+			case 'accountPage.diaLog.googleText': return '現在のアカウントとGoogleアカウントの連携を解除しますか？';
+			case 'accountPage.diaLog.appleText': return '現在のアカウントとAppleアカウントの連携を解除しますか？';
+			case 'authentication.signInPage.title': return 'ログイン';
+			case 'authentication.signInPage.optionText': return ' または ';
+			case 'authentication.signInPage.textFields.email': return 'メールアドレス';
+			case 'authentication.signInPage.textFields.password': return 'パスワード';
+			case 'authentication.signInPage.buttons.signIn': return 'ログイン';
+			case 'authentication.signInPage.buttons.signUp': return '新規登録';
+			case 'authentication.signInPage.buttons.resetPassword': return 'パスワードを忘れた方はこちら';
+			case 'authentication.signInPage.buttons.appleSignIn': return 'Appleでログイン';
+			case 'authentication.signInPage.buttons.googleSignIn': return 'Googleでログイン';
+			case 'authentication.signInPage.buttons.signInAfter': return '後で登録';
+			case 'authentication.resetPasswordPage.title': return 'パスワードのリセット';
+			case 'authentication.resetPasswordPage.description': return '入力されたメールアドレスにパスワードリセットのメールを送信します';
+			case 'authentication.resetPasswordPage.textFields.email': return 'メールアドレス';
+			case 'authentication.resetPasswordPage.buttons.submit': return '送信';
+			case 'authentication.signUpPage.title': return '新規登録';
+			case 'authentication.signUpPage.textFields.email': return 'メールアドレス';
+			case 'authentication.signUpPage.textFields.password': return 'パスワード';
+			case 'authentication.signUpPage.button': return '新規登録';
+			case 'authentication.emailVerificationPage.title': return 'メールアドレスの確認';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '入力された${email}に確認メールを送信します';
+			case 'authentication.emailVerificationPage.descriptionForCoolDown': return '確認メールの再送信は、60秒ごとに1回可能です。';
+			case 'authentication.emailVerificationPage.buttons.sendEmail': return '確認メールを送信';
+			case 'authentication.emailVerificationPage.buttons.resendEmail': return '確認メールを再送信';
+			case 'authentication.emailVerificationPage.buttons.toNext': return '次へ';
+			case 'authentication.emailVerificationPage.buttons.retypeEmail': return 'メールアドレスの修正';
+			case 'authentication.emailVerificationPage.snackBar.success': return '送信が完了しました';
+			case 'authentication.emailVerificationPage.snackBar.error.unexpected': return 'エラーが発生しました。時間をおいて再度お試しください';
+			case 'authentication.registerProfilePage.title': return 'プロフィールの登録';
+			case 'authentication.registerProfilePage.textFields': return '名前';
+			case 'authentication.registerProfilePage.buttons.submit': return '完了';
+			case 'authentication.registerProfilePage.buttons.skip': return 'スキップ';
+			case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty': return '入力してください';
+			case 'authentication.registerProfilePage.snackBar.error.unexpected': return 'エラーが発生しました。時間をおいて再度お試しください';
+			case 'authentication.completeSendEmailPage.title': return '送信完了';
+			case 'authentication.completeSendEmailPage.description': return ({required Object email}) => 'パスワードリセット用のメールが${email}に送信されました \n リセット後にログイン画面からログインしてください';
+			case 'authentication.completeSendEmailPage.successResendEmail': return '確認メールを再送信しました';
+			case 'authentication.completeSendEmailPage.buttons.toSignIn': return 'ログイン画面へ';
+			case 'authentication.completeSendEmailPage.buttons.resendEmail': return '確認メールを再送信';
+			case 'authentication.completeSendEmailPage.buttons.changeEmail': return 'メールアドレスの変更';
+			case 'authentication.firebaseAuth.error.networkRequestFailed': return '通信環境がいい所で再度やり直してください';
+			case 'authentication.firebaseAuth.error.weakPassword': return 'パスワードが短すぎます。6文字以上を入力してください';
+			case 'authentication.firebaseAuth.error.invalidEmail': return 'メールアドレスの形式が正しくありません';
+			case 'authentication.firebaseAuth.error.userNotFound': return 'アカウントが見つかりません';
+			case 'authentication.firebaseAuth.error.wrongPassword': return 'パスワードが正しくありません';
+			case 'authentication.firebaseAuth.error.emailAlreadyInUse': return 'メールアドレスがすでに使用されています。ログインするか別のメールアドレスで作成してください';
+			case 'authentication.firebaseAuth.error.unexpected': return 'エラーが発生しました。通信環境がいい所で再度やり直してください。';
+			case 'validation.emailRequired': return 'メールアドレスを入力してください';
+			case 'validation.emailInvalid': return 'メールアドレスの形式が正しくありません';
+			case 'validation.passwordRequired': return 'パスワードを入力してください';
+			case 'validation.passwordShort': return 'パスワードは少なくとも8文字以上である必要があります';
+			case 'validation.passwordWeak': return 'パスワードは半角英数字を組み合わせてください';
+			case 'validation.passwordMatch': return 'パスワードが一致しません';
+			case 'validation.informationRequired': return '情報を入力してください';
+			case 'validation.urlInvalid': return 'URLの形式が正しくありません';
+			case 'validation.userNameRequired': return 'ユーザーネームを入力してください';
+			case 'validation.userNameMaxLength': return 'ユーザーネームは8文字以内である必要があります';
+			case 'myPage.unregisteredUserName': return '未登録';
+			case 'myPage.editProfile': return 'プロフィール編集';
+			case 'myPage.premiumPlan': return 'プレミアムプラン';
+			case 'myPage.details': return '詳細';
+			case 'myPage.settings': return '設定';
+			case 'myPage.account': return 'アカウント';
+			case 'myPage.language': return '言語';
+			case 'myPage.theme': return 'テーマ';
+			case 'myPage.termsOfUsePrivacyPolicy': return '利用規約・プライバシーポリシー';
+			case 'myPage.aboutThisApp': return 'このアプリについて';
+			case 'myPage.aboutTheDeveloper': return '開発者について';
+			case 'myPage.accountStatus.dateTime.registeredOn': return ({required Object date}) => '${date}に登録';
+			case 'myPage.accountStatus.dateTime.registeredOnFormat': return 'yyyy年MM月dd日';
+			case 'myPage.accountStatus.dateTime.validUntil': return ({required Object date}) => '${date}まで';
+			case 'myPage.accountStatus.dateTime.validUntilFormat': return 'yyyy年MM月dd日 HH時mm分';
+			case 'myPage.accountStatus.premium': return 'プレミアム会員';
+			case 'myPage.accountStatus.standard': return 'スタンダード会員';
+			case 'changeLanguagePage.title': return '言語';
+			case 'changeLanguagePage.items.japanese': return '日本語';
+			case 'changeLanguagePage.items.english': return '英語';
+			case 'changeLanguagePage.items.simplifiedChinese': return '中国語（簡体字）';
+			case 'changeLanguagePage.items.traditionalChinese': return '中国語（繁体字）';
+			case 'changeThemePage.title': return 'テーマ';
+			case 'changeThemePage.items.system': return 'システム';
+			case 'changeThemePage.items.light': return 'ライト';
+			case 'changeThemePage.items.dark': return 'ダーク';
+			case 'myPlanPage.title': return 'マイプラン';
+			case 'myPlanPage.tabs.createdPlans': return '作成したプラン';
+			case 'myPlanPage.tabs.bookmark': return 'ブックマーク';
+			case 'myPlanPage.bookmarkItems.nondata': return 'ブックマークしているプランはありません。';
+			case 'myPlanPage.bookmarkItems.reloading': return '再読み込み';
+			case 'myPlanPage.createdPlansItems.nondata': return 'プランを作成してみよう!';
+			case 'myPlanPage.createdPlansItems.createaplan': return 'プランを作成する';
+			case 'myPlanPage.error.displayError': return 'プラン表示時に問題が発生しました。';
+			case 'myPlanPage.error.failedGetId': return 'プランIDの取得に失敗しました。';
+			case 'myPlanPage.error.failedGetPlanData': return 'プランデータ取得時に問題が発生しました。';
+			case 'myPlanPage.error.failedUnBookmark': return 'ブックマーク解除時に問題が発生しました。';
+			case 'buddyChatPage.title': return 'Buddyの提案';
+			case 'buddyChatPage.possibleChatCount': return ({required Object possibleChatCount}) => 'メッセージは残り${possibleChatCount}回送信可能です';
+			case 'buddyChatPage.textFields.message': return 'メッセージを入力';
+			case 'buddyChatPage.buttons.send': return '完了';
+			case 'buddyChatPage.placeCard.openingHours': return '営業時間';
+			case 'buddyChatPage.placeCard.averageAmount': return '平均予算';
+			case 'buddyChatPage.placeCard.website': return 'Webサイト';
+			case 'buddyChatPage.snackBar.error.failedRecieveMessage': return '返信の受信に失敗しました。時間をおいて再度お試しください';
+			case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan': return 'プランの作成に失敗しました。時間をおいて再度お試しください';
+			case 'popularTopics.sectionName': return '人気のトピック';
+			case 'createPlanPage.title': return 'プランの作成';
+			case 'createPlanPage.label.location': return '目的地';
+			case 'createPlanPage.label.scheduleStart': return '開始日';
+			case 'createPlanPage.label.scheduleEnd': return '終了日';
+			case 'createPlanPage.label.numberOfPeople': return '人数';
+			case 'createPlanPage.label.transport': return '交通手段';
+			case 'createPlanPage.label.category': return 'カテゴリ';
+			case 'createPlanPage.label.topics': return '旅のトピック';
+			case 'createPlanPage.hintText.location': return '渋谷';
+			case 'createPlanPage.modal.title': return '日付を選択';
+			case 'createPlanPage.numberOfPeopleOptions.0': return '1人';
+			case 'createPlanPage.numberOfPeopleOptions.1': return '2人';
+			case 'createPlanPage.numberOfPeopleOptions.2': return '3人';
+			case 'createPlanPage.numberOfPeopleOptions.3': return '4人';
+			case 'createPlanPage.numberOfPeopleOptions.4': return '5人';
+			case 'createPlanPage.numberOfPeopleOptions.5': return '6人以上';
+			case 'createPlanPage.transportOptions.0': return '電車';
+			case 'createPlanPage.transportOptions.1': return '徒歩';
+			case 'createPlanPage.transportOptions.2': return '車';
+			case 'createPlanPage.transportOptions.3': return 'バス';
+			case 'createPlanPage.categoryOptions.0': return '子連れ向け';
+			case 'createPlanPage.categoryOptions.1': return '大人向け';
+			case 'createPlanPage.categoryOptions.2': return 'エンタメ';
+			case 'createPlanPage.categoryOptions.3': return 'アクティビティ';
+			case 'createPlanPage.categoryOptions.4': return '歴史';
+			case 'createPlanPage.defaultTopics.0': return 'グルメ';
+			case 'createPlanPage.defaultTopics.1': return 'ショッピング';
+			case 'createPlanPage.defaultTopics.2': return 'アクティビティ';
+			case 'createPlanPage.defaultTopics.3': return '映画';
+			case 'createPlanPage.submitButton': return 'プランをAIに伝える';
+			case 'createPlanPage.snackBar.error.foundUnSelectedField': return '選択されていない項目があります 全ての項目を選択してください';
+			case 'editProfilePage.title': return '編集';
+			case 'editProfilePage.textFields.name': return '名前';
+			case 'editProfilePage.buttons.submit': return '保存';
+			case 'editProfilePage.snackBar.success': return '更新しました';
+			case 'editProfilePage.snackBar.error.noChange': return '変更がありません';
+			case 'editProfilePage.snackBar.error.failedToUpdate': return '更新に失敗しました しばらくしてから再度お試しください';
+			case 'editProfilePage.snackBar.error.failedToPickImage': return '画像の選択に失敗しました しばらくしてから再度お試しください';
+			case 'confirmDialog.answers.yes': return 'はい';
+			case 'confirmDialog.answers.no': return 'いいえ';
+			case 'confirmDialog.popPage.title': return '前の画面に戻りますか？';
+			case 'confirmDialog.popPage.description': return '現在の内容は保存されません';
+			case 'confirmDialog.completeCreatePlan.title': return 'プランを確定しますか？';
+			case 'confirmDialog.completeCreatePlan.description': return '一番最後のメッセージに含まれるプランが保存されます';
+			case 'prompt.planProposalMessage': return 'こんなプランを考えてみました！いかがですか？';
+			case 'billDetailsPage.title': return 'プレミアムプラン';
+			case 'billDetailsPage.description': return 'プレミアムプランに加入することで、より快適に渋谷観光をお楽しみいただけます。';
+			case 'billDetailsPage.pricingPlan.title': return '料金プラン';
+			case 'billDetailsPage.pricingPlan.columns.standard': return 'スタンダード';
+			case 'billDetailsPage.pricingPlan.columns.premium': return 'プレミアム';
+			case 'billDetailsPage.pricingPlan.details.free': return '無料 🎉';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.days': return '日数分購入';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.daily': return '・1日 300円';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays': return '・3日 855円';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays': return '・5日 1,480円';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays': return '・7日 2,070円';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.or': return 'または';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime': return '永年分';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice': return '25,800円';
+			case 'billDetailsPage.features.title': return 'グレードごとの機能';
+			case 'billDetailsPage.features.rows.planCreationLimit': return 'プランの作成可能回数';
+			case 'billDetailsPage.features.rows.chatLimit': return 'プラン作成中のチャット可能回数';
+			case 'billDetailsPage.features.rows.timelineAccess': return '全プラン一覧のタイムライン閲覧';
+			case 'billDetailsPage.features.rows.adFree': return '広告の非表示';
+			case 'billDetailsPage.features.rows.exclusiveFeatures': return 'プランの認証機能';
+			case 'billDetailsPage.features.columns.standard.label': return 'スタンダード';
+			case 'billDetailsPage.features.columns.standard.planCreationLimit': return '2回';
+			case 'billDetailsPage.features.columns.standard.chatLimit': return '3回';
+			case 'billDetailsPage.features.columns.premium.label': return 'プレミアム';
+			case 'billDetailsPage.features.columns.premium.planCreationLimit': return '無制限';
+			case 'billDetailsPage.features.columns.premium.chatLimit': return '無制限';
+			case 'billDetailsPage.pricingOptions.oneDay.duration': return '1日';
+			case 'billDetailsPage.pricingOptions.oneDay.discount': return '';
+			case 'billDetailsPage.pricingOptions.oneDay.price': return '300円';
+			case 'billDetailsPage.pricingOptions.threeDays.duration': return '3日';
+			case 'billDetailsPage.pricingOptions.threeDays.discount': return '-5%';
+			case 'billDetailsPage.pricingOptions.threeDays.price': return '890円';
+			case 'billDetailsPage.pricingOptions.fiveDays.duration': return '5日';
+			case 'billDetailsPage.pricingOptions.fiveDays.discount': return '-7.5%';
+			case 'billDetailsPage.pricingOptions.fiveDays.price': return '1,387円';
+			case 'billDetailsPage.pricingOptions.sevenDays.duration': return '7日';
+			case 'billDetailsPage.pricingOptions.sevenDays.discount': return '-10%';
+			case 'billDetailsPage.pricingOptions.sevenDays.price': return '2,070円';
+			case 'billDetailsPage.pricingOptions.lifetime.duration': return '永年分';
+			case 'billDetailsPage.pricingOptions.lifetime.discount': return '';
+			case 'billDetailsPage.pricingOptions.lifetime.price': return '25,800円';
+			case 'billDetailsPage.upgradeButton': return 'プレミアムにアップグレード';
+			case 'planDetailsPage.dateTime.createOn': return ({required Object date}) => '${date}に作られたプラン';
+			case 'planDetailsPage.dateTime.dateFormat': return 'yyyy年MM月dd日';
+			case 'planDetailsPage.item.viewOnMap': return '地図で見る';
+			case 'planDetailsPage.snackBar.error.failedToUpdateBookmark': return 'ブックマークの更新に失敗しました しばらくしてから再度お試しください';
+			case 'locales.en': return '英語';
+			case 'locales.ja': return '日本語';
+			case 'locales.zh': return '中国語';
+			case 'errorPage.title': return 'エラーが発生しました...';
+			case 'errorPage.message': return '通信環境を確認し、もう一度お試しください';
+			case 'errorPage.retryButton': return 'もう一度読み込む';
+			case 'mapPage.title': return 'マップ';
+			default: return null;
+		}
+	}
 }
+

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -125,8 +125,8 @@ class _TranslationsValidationJa implements TranslationsValidationEn {
 	@override String get passwordMatch => 'パスワードが一致しません';
 	@override String get informationRequired => '情報を入力してください';
 	@override String get urlInvalid => 'URLの形式が正しくありません';
-	@override String get userNameRequired => 'ユーザーネームを入力してください';
-	@override String get userNameMaxLength => 'ユーザーネームは8文字以内である必要があります';
+	@override String get usernameRequired => 'ユーザーネームを入力してください';
+	@override String get usernameMaxLength => 'ユーザーネームは8文字以内である必要があります';
 }
 
 // Path: myPage
@@ -1263,8 +1263,8 @@ extension on TranslationsJa {
 			case 'validation.passwordMatch': return 'パスワードが一致しません';
 			case 'validation.informationRequired': return '情報を入力してください';
 			case 'validation.urlInvalid': return 'URLの形式が正しくありません';
-			case 'validation.userNameRequired': return 'ユーザーネームを入力してください';
-			case 'validation.userNameMaxLength': return 'ユーザーネームは8文字以内である必要があります';
+			case 'validation.usernameRequired': return 'ユーザーネームを入力してください';
+			case 'validation.usernameMaxLength': return 'ユーザーネームは8文字以内である必要があります';
 			case 'myPage.unregisteredUserName': return '未登録';
 			case 'myPage.editProfile': return 'プロフィール編集';
 			case 'myPage.premiumPlan': return 'プレミアムプラン';

--- a/lib/i18n/strings_ja.i18n.json
+++ b/lib/i18n/strings_ja.i18n.json
@@ -145,8 +145,8 @@
         "passwordMatch": "パスワードが一致しません",
         "informationRequired": "情報を入力してください",
         "urlInvalid": "URLの形式が正しくありません",
-        "userNameRequired": "ユーザーネームを入力してください",
-        "userNameMaxLength": "ユーザーネームは8文字以内である必要があります"
+        "usernameRequired": "ユーザーネームを入力してください",
+        "usernameMaxLength": "ユーザーネームは8文字以内である必要があります"
     },
     "myPage": {
         "unregisteredUserName": "未登録",

--- a/lib/i18n/strings_ja.i18n.json
+++ b/lib/i18n/strings_ja.i18n.json
@@ -144,7 +144,9 @@
         "passwordWeak": "パスワードは半角英数字を組み合わせてください",
         "passwordMatch": "パスワードが一致しません",
         "informationRequired": "情報を入力してください",
-        "urlInvalid": "URLの形式が正しくありません"
+        "urlInvalid": "URLの形式が正しくありません",
+        "userNameRequired": "ユーザーネームを入力してください",
+        "userNameMaxLength": "ユーザーネームは8文字以内である必要があります"
     },
     "myPage": {
         "unregisteredUserName": "未登録",

--- a/lib/i18n/strings_zh-Hans.i18n.json
+++ b/lib/i18n/strings_zh-Hans.i18n.json
@@ -145,8 +145,8 @@
         "passwordMatch": "密码不匹配",
         "informationRequired": "请输入信息",
         "urlInvalid": "URL格式不正确",
-        "userNameRequired": "请输入您的用户名",
-        "userNameMaxLength": "用户名必须为8个字符或更少"
+        "usernameRequired": "请输入您的用户名",
+        "usernameMaxLength": "用户名必须为8个字符或更少"
     },
     "myPage": {
         "unregisteredUserName": "未注册",

--- a/lib/i18n/strings_zh-Hans.i18n.json
+++ b/lib/i18n/strings_zh-Hans.i18n.json
@@ -144,7 +144,9 @@
         "passwordWeak": "密码应包含字母和数字的组合",
         "passwordMatch": "密码不匹配",
         "informationRequired": "请输入信息",
-        "urlInvalid": "URL格式不正确"
+        "urlInvalid": "URL格式不正确",
+        "userNameRequired": "请输入您的用户名",
+        "userNameMaxLength": "用户名必须为8个字符或更少"
     },
     "myPage": {
         "unregisteredUserName": "未注册",

--- a/lib/i18n/strings_zh-Hant.i18n.json
+++ b/lib/i18n/strings_zh-Hant.i18n.json
@@ -145,8 +145,8 @@
         "passwordMatch": "密碼不匹配",
         "informationRequired": "請輸入信息",
         "urlInvalid": "URL格式不正確",
-        "userNameRequired": "請輸入您的使用者名稱",
-        "userNameMaxLength": "使用者名稱必須為8個字符或更少"
+        "usernameRequired": "請輸入您的使用者名稱",
+        "usernameMaxLength": "使用者名稱必須為8個字符或更少"
     },
     "myPage": {
         "unregisteredUserName": "未註冊",

--- a/lib/i18n/strings_zh-Hant.i18n.json
+++ b/lib/i18n/strings_zh-Hant.i18n.json
@@ -144,7 +144,9 @@
         "passwordWeak": "密碼應包含字母和數字的組合",
         "passwordMatch": "密碼不匹配",
         "informationRequired": "請輸入信息",
-        "urlInvalid": "URL格式不正確"
+        "urlInvalid": "URL格式不正確",
+        "userNameRequired": "請輸入您的使用者名稱",
+        "userNameMaxLength": "使用者名稱必須為8個字符或更少"
     },
     "myPage": {
         "unregisteredUserName": "未註冊",

--- a/lib/i18n/strings_zh_Hans.g.dart
+++ b/lib/i18n/strings_zh_Hans.g.dart
@@ -125,8 +125,8 @@ class _TranslationsValidationZhHans implements TranslationsValidationEn {
 	@override String get passwordMatch => '密码不匹配';
 	@override String get informationRequired => '请输入信息';
 	@override String get urlInvalid => 'URL格式不正确';
-	@override String get userNameRequired => '请输入您的用户名';
-	@override String get userNameMaxLength => '用户名必须为8个字符或更少';
+	@override String get usernameRequired => '请输入您的用户名';
+	@override String get usernameMaxLength => '用户名必须为8个字符或更少';
 }
 
 // Path: myPage
@@ -1263,8 +1263,8 @@ extension on TranslationsZhHans {
 			case 'validation.passwordMatch': return '密码不匹配';
 			case 'validation.informationRequired': return '请输入信息';
 			case 'validation.urlInvalid': return 'URL格式不正确';
-			case 'validation.userNameRequired': return '请输入您的用户名';
-			case 'validation.userNameMaxLength': return '用户名必须为8个字符或更少';
+			case 'validation.usernameRequired': return '请输入您的用户名';
+			case 'validation.usernameMaxLength': return '用户名必须为8个字符或更少';
 			case 'myPage.unregisteredUserName': return '未注册';
 			case 'myPage.editProfile': return '编辑个人资料';
 			case 'myPage.premiumPlan': return '高级计划';

--- a/lib/i18n/strings_zh_Hans.g.dart
+++ b/lib/i18n/strings_zh_Hans.g.dart
@@ -11,2132 +11,1407 @@ import 'strings.g.dart';
 
 // Path: <root>
 class TranslationsZhHans implements Translations {
-  /// You can call this constructor and build your own translation instance of this locale.
-  /// Constructing via the enum [AppLocale.build] is preferred.
-  TranslationsZhHans(
-      {Map<String, Node>? overrides,
-      PluralResolver? cardinalResolver,
-      PluralResolver? ordinalResolver})
-      : assert(overrides == null,
-            'Set "translation_overrides: true" in order to enable this feature.'),
-        $meta = TranslationMetadata(
-          locale: AppLocale.zhHans,
-          overrides: overrides ?? {},
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        ) {
-    $meta.setFlatMapFunction(_flatMapFunction);
-  }
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsZhHans({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = TranslationMetadata(
+		    locale: AppLocale.zhHans,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
 
-  /// Metadata for the translations of <zh-Hans>.
-  @override
-  final TranslationMetadata<AppLocale, Translations> $meta;
+	/// Metadata for the translations of <zh-Hans>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
 
-  /// Access flat map
-  @override
-  dynamic operator [](String key) => $meta.getTranslation(key);
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key);
 
-  late final TranslationsZhHans _root = this; // ignore: unused_field
+	late final TranslationsZhHans _root = this; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsNavigationBarZhHans navigationBar =
-      _TranslationsNavigationBarZhHans._(_root);
-  @override
-  late final _TranslationsHomePageZhHans homePage =
-      _TranslationsHomePageZhHans._(_root);
-  @override
-  late final _TranslationsAccountPageZhHans accountPage =
-      _TranslationsAccountPageZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationZhHans authentication =
-      _TranslationsAuthenticationZhHans._(_root);
-  @override
-  late final _TranslationsValidationZhHans validation =
-      _TranslationsValidationZhHans._(_root);
-  @override
-  late final _TranslationsMyPageZhHans myPage =
-      _TranslationsMyPageZhHans._(_root);
-  @override
-  late final _TranslationsChangeLanguagePageZhHans changeLanguagePage =
-      _TranslationsChangeLanguagePageZhHans._(_root);
-  @override
-  late final _TranslationsChangeThemePageZhHans changeThemePage =
-      _TranslationsChangeThemePageZhHans._(_root);
-  @override
-  late final _TranslationsMyPlanPageZhHans myPlanPage =
-      _TranslationsMyPlanPageZhHans._(_root);
-  @override
-  late final _TranslationsBuddyChatPageZhHans buddyChatPage =
-      _TranslationsBuddyChatPageZhHans._(_root);
-  @override
-  late final _TranslationsPopularTopicsZhHans popularTopics =
-      _TranslationsPopularTopicsZhHans._(_root);
-  @override
-  late final _TranslationsCreatePlanPageZhHans createPlanPage =
-      _TranslationsCreatePlanPageZhHans._(_root);
-  @override
-  late final _TranslationsEditProfilePageZhHans editProfilePage =
-      _TranslationsEditProfilePageZhHans._(_root);
-  @override
-  late final _TranslationsConfirmDialogZhHans confirmDialog =
-      _TranslationsConfirmDialogZhHans._(_root);
-  @override
-  late final _TranslationsPromptZhHans prompt =
-      _TranslationsPromptZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPageZhHans billDetailsPage =
-      _TranslationsBillDetailsPageZhHans._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageZhHans planDetailsPage =
-      _TranslationsPlanDetailsPageZhHans._(_root);
-  @override
-  Map<String, String> get locales => {
-        'en': '英语',
-        'ja': '日语',
-        'zh': '中文',
-      };
-  @override
-  late final _TranslationsErrorPageZhHans errorPage =
-      _TranslationsErrorPageZhHans._(_root);
-  @override
-  late final _TranslationsMapPageZhHans mapPage =
-      _TranslationsMapPageZhHans._(_root);
+	// Translations
+	@override late final _TranslationsNavigationBarZhHans navigationBar = _TranslationsNavigationBarZhHans._(_root);
+	@override late final _TranslationsHomePageZhHans homePage = _TranslationsHomePageZhHans._(_root);
+	@override late final _TranslationsAccountPageZhHans accountPage = _TranslationsAccountPageZhHans._(_root);
+	@override late final _TranslationsAuthenticationZhHans authentication = _TranslationsAuthenticationZhHans._(_root);
+	@override late final _TranslationsValidationZhHans validation = _TranslationsValidationZhHans._(_root);
+	@override late final _TranslationsMyPageZhHans myPage = _TranslationsMyPageZhHans._(_root);
+	@override late final _TranslationsChangeLanguagePageZhHans changeLanguagePage = _TranslationsChangeLanguagePageZhHans._(_root);
+	@override late final _TranslationsChangeThemePageZhHans changeThemePage = _TranslationsChangeThemePageZhHans._(_root);
+	@override late final _TranslationsMyPlanPageZhHans myPlanPage = _TranslationsMyPlanPageZhHans._(_root);
+	@override late final _TranslationsBuddyChatPageZhHans buddyChatPage = _TranslationsBuddyChatPageZhHans._(_root);
+	@override late final _TranslationsPopularTopicsZhHans popularTopics = _TranslationsPopularTopicsZhHans._(_root);
+	@override late final _TranslationsCreatePlanPageZhHans createPlanPage = _TranslationsCreatePlanPageZhHans._(_root);
+	@override late final _TranslationsEditProfilePageZhHans editProfilePage = _TranslationsEditProfilePageZhHans._(_root);
+	@override late final _TranslationsConfirmDialogZhHans confirmDialog = _TranslationsConfirmDialogZhHans._(_root);
+	@override late final _TranslationsPromptZhHans prompt = _TranslationsPromptZhHans._(_root);
+	@override late final _TranslationsBillDetailsPageZhHans billDetailsPage = _TranslationsBillDetailsPageZhHans._(_root);
+	@override late final _TranslationsPlanDetailsPageZhHans planDetailsPage = _TranslationsPlanDetailsPageZhHans._(_root);
+	@override Map<String, String> get locales => {
+		'en': '英语',
+		'ja': '日语',
+		'zh': '中文',
+	};
+	@override late final _TranslationsErrorPageZhHans errorPage = _TranslationsErrorPageZhHans._(_root);
+	@override late final _TranslationsMapPageZhHans mapPage = _TranslationsMapPageZhHans._(_root);
 }
 
 // Path: navigationBar
 class _TranslationsNavigationBarZhHans implements TranslationsNavigationBarEn {
-  _TranslationsNavigationBarZhHans._(this._root);
+	_TranslationsNavigationBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsNavigationBarItemsZhHans items =
-      _TranslationsNavigationBarItemsZhHans._(_root);
+	// Translations
+	@override late final _TranslationsNavigationBarItemsZhHans items = _TranslationsNavigationBarItemsZhHans._(_root);
 }
 
 // Path: homePage
 class _TranslationsHomePageZhHans implements TranslationsHomePageEn {
-  _TranslationsHomePageZhHans._(this._root);
+	_TranslationsHomePageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsHomePagePopularPlansZhHans popularPlans =
-      _TranslationsHomePagePopularPlansZhHans._(_root);
-  @override
-  late final _TranslationsHomePagePopularTopicsZhHans popularTopics =
-      _TranslationsHomePagePopularTopicsZhHans._(_root);
-  @override
-  late final _TranslationsHomePageRecentPlansZhHans recentPlans =
-      _TranslationsHomePageRecentPlansZhHans._(_root);
+	// Translations
+	@override late final _TranslationsHomePagePopularPlansZhHans popularPlans = _TranslationsHomePagePopularPlansZhHans._(_root);
+	@override late final _TranslationsHomePagePopularTopicsZhHans popularTopics = _TranslationsHomePagePopularTopicsZhHans._(_root);
+	@override late final _TranslationsHomePageRecentPlansZhHans recentPlans = _TranslationsHomePageRecentPlansZhHans._(_root);
 }
 
 // Path: accountPage
 class _TranslationsAccountPageZhHans implements TranslationsAccountPageEn {
-  _TranslationsAccountPageZhHans._(this._root);
+	_TranslationsAccountPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '账户';
-  @override
-  late final _TranslationsAccountPageItemsZhHans items =
-      _TranslationsAccountPageItemsZhHans._(_root);
-  @override
-  late final _TranslationsAccountPageSnackBarZhHans snackBar =
-      _TranslationsAccountPageSnackBarZhHans._(_root);
-  @override
-  late final _TranslationsAccountPageDiaLogZhHans diaLog =
-      _TranslationsAccountPageDiaLogZhHans._(_root);
+	// Translations
+	@override String get title => '账户';
+	@override late final _TranslationsAccountPageItemsZhHans items = _TranslationsAccountPageItemsZhHans._(_root);
+	@override late final _TranslationsAccountPageSnackBarZhHans snackBar = _TranslationsAccountPageSnackBarZhHans._(_root);
+	@override late final _TranslationsAccountPageDiaLogZhHans diaLog = _TranslationsAccountPageDiaLogZhHans._(_root);
 }
 
 // Path: authentication
-class _TranslationsAuthenticationZhHans
-    implements TranslationsAuthenticationEn {
-  _TranslationsAuthenticationZhHans._(this._root);
+class _TranslationsAuthenticationZhHans implements TranslationsAuthenticationEn {
+	_TranslationsAuthenticationZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationSignInPageZhHans signInPage =
-      _TranslationsAuthenticationSignInPageZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationFirebaseAuthZhHans firebaseAuth =
-      _TranslationsAuthenticationFirebaseAuthZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageZhHans
-      resetPasswordPage =
-      _TranslationsAuthenticationResetPasswordPageZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationSignUpPageZhHans signUpPage =
-      _TranslationsAuthenticationSignUpPageZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageZhHans
-      emailVerificationPage =
-      _TranslationsAuthenticationEmailVerificationPageZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageZhHans
-      registerProfilePage =
-      _TranslationsAuthenticationRegisterProfilePageZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationCompleteSendEmailPageZhHans
-      completeSendEmailPage =
-      _TranslationsAuthenticationCompleteSendEmailPageZhHans._(_root);
+	// Translations
+	@override late final _TranslationsAuthenticationSignInPageZhHans signInPage = _TranslationsAuthenticationSignInPageZhHans._(_root);
+	@override late final _TranslationsAuthenticationFirebaseAuthZhHans firebaseAuth = _TranslationsAuthenticationFirebaseAuthZhHans._(_root);
+	@override late final _TranslationsAuthenticationResetPasswordPageZhHans resetPasswordPage = _TranslationsAuthenticationResetPasswordPageZhHans._(_root);
+	@override late final _TranslationsAuthenticationSignUpPageZhHans signUpPage = _TranslationsAuthenticationSignUpPageZhHans._(_root);
+	@override late final _TranslationsAuthenticationEmailVerificationPageZhHans emailVerificationPage = _TranslationsAuthenticationEmailVerificationPageZhHans._(_root);
+	@override late final _TranslationsAuthenticationRegisterProfilePageZhHans registerProfilePage = _TranslationsAuthenticationRegisterProfilePageZhHans._(_root);
+	@override late final _TranslationsAuthenticationCompleteSendEmailPageZhHans completeSendEmailPage = _TranslationsAuthenticationCompleteSendEmailPageZhHans._(_root);
 }
 
 // Path: validation
 class _TranslationsValidationZhHans implements TranslationsValidationEn {
-  _TranslationsValidationZhHans._(this._root);
+	_TranslationsValidationZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get emailRequired => '请输入电子邮件地址';
-  @override
-  String get emailInvalid => '电子邮件地址格式不正确';
-  @override
-  String get passwordRequired => '请输入密码';
-  @override
-  String get passwordShort => '密码至少需要8个字符';
-  @override
-  String get passwordWeak => '密码应包含字母和数字的组合';
-  @override
-  String get passwordMatch => '密码不匹配';
-  @override
-  String get informationRequired => '请输入信息';
-  @override
-  String get urlInvalid => 'URL格式不正确';
+	// Translations
+	@override String get emailRequired => '请输入电子邮件地址';
+	@override String get emailInvalid => '电子邮件地址格式不正确';
+	@override String get passwordRequired => '请输入密码';
+	@override String get passwordShort => '密码至少需要8个字符';
+	@override String get passwordWeak => '密码应包含字母和数字的组合';
+	@override String get passwordMatch => '密码不匹配';
+	@override String get informationRequired => '请输入信息';
+	@override String get urlInvalid => 'URL格式不正确';
+	@override String get userNameRequired => '请输入您的用户名';
+	@override String get userNameMaxLength => '用户名必须为8个字符或更少';
 }
 
 // Path: myPage
 class _TranslationsMyPageZhHans implements TranslationsMyPageEn {
-  _TranslationsMyPageZhHans._(this._root);
+	_TranslationsMyPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get unregisteredUserName => '未注册';
-  @override
-  String get editProfile => '编辑个人资料';
-  @override
-  String get premiumPlan => '高级计划';
-  @override
-  String get details => '详细';
-  @override
-  String get settings => '设置';
-  @override
-  String get account => '账户';
-  @override
-  String get language => '语言';
-  @override
-  String get theme => '主题';
-  @override
-  String get termsOfUsePrivacyPolicy => '使用条款和隐私政策';
-  @override
-  String get aboutThisApp => '关于本应用';
-  @override
-  String get aboutTheDeveloper => '关于开发者';
-  @override
-  late final _TranslationsMyPageAccountStatusZhHans accountStatus =
-      _TranslationsMyPageAccountStatusZhHans._(_root);
+	// Translations
+	@override String get unregisteredUserName => '未注册';
+	@override String get editProfile => '编辑个人资料';
+	@override String get premiumPlan => '高级计划';
+	@override String get details => '详细';
+	@override String get settings => '设置';
+	@override String get account => '账户';
+	@override String get language => '语言';
+	@override String get theme => '主题';
+	@override String get termsOfUsePrivacyPolicy => '使用条款和隐私政策';
+	@override String get aboutThisApp => '关于本应用';
+	@override String get aboutTheDeveloper => '关于开发者';
+	@override late final _TranslationsMyPageAccountStatusZhHans accountStatus = _TranslationsMyPageAccountStatusZhHans._(_root);
 }
 
 // Path: changeLanguagePage
-class _TranslationsChangeLanguagePageZhHans
-    implements TranslationsChangeLanguagePageEn {
-  _TranslationsChangeLanguagePageZhHans._(this._root);
+class _TranslationsChangeLanguagePageZhHans implements TranslationsChangeLanguagePageEn {
+	_TranslationsChangeLanguagePageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '语言';
-  @override
-  late final _TranslationsChangeLanguagePageItemsZhHans items =
-      _TranslationsChangeLanguagePageItemsZhHans._(_root);
+	// Translations
+	@override String get title => '语言';
+	@override late final _TranslationsChangeLanguagePageItemsZhHans items = _TranslationsChangeLanguagePageItemsZhHans._(_root);
 }
 
 // Path: changeThemePage
-class _TranslationsChangeThemePageZhHans
-    implements TranslationsChangeThemePageEn {
-  _TranslationsChangeThemePageZhHans._(this._root);
+class _TranslationsChangeThemePageZhHans implements TranslationsChangeThemePageEn {
+	_TranslationsChangeThemePageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '主题';
-  @override
-  late final _TranslationsChangeThemePageItemsZhHans items =
-      _TranslationsChangeThemePageItemsZhHans._(_root);
+	// Translations
+	@override String get title => '主题';
+	@override late final _TranslationsChangeThemePageItemsZhHans items = _TranslationsChangeThemePageItemsZhHans._(_root);
 }
 
 // Path: myPlanPage
 class _TranslationsMyPlanPageZhHans implements TranslationsMyPlanPageEn {
-  _TranslationsMyPlanPageZhHans._(this._root);
+	_TranslationsMyPlanPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '我的计划';
-  @override
-  late final _TranslationsMyPlanPageTabsZhHans tabs =
-      _TranslationsMyPlanPageTabsZhHans._(_root);
-  @override
-  late final _TranslationsMyPlanPageBookmarkItemsZhHans bookmarkItems =
-      _TranslationsMyPlanPageBookmarkItemsZhHans._(_root);
-  @override
-  late final _TranslationsMyPlanPageCreatedPlansItemsZhHans createdPlansItems =
-      _TranslationsMyPlanPageCreatedPlansItemsZhHans._(_root);
-  @override
-  late final _TranslationsMyPlanPageErrorZhHans error =
-      _TranslationsMyPlanPageErrorZhHans._(_root);
+	// Translations
+	@override String get title => '我的计划';
+	@override late final _TranslationsMyPlanPageTabsZhHans tabs = _TranslationsMyPlanPageTabsZhHans._(_root);
+	@override late final _TranslationsMyPlanPageBookmarkItemsZhHans bookmarkItems = _TranslationsMyPlanPageBookmarkItemsZhHans._(_root);
+	@override late final _TranslationsMyPlanPageCreatedPlansItemsZhHans createdPlansItems = _TranslationsMyPlanPageCreatedPlansItemsZhHans._(_root);
+	@override late final _TranslationsMyPlanPageErrorZhHans error = _TranslationsMyPlanPageErrorZhHans._(_root);
 }
 
 // Path: buddyChatPage
 class _TranslationsBuddyChatPageZhHans implements TranslationsBuddyChatPageEn {
-  _TranslationsBuddyChatPageZhHans._(this._root);
+	_TranslationsBuddyChatPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'Buddy的建议';
-  @override
-  String possibleChatCount({required Object possibleChatCount}) =>
-      '消息还可以发送${possibleChatCount}次';
-  @override
-  late final _TranslationsBuddyChatPageTextFieldsZhHans textFields =
-      _TranslationsBuddyChatPageTextFieldsZhHans._(_root);
-  @override
-  late final _TranslationsBuddyChatPageButtonsZhHans buttons =
-      _TranslationsBuddyChatPageButtonsZhHans._(_root);
-  @override
-  late final _TranslationsBuddyChatPagePlaceCardZhHans placeCard =
-      _TranslationsBuddyChatPagePlaceCardZhHans._(_root);
-  @override
-  late final _TranslationsBuddyChatPageSnackBarZhHans snackBar =
-      _TranslationsBuddyChatPageSnackBarZhHans._(_root);
+	// Translations
+	@override String get title => 'Buddy的建议';
+	@override String possibleChatCount({required Object possibleChatCount}) => '消息还可以发送${possibleChatCount}次';
+	@override late final _TranslationsBuddyChatPageTextFieldsZhHans textFields = _TranslationsBuddyChatPageTextFieldsZhHans._(_root);
+	@override late final _TranslationsBuddyChatPageButtonsZhHans buttons = _TranslationsBuddyChatPageButtonsZhHans._(_root);
+	@override late final _TranslationsBuddyChatPagePlaceCardZhHans placeCard = _TranslationsBuddyChatPagePlaceCardZhHans._(_root);
+	@override late final _TranslationsBuddyChatPageSnackBarZhHans snackBar = _TranslationsBuddyChatPageSnackBarZhHans._(_root);
 }
 
 // Path: popularTopics
 class _TranslationsPopularTopicsZhHans implements TranslationsPopularTopicsEn {
-  _TranslationsPopularTopicsZhHans._(this._root);
+	_TranslationsPopularTopicsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get sectionName => '热门话题';
+	// Translations
+	@override String get sectionName => '热门话题';
 }
 
 // Path: createPlanPage
-class _TranslationsCreatePlanPageZhHans
-    implements TranslationsCreatePlanPageEn {
-  _TranslationsCreatePlanPageZhHans._(this._root);
+class _TranslationsCreatePlanPageZhHans implements TranslationsCreatePlanPageEn {
+	_TranslationsCreatePlanPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '创建计划';
-  @override
-  late final _TranslationsCreatePlanPageLabelZhHans label =
-      _TranslationsCreatePlanPageLabelZhHans._(_root);
-  @override
-  late final _TranslationsCreatePlanPageHintTextZhHans hintText =
-      _TranslationsCreatePlanPageHintTextZhHans._(_root);
-  @override
-  late final _TranslationsCreatePlanPageModalZhHans modal =
-      _TranslationsCreatePlanPageModalZhHans._(_root);
-  @override
-  List<String> get numberOfPeopleOptions => [
-        '1人',
-        '2人',
-        '3人',
-        '4人',
-        '5人',
-        '6人以上',
-      ];
-  @override
-  List<String> get transportOptions => [
-        '火车',
-        '步行',
-        '汽车',
-        '巴士',
-      ];
-  @override
-  List<String> get categoryOptions => [
-        '亲子',
-        '成人',
-        '娱乐',
-        '活动',
-        '历史',
-      ];
-  @override
-  List<String> get defaultTopics => [
-        '美食',
-        '购物',
-        '活动',
-        '电影',
-      ];
-  @override
-  String get submitButton => '提交计划给AI';
-  @override
-  late final _TranslationsCreatePlanPageSnackBarZhHans snackBar =
-      _TranslationsCreatePlanPageSnackBarZhHans._(_root);
+	// Translations
+	@override String get title => '创建计划';
+	@override late final _TranslationsCreatePlanPageLabelZhHans label = _TranslationsCreatePlanPageLabelZhHans._(_root);
+	@override late final _TranslationsCreatePlanPageHintTextZhHans hintText = _TranslationsCreatePlanPageHintTextZhHans._(_root);
+	@override late final _TranslationsCreatePlanPageModalZhHans modal = _TranslationsCreatePlanPageModalZhHans._(_root);
+	@override List<String> get numberOfPeopleOptions => [
+		'1人',
+		'2人',
+		'3人',
+		'4人',
+		'5人',
+		'6人以上',
+	];
+	@override List<String> get transportOptions => [
+		'火车',
+		'步行',
+		'汽车',
+		'巴士',
+	];
+	@override List<String> get categoryOptions => [
+		'亲子',
+		'成人',
+		'娱乐',
+		'活动',
+		'历史',
+	];
+	@override List<String> get defaultTopics => [
+		'美食',
+		'购物',
+		'活动',
+		'电影',
+	];
+	@override String get submitButton => '提交计划给AI';
+	@override late final _TranslationsCreatePlanPageSnackBarZhHans snackBar = _TranslationsCreatePlanPageSnackBarZhHans._(_root);
 }
 
 // Path: editProfilePage
-class _TranslationsEditProfilePageZhHans
-    implements TranslationsEditProfilePageEn {
-  _TranslationsEditProfilePageZhHans._(this._root);
+class _TranslationsEditProfilePageZhHans implements TranslationsEditProfilePageEn {
+	_TranslationsEditProfilePageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '编辑个人资料';
-  @override
-  late final _TranslationsEditProfilePageTextFieldsZhHans textFields =
-      _TranslationsEditProfilePageTextFieldsZhHans._(_root);
-  @override
-  late final _TranslationsEditProfilePageButtonsZhHans buttons =
-      _TranslationsEditProfilePageButtonsZhHans._(_root);
-  @override
-  late final _TranslationsEditProfilePageSnackBarZhHans snackBar =
-      _TranslationsEditProfilePageSnackBarZhHans._(_root);
+	// Translations
+	@override String get title => '编辑个人资料';
+	@override late final _TranslationsEditProfilePageTextFieldsZhHans textFields = _TranslationsEditProfilePageTextFieldsZhHans._(_root);
+	@override late final _TranslationsEditProfilePageButtonsZhHans buttons = _TranslationsEditProfilePageButtonsZhHans._(_root);
+	@override late final _TranslationsEditProfilePageSnackBarZhHans snackBar = _TranslationsEditProfilePageSnackBarZhHans._(_root);
 }
 
 // Path: confirmDialog
 class _TranslationsConfirmDialogZhHans implements TranslationsConfirmDialogEn {
-  _TranslationsConfirmDialogZhHans._(this._root);
+	_TranslationsConfirmDialogZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsConfirmDialogAnswersZhHans answers =
-      _TranslationsConfirmDialogAnswersZhHans._(_root);
-  @override
-  late final _TranslationsConfirmDialogPopPageZhHans popPage =
-      _TranslationsConfirmDialogPopPageZhHans._(_root);
-  @override
-  late final _TranslationsConfirmDialogCompleteCreatePlanZhHans
-      completeCreatePlan =
-      _TranslationsConfirmDialogCompleteCreatePlanZhHans._(_root);
+	// Translations
+	@override late final _TranslationsConfirmDialogAnswersZhHans answers = _TranslationsConfirmDialogAnswersZhHans._(_root);
+	@override late final _TranslationsConfirmDialogPopPageZhHans popPage = _TranslationsConfirmDialogPopPageZhHans._(_root);
+	@override late final _TranslationsConfirmDialogCompleteCreatePlanZhHans completeCreatePlan = _TranslationsConfirmDialogCompleteCreatePlanZhHans._(_root);
 }
 
 // Path: prompt
 class _TranslationsPromptZhHans implements TranslationsPromptEn {
-  _TranslationsPromptZhHans._(this._root);
+	_TranslationsPromptZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get planProposalMessage => '我考虑了这个计划！您觉得怎么样？';
+	// Translations
+	@override String get planProposalMessage => '我考虑了这个计划！您觉得怎么样？';
 }
 
 // Path: billDetailsPage
-class _TranslationsBillDetailsPageZhHans
-    implements TranslationsBillDetailsPageEn {
-  _TranslationsBillDetailsPageZhHans._(this._root);
+class _TranslationsBillDetailsPageZhHans implements TranslationsBillDetailsPageEn {
+	_TranslationsBillDetailsPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '高级计划';
-  @override
-  String get description => '订阅高级计划后，您可以更舒适地享受涩谷观光。';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanZhHans pricingPlan =
-      _TranslationsBillDetailsPagePricingPlanZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesZhHans features =
-      _TranslationsBillDetailsPageFeaturesZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsZhHans pricingOptions =
-      _TranslationsBillDetailsPagePricingOptionsZhHans._(_root);
-  @override
-  String get upgradeButton => '升级到高级计划';
+	// Translations
+	@override String get title => '高级计划';
+	@override String get description => '订阅高级计划后，您可以更舒适地享受涩谷观光。';
+	@override late final _TranslationsBillDetailsPagePricingPlanZhHans pricingPlan = _TranslationsBillDetailsPagePricingPlanZhHans._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesZhHans features = _TranslationsBillDetailsPageFeaturesZhHans._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsZhHans pricingOptions = _TranslationsBillDetailsPagePricingOptionsZhHans._(_root);
+	@override String get upgradeButton => '升级到高级计划';
 }
 
 // Path: planDetailsPage
-class _TranslationsPlanDetailsPageZhHans
-    implements TranslationsPlanDetailsPageEn {
-  _TranslationsPlanDetailsPageZhHans._(this._root);
+class _TranslationsPlanDetailsPageZhHans implements TranslationsPlanDetailsPageEn {
+	_TranslationsPlanDetailsPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsPlanDetailsPageDateTimeZhHans dateTime =
-      _TranslationsPlanDetailsPageDateTimeZhHans._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageItemZhHans item =
-      _TranslationsPlanDetailsPageItemZhHans._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageSnackBarZhHans snackBar =
-      _TranslationsPlanDetailsPageSnackBarZhHans._(_root);
+	// Translations
+	@override late final _TranslationsPlanDetailsPageDateTimeZhHans dateTime = _TranslationsPlanDetailsPageDateTimeZhHans._(_root);
+	@override late final _TranslationsPlanDetailsPageItemZhHans item = _TranslationsPlanDetailsPageItemZhHans._(_root);
+	@override late final _TranslationsPlanDetailsPageSnackBarZhHans snackBar = _TranslationsPlanDetailsPageSnackBarZhHans._(_root);
 }
 
 // Path: errorPage
 class _TranslationsErrorPageZhHans implements TranslationsErrorPageEn {
-  _TranslationsErrorPageZhHans._(this._root);
+	_TranslationsErrorPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '发生错误...';
-  @override
-  String get message => '请检查您的网络连接并重试。';
-  @override
-  String get retryButton => '重试';
+	// Translations
+	@override String get title => '发生错误...';
+	@override String get message => '请检查您的网络连接并重试。';
+	@override String get retryButton => '重试';
 }
 
 // Path: mapPage
 class _TranslationsMapPageZhHans implements TranslationsMapPageEn {
-  _TranslationsMapPageZhHans._(this._root);
+	_TranslationsMapPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '地图';
+	// Translations
+	@override String get title => '地图';
 }
 
 // Path: navigationBar.items
-class _TranslationsNavigationBarItemsZhHans
-    implements TranslationsNavigationBarItemsEn {
-  _TranslationsNavigationBarItemsZhHans._(this._root);
+class _TranslationsNavigationBarItemsZhHans implements TranslationsNavigationBarItemsEn {
+	_TranslationsNavigationBarItemsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get home => '首页';
-  @override
-  String get myPlan => '我的计划';
-  @override
-  String get myPage => '我的页面';
+	// Translations
+	@override String get home => '首页';
+	@override String get myPlan => '我的计划';
+	@override String get myPage => '我的页面';
 }
 
 // Path: homePage.popularPlans
-class _TranslationsHomePagePopularPlansZhHans
-    implements TranslationsHomePagePopularPlansEn {
-  _TranslationsHomePagePopularPlansZhHans._(this._root);
+class _TranslationsHomePagePopularPlansZhHans implements TranslationsHomePagePopularPlansEn {
+	_TranslationsHomePagePopularPlansZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '热门计划';
+	// Translations
+	@override String get title => '热门计划';
 }
 
 // Path: homePage.popularTopics
-class _TranslationsHomePagePopularTopicsZhHans
-    implements TranslationsHomePagePopularTopicsEn {
-  _TranslationsHomePagePopularTopicsZhHans._(this._root);
+class _TranslationsHomePagePopularTopicsZhHans implements TranslationsHomePagePopularTopicsEn {
+	_TranslationsHomePagePopularTopicsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '热门话题';
-  @override
-  String numberOfTopics({required Object number}) => '${number}件~';
+	// Translations
+	@override String get title => '热门话题';
+	@override String numberOfTopics({required Object number}) => '${number}件~';
 }
 
 // Path: homePage.recentPlans
-class _TranslationsHomePageRecentPlansZhHans
-    implements TranslationsHomePageRecentPlansEn {
-  _TranslationsHomePageRecentPlansZhHans._(this._root);
+class _TranslationsHomePageRecentPlansZhHans implements TranslationsHomePageRecentPlansEn {
+	_TranslationsHomePageRecentPlansZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '最近创建的计划';
+	// Translations
+	@override String get title => '最近创建的计划';
 }
 
 // Path: accountPage.items
-class _TranslationsAccountPageItemsZhHans
-    implements TranslationsAccountPageItemsEn {
-  _TranslationsAccountPageItemsZhHans._(this._root);
+class _TranslationsAccountPageItemsZhHans implements TranslationsAccountPageItemsEn {
+	_TranslationsAccountPageItemsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signOut => '退出登录';
-  @override
-  String get linkedWithGoogle => '与Google连接';
-  @override
-  String get linkedWithApple => '与Apple连接';
-  @override
-  String get alreadyLinkedGoogle => '已与Google连接';
-  @override
-  String get alreadyLinkedApple => '已与Apple连接';
+	// Translations
+	@override String get signOut => '退出登录';
+	@override String get linkedWithGoogle => '与Google连接';
+	@override String get linkedWithApple => '与Apple连接';
+	@override String get alreadyLinkedGoogle => '已与Google连接';
+	@override String get alreadyLinkedApple => '已与Apple连接';
 }
 
 // Path: accountPage.snackBar
-class _TranslationsAccountPageSnackBarZhHans
-    implements TranslationsAccountPageSnackBarEn {
-  _TranslationsAccountPageSnackBarZhHans._(this._root);
+class _TranslationsAccountPageSnackBarZhHans implements TranslationsAccountPageSnackBarEn {
+	_TranslationsAccountPageSnackBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signOut => '已成功退出登录。';
-  @override
-  String get signOutFailure => '退出登录时发生错误。';
-  @override
-  String get successfulLinkage => '账户关联成功。';
-  @override
-  String get linkageFailure => '账户关联失败。';
-  @override
-  String get providerAlreadyLinked => '此账户已经关联。';
-  @override
-  String get accountDeactivation => '已解除账户关联。';
-  @override
-  String get invalidCredential => '请重新登录。';
-  @override
-  String get linkageCancelled => '账户关联已取消。';
-  @override
-  String get unlinkageFailure => '解除账户关联失败。';
-  @override
-  String get operationNotAllowed => '提供者无效。请联系开发者。';
-  @override
-  String get unknownError => '发生未知错误。';
+	// Translations
+	@override String get signOut => '已成功退出登录。';
+	@override String get signOutFailure => '退出登录时发生错误。';
+	@override String get successfulLinkage => '账户关联成功。';
+	@override String get linkageFailure => '账户关联失败。';
+	@override String get providerAlreadyLinked => '此账户已经关联。';
+	@override String get accountDeactivation => '已解除账户关联。';
+	@override String get invalidCredential => '请重新登录。';
+	@override String get linkageCancelled => '账户关联已取消。';
+	@override String get unlinkageFailure => '解除账户关联失败。';
+	@override String get operationNotAllowed => '提供者无效。请联系开发者。';
+	@override String get unknownError => '发生未知错误。';
 }
 
 // Path: accountPage.diaLog
-class _TranslationsAccountPageDiaLogZhHans
-    implements TranslationsAccountPageDiaLogEn {
-  _TranslationsAccountPageDiaLogZhHans._(this._root);
+class _TranslationsAccountPageDiaLogZhHans implements TranslationsAccountPageDiaLogEn {
+	_TranslationsAccountPageDiaLogZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get yes => '是';
-  @override
-  String get no => '否';
-  @override
-  String get title => '确认解除账户连接';
-  @override
-  String get googleText => '是否要解除当前账户与Google账户的连接？';
-  @override
-  String get appleText => '是否要解除当前账户与Apple账户的连接？';
+	// Translations
+	@override String get yes => '是';
+	@override String get no => '否';
+	@override String get title => '确认解除账户连接';
+	@override String get googleText => '是否要解除当前账户与Google账户的连接？';
+	@override String get appleText => '是否要解除当前账户与Apple账户的连接？';
 }
 
 // Path: authentication.signInPage
-class _TranslationsAuthenticationSignInPageZhHans
-    implements TranslationsAuthenticationSignInPageEn {
-  _TranslationsAuthenticationSignInPageZhHans._(this._root);
+class _TranslationsAuthenticationSignInPageZhHans implements TranslationsAuthenticationSignInPageEn {
+	_TranslationsAuthenticationSignInPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '登录';
-  @override
-  String get optionText => ' 或 ';
-  @override
-  late final _TranslationsAuthenticationSignInPageTextFieldsZhHans textFields =
-      _TranslationsAuthenticationSignInPageTextFieldsZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationSignInPageButtonsZhHans buttons =
-      _TranslationsAuthenticationSignInPageButtonsZhHans._(_root);
+	// Translations
+	@override String get title => '登录';
+	@override String get optionText => ' 或 ';
+	@override late final _TranslationsAuthenticationSignInPageTextFieldsZhHans textFields = _TranslationsAuthenticationSignInPageTextFieldsZhHans._(_root);
+	@override late final _TranslationsAuthenticationSignInPageButtonsZhHans buttons = _TranslationsAuthenticationSignInPageButtonsZhHans._(_root);
 }
 
 // Path: authentication.firebaseAuth
-class _TranslationsAuthenticationFirebaseAuthZhHans
-    implements TranslationsAuthenticationFirebaseAuthEn {
-  _TranslationsAuthenticationFirebaseAuthZhHans._(this._root);
+class _TranslationsAuthenticationFirebaseAuthZhHans implements TranslationsAuthenticationFirebaseAuthEn {
+	_TranslationsAuthenticationFirebaseAuthZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationFirebaseAuthErrorZhHans error =
-      _TranslationsAuthenticationFirebaseAuthErrorZhHans._(_root);
+	// Translations
+	@override late final _TranslationsAuthenticationFirebaseAuthErrorZhHans error = _TranslationsAuthenticationFirebaseAuthErrorZhHans._(_root);
 }
 
 // Path: authentication.resetPasswordPage
-class _TranslationsAuthenticationResetPasswordPageZhHans
-    implements TranslationsAuthenticationResetPasswordPageEn {
-  _TranslationsAuthenticationResetPasswordPageZhHans._(this._root);
+class _TranslationsAuthenticationResetPasswordPageZhHans implements TranslationsAuthenticationResetPasswordPageEn {
+	_TranslationsAuthenticationResetPasswordPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '重置密码';
-  @override
-  String get description => '将向输入的电子邮件地址发送密码重置邮件';
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans
-      textFields =
-      _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageButtonsZhHans buttons =
-      _TranslationsAuthenticationResetPasswordPageButtonsZhHans._(_root);
+	// Translations
+	@override String get title => '重置密码';
+	@override String get description => '将向输入的电子邮件地址发送密码重置邮件';
+	@override late final _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans textFields = _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans._(_root);
+	@override late final _TranslationsAuthenticationResetPasswordPageButtonsZhHans buttons = _TranslationsAuthenticationResetPasswordPageButtonsZhHans._(_root);
 }
 
 // Path: authentication.signUpPage
-class _TranslationsAuthenticationSignUpPageZhHans
-    implements TranslationsAuthenticationSignUpPageEn {
-  _TranslationsAuthenticationSignUpPageZhHans._(this._root);
+class _TranslationsAuthenticationSignUpPageZhHans implements TranslationsAuthenticationSignUpPageEn {
+	_TranslationsAuthenticationSignUpPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '注册';
-  @override
-  late final _TranslationsAuthenticationSignUpPageTextFieldsZhHans textFields =
-      _TranslationsAuthenticationSignUpPageTextFieldsZhHans._(_root);
-  @override
-  String get button => '注册';
+	// Translations
+	@override String get title => '注册';
+	@override late final _TranslationsAuthenticationSignUpPageTextFieldsZhHans textFields = _TranslationsAuthenticationSignUpPageTextFieldsZhHans._(_root);
+	@override String get button => '注册';
 }
 
 // Path: authentication.emailVerificationPage
-class _TranslationsAuthenticationEmailVerificationPageZhHans
-    implements TranslationsAuthenticationEmailVerificationPageEn {
-  _TranslationsAuthenticationEmailVerificationPageZhHans._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageZhHans implements TranslationsAuthenticationEmailVerificationPageEn {
+	_TranslationsAuthenticationEmailVerificationPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '邮箱地址验证';
-  @override
-  String descriptionForDestination({required Object email}) =>
-      '将向输入的${email}发送确认邮件。';
-  @override
-  String get descriptionForCoolDown => '确认邮件每60秒只能重新发送一次。';
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageButtonsZhHans
-      buttons =
-      _TranslationsAuthenticationEmailVerificationPageButtonsZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans
-      snackBar =
-      _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans._(_root);
+	// Translations
+	@override String get title => '邮箱地址验证';
+	@override String descriptionForDestination({required Object email}) => '将向输入的${email}发送确认邮件。';
+	@override String get descriptionForCoolDown => '确认邮件每60秒只能重新发送一次。';
+	@override late final _TranslationsAuthenticationEmailVerificationPageButtonsZhHans buttons = _TranslationsAuthenticationEmailVerificationPageButtonsZhHans._(_root);
+	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans snackBar = _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans._(_root);
 }
 
 // Path: authentication.registerProfilePage
-class _TranslationsAuthenticationRegisterProfilePageZhHans
-    implements TranslationsAuthenticationRegisterProfilePageEn {
-  _TranslationsAuthenticationRegisterProfilePageZhHans._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageZhHans implements TranslationsAuthenticationRegisterProfilePageEn {
+	_TranslationsAuthenticationRegisterProfilePageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '注册个人信息';
-  @override
-  String get textFields => '姓名';
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageButtonsZhHans
-      buttons =
-      _TranslationsAuthenticationRegisterProfilePageButtonsZhHans._(_root);
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageSnackBarZhHans
-      snackBar =
-      _TranslationsAuthenticationRegisterProfilePageSnackBarZhHans._(_root);
+	// Translations
+	@override String get title => '注册个人信息';
+	@override String get textFields => '姓名';
+	@override late final _TranslationsAuthenticationRegisterProfilePageButtonsZhHans buttons = _TranslationsAuthenticationRegisterProfilePageButtonsZhHans._(_root);
+	@override late final _TranslationsAuthenticationRegisterProfilePageSnackBarZhHans snackBar = _TranslationsAuthenticationRegisterProfilePageSnackBarZhHans._(_root);
 }
 
 // Path: authentication.completeSendEmailPage
-class _TranslationsAuthenticationCompleteSendEmailPageZhHans
-    implements TranslationsAuthenticationCompleteSendEmailPageEn {
-  _TranslationsAuthenticationCompleteSendEmailPageZhHans._(this._root);
+class _TranslationsAuthenticationCompleteSendEmailPageZhHans implements TranslationsAuthenticationCompleteSendEmailPageEn {
+	_TranslationsAuthenticationCompleteSendEmailPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '发送完成';
-  @override
-  String description({required Object email}) =>
-      '密码重置邮件已发送到${email} \n 重置后请从登录页面登录';
-  @override
-  String get successResendEmail => '确认邮件已重新发送';
-  @override
-  late final _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans
-      buttons =
-      _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans._(_root);
+	// Translations
+	@override String get title => '发送完成';
+	@override String description({required Object email}) => '密码重置邮件已发送到${email} \n 重置后请从登录页面登录';
+	@override String get successResendEmail => '确认邮件已重新发送';
+	@override late final _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans buttons = _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans._(_root);
 }
 
 // Path: myPage.accountStatus
-class _TranslationsMyPageAccountStatusZhHans
-    implements TranslationsMyPageAccountStatusEn {
-  _TranslationsMyPageAccountStatusZhHans._(this._root);
+class _TranslationsMyPageAccountStatusZhHans implements TranslationsMyPageAccountStatusEn {
+	_TranslationsMyPageAccountStatusZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsMyPageAccountStatusDateTimeZhHans dateTime =
-      _TranslationsMyPageAccountStatusDateTimeZhHans._(_root);
-  @override
-  String get premium => '高级会员';
-  @override
-  String get standard => '标准会员';
+	// Translations
+	@override late final _TranslationsMyPageAccountStatusDateTimeZhHans dateTime = _TranslationsMyPageAccountStatusDateTimeZhHans._(_root);
+	@override String get premium => '高级会员';
+	@override String get standard => '标准会员';
 }
 
 // Path: changeLanguagePage.items
-class _TranslationsChangeLanguagePageItemsZhHans
-    implements TranslationsChangeLanguagePageItemsEn {
-  _TranslationsChangeLanguagePageItemsZhHans._(this._root);
+class _TranslationsChangeLanguagePageItemsZhHans implements TranslationsChangeLanguagePageItemsEn {
+	_TranslationsChangeLanguagePageItemsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get japanese => '日本人';
-  @override
-  String get english => '英语';
-  @override
-  String get simplifiedChinese => '中文（简体）';
-  @override
-  String get traditionalChinese => '中文（繁体）';
+	// Translations
+	@override String get japanese => '日本人';
+	@override String get english => '英语';
+	@override String get simplifiedChinese => '中文（简体）';
+	@override String get traditionalChinese => '中文（繁体）';
 }
 
 // Path: changeThemePage.items
-class _TranslationsChangeThemePageItemsZhHans
-    implements TranslationsChangeThemePageItemsEn {
-  _TranslationsChangeThemePageItemsZhHans._(this._root);
+class _TranslationsChangeThemePageItemsZhHans implements TranslationsChangeThemePageItemsEn {
+	_TranslationsChangeThemePageItemsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get system => '系统';
-  @override
-  String get light => '光';
-  @override
-  String get dark => '暗处';
+	// Translations
+	@override String get system => '系统';
+	@override String get light => '光';
+	@override String get dark => '暗处';
 }
 
 // Path: myPlanPage.tabs
-class _TranslationsMyPlanPageTabsZhHans
-    implements TranslationsMyPlanPageTabsEn {
-  _TranslationsMyPlanPageTabsZhHans._(this._root);
+class _TranslationsMyPlanPageTabsZhHans implements TranslationsMyPlanPageTabsEn {
+	_TranslationsMyPlanPageTabsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get createdPlans => '已创建计划';
-  @override
-  String get bookmark => '书签';
+	// Translations
+	@override String get createdPlans => '已创建计划';
+	@override String get bookmark => '书签';
 }
 
 // Path: myPlanPage.bookmarkItems
-class _TranslationsMyPlanPageBookmarkItemsZhHans
-    implements TranslationsMyPlanPageBookmarkItemsEn {
-  _TranslationsMyPlanPageBookmarkItemsZhHans._(this._root);
+class _TranslationsMyPlanPageBookmarkItemsZhHans implements TranslationsMyPlanPageBookmarkItemsEn {
+	_TranslationsMyPlanPageBookmarkItemsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get nondata => '暂无收藏计划。';
-  @override
-  String get reloading => '重新加载';
+	// Translations
+	@override String get nondata => '暂无收藏计划。';
+	@override String get reloading => '重新加载';
 }
 
 // Path: myPlanPage.createdPlansItems
-class _TranslationsMyPlanPageCreatedPlansItemsZhHans
-    implements TranslationsMyPlanPageCreatedPlansItemsEn {
-  _TranslationsMyPlanPageCreatedPlansItemsZhHans._(this._root);
+class _TranslationsMyPlanPageCreatedPlansItemsZhHans implements TranslationsMyPlanPageCreatedPlansItemsEn {
+	_TranslationsMyPlanPageCreatedPlansItemsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get nondata => '开始创建计划吧！';
-  @override
-  String get createaplan => '创建计划';
+	// Translations
+	@override String get nondata => '开始创建计划吧！';
+	@override String get createaplan => '创建计划';
 }
 
 // Path: myPlanPage.error
-class _TranslationsMyPlanPageErrorZhHans
-    implements TranslationsMyPlanPageErrorEn {
-  _TranslationsMyPlanPageErrorZhHans._(this._root);
+class _TranslationsMyPlanPageErrorZhHans implements TranslationsMyPlanPageErrorEn {
+	_TranslationsMyPlanPageErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get displayError => '显示计划时出现错误。';
-  @override
-  String get failedGetId => '获取计划ID失败。';
-  @override
-  String get failedGetPlanData => '获取计划数据时出现错误。';
-  @override
-  String get failedUnBookmark => '取消收藏时出现错误。';
+	// Translations
+	@override String get displayError => '显示计划时出现错误。';
+	@override String get failedGetId => '获取计划ID失败。';
+	@override String get failedGetPlanData => '获取计划数据时出现错误。';
+	@override String get failedUnBookmark => '取消收藏时出现错误。';
 }
 
 // Path: buddyChatPage.textFields
-class _TranslationsBuddyChatPageTextFieldsZhHans
-    implements TranslationsBuddyChatPageTextFieldsEn {
-  _TranslationsBuddyChatPageTextFieldsZhHans._(this._root);
+class _TranslationsBuddyChatPageTextFieldsZhHans implements TranslationsBuddyChatPageTextFieldsEn {
+	_TranslationsBuddyChatPageTextFieldsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get message => '输入消息';
+	// Translations
+	@override String get message => '输入消息';
 }
 
 // Path: buddyChatPage.buttons
-class _TranslationsBuddyChatPageButtonsZhHans
-    implements TranslationsBuddyChatPageButtonsEn {
-  _TranslationsBuddyChatPageButtonsZhHans._(this._root);
+class _TranslationsBuddyChatPageButtonsZhHans implements TranslationsBuddyChatPageButtonsEn {
+	_TranslationsBuddyChatPageButtonsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get send => '完成';
+	// Translations
+	@override String get send => '完成';
 }
 
 // Path: buddyChatPage.placeCard
-class _TranslationsBuddyChatPagePlaceCardZhHans
-    implements TranslationsBuddyChatPagePlaceCardEn {
-  _TranslationsBuddyChatPagePlaceCardZhHans._(this._root);
+class _TranslationsBuddyChatPagePlaceCardZhHans implements TranslationsBuddyChatPagePlaceCardEn {
+	_TranslationsBuddyChatPagePlaceCardZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get openingHours => '营业时间';
-  @override
-  String get averageAmount => '平均预算';
-  @override
-  String get website => '网站';
+	// Translations
+	@override String get openingHours => '营业时间';
+	@override String get averageAmount => '平均预算';
+	@override String get website => '网站';
 }
 
 // Path: buddyChatPage.snackBar
-class _TranslationsBuddyChatPageSnackBarZhHans
-    implements TranslationsBuddyChatPageSnackBarEn {
-  _TranslationsBuddyChatPageSnackBarZhHans._(this._root);
+class _TranslationsBuddyChatPageSnackBarZhHans implements TranslationsBuddyChatPageSnackBarEn {
+	_TranslationsBuddyChatPageSnackBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBuddyChatPageSnackBarErrorZhHans error =
-      _TranslationsBuddyChatPageSnackBarErrorZhHans._(_root);
+	// Translations
+	@override late final _TranslationsBuddyChatPageSnackBarErrorZhHans error = _TranslationsBuddyChatPageSnackBarErrorZhHans._(_root);
 }
 
 // Path: createPlanPage.label
-class _TranslationsCreatePlanPageLabelZhHans
-    implements TranslationsCreatePlanPageLabelEn {
-  _TranslationsCreatePlanPageLabelZhHans._(this._root);
+class _TranslationsCreatePlanPageLabelZhHans implements TranslationsCreatePlanPageLabelEn {
+	_TranslationsCreatePlanPageLabelZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get location => '目的地';
-  @override
-  String get scheduleStart => '开始日期';
-  @override
-  String get scheduleEnd => '结束日期';
-  @override
-  String get numberOfPeople => '人数';
-  @override
-  String get transport => '交通方式';
-  @override
-  String get category => '类别';
-  @override
-  String get topics => '旅行主题';
+	// Translations
+	@override String get location => '目的地';
+	@override String get scheduleStart => '开始日期';
+	@override String get scheduleEnd => '结束日期';
+	@override String get numberOfPeople => '人数';
+	@override String get transport => '交通方式';
+	@override String get category => '类别';
+	@override String get topics => '旅行主题';
 }
 
 // Path: createPlanPage.hintText
-class _TranslationsCreatePlanPageHintTextZhHans
-    implements TranslationsCreatePlanPageHintTextEn {
-  _TranslationsCreatePlanPageHintTextZhHans._(this._root);
+class _TranslationsCreatePlanPageHintTextZhHans implements TranslationsCreatePlanPageHintTextEn {
+	_TranslationsCreatePlanPageHintTextZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get location => '涩谷';
+	// Translations
+	@override String get location => '涩谷';
 }
 
 // Path: createPlanPage.modal
-class _TranslationsCreatePlanPageModalZhHans
-    implements TranslationsCreatePlanPageModalEn {
-  _TranslationsCreatePlanPageModalZhHans._(this._root);
+class _TranslationsCreatePlanPageModalZhHans implements TranslationsCreatePlanPageModalEn {
+	_TranslationsCreatePlanPageModalZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '选择日期';
+	// Translations
+	@override String get title => '选择日期';
 }
 
 // Path: createPlanPage.snackBar
-class _TranslationsCreatePlanPageSnackBarZhHans
-    implements TranslationsCreatePlanPageSnackBarEn {
-  _TranslationsCreatePlanPageSnackBarZhHans._(this._root);
+class _TranslationsCreatePlanPageSnackBarZhHans implements TranslationsCreatePlanPageSnackBarEn {
+	_TranslationsCreatePlanPageSnackBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsCreatePlanPageSnackBarErrorZhHans error =
-      _TranslationsCreatePlanPageSnackBarErrorZhHans._(_root);
+	// Translations
+	@override late final _TranslationsCreatePlanPageSnackBarErrorZhHans error = _TranslationsCreatePlanPageSnackBarErrorZhHans._(_root);
 }
 
 // Path: editProfilePage.textFields
-class _TranslationsEditProfilePageTextFieldsZhHans
-    implements TranslationsEditProfilePageTextFieldsEn {
-  _TranslationsEditProfilePageTextFieldsZhHans._(this._root);
+class _TranslationsEditProfilePageTextFieldsZhHans implements TranslationsEditProfilePageTextFieldsEn {
+	_TranslationsEditProfilePageTextFieldsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get name => '姓名';
+	// Translations
+	@override String get name => '姓名';
 }
 
 // Path: editProfilePage.buttons
-class _TranslationsEditProfilePageButtonsZhHans
-    implements TranslationsEditProfilePageButtonsEn {
-  _TranslationsEditProfilePageButtonsZhHans._(this._root);
+class _TranslationsEditProfilePageButtonsZhHans implements TranslationsEditProfilePageButtonsEn {
+	_TranslationsEditProfilePageButtonsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '保存';
+	// Translations
+	@override String get submit => '保存';
 }
 
 // Path: editProfilePage.snackBar
-class _TranslationsEditProfilePageSnackBarZhHans
-    implements TranslationsEditProfilePageSnackBarEn {
-  _TranslationsEditProfilePageSnackBarZhHans._(this._root);
+class _TranslationsEditProfilePageSnackBarZhHans implements TranslationsEditProfilePageSnackBarEn {
+	_TranslationsEditProfilePageSnackBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get success => '更新成功';
-  @override
-  late final _TranslationsEditProfilePageSnackBarErrorZhHans error =
-      _TranslationsEditProfilePageSnackBarErrorZhHans._(_root);
+	// Translations
+	@override String get success => '更新成功';
+	@override late final _TranslationsEditProfilePageSnackBarErrorZhHans error = _TranslationsEditProfilePageSnackBarErrorZhHans._(_root);
 }
 
 // Path: confirmDialog.answers
-class _TranslationsConfirmDialogAnswersZhHans
-    implements TranslationsConfirmDialogAnswersEn {
-  _TranslationsConfirmDialogAnswersZhHans._(this._root);
+class _TranslationsConfirmDialogAnswersZhHans implements TranslationsConfirmDialogAnswersEn {
+	_TranslationsConfirmDialogAnswersZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get yes => '是';
-  @override
-  String get no => '否';
+	// Translations
+	@override String get yes => '是';
+	@override String get no => '否';
 }
 
 // Path: confirmDialog.popPage
-class _TranslationsConfirmDialogPopPageZhHans
-    implements TranslationsConfirmDialogPopPageEn {
-  _TranslationsConfirmDialogPopPageZhHans._(this._root);
+class _TranslationsConfirmDialogPopPageZhHans implements TranslationsConfirmDialogPopPageEn {
+	_TranslationsConfirmDialogPopPageZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '要返回上一页吗？';
-  @override
-  String get description => '当前内容不会被保存';
+	// Translations
+	@override String get title => '要返回上一页吗？';
+	@override String get description => '当前内容不会被保存';
 }
 
 // Path: confirmDialog.completeCreatePlan
-class _TranslationsConfirmDialogCompleteCreatePlanZhHans
-    implements TranslationsConfirmDialogCompleteCreatePlanEn {
-  _TranslationsConfirmDialogCompleteCreatePlanZhHans._(this._root);
+class _TranslationsConfirmDialogCompleteCreatePlanZhHans implements TranslationsConfirmDialogCompleteCreatePlanEn {
+	_TranslationsConfirmDialogCompleteCreatePlanZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '确定要保存计划吗？';
-  @override
-  String get description => '最后一条消息中的计划将被保存';
+	// Translations
+	@override String get title => '确定要保存计划吗？';
+	@override String get description => '最后一条消息中的计划将被保存';
 }
 
 // Path: billDetailsPage.pricingPlan
-class _TranslationsBillDetailsPagePricingPlanZhHans
-    implements TranslationsBillDetailsPagePricingPlanEn {
-  _TranslationsBillDetailsPagePricingPlanZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingPlanZhHans implements TranslationsBillDetailsPagePricingPlanEn {
+	_TranslationsBillDetailsPagePricingPlanZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '价格计划';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanColumnsZhHans columns =
-      _TranslationsBillDetailsPagePricingPlanColumnsZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanDetailsZhHans details =
-      _TranslationsBillDetailsPagePricingPlanDetailsZhHans._(_root);
+	// Translations
+	@override String get title => '价格计划';
+	@override late final _TranslationsBillDetailsPagePricingPlanColumnsZhHans columns = _TranslationsBillDetailsPagePricingPlanColumnsZhHans._(_root);
+	@override late final _TranslationsBillDetailsPagePricingPlanDetailsZhHans details = _TranslationsBillDetailsPagePricingPlanDetailsZhHans._(_root);
 }
 
 // Path: billDetailsPage.features
-class _TranslationsBillDetailsPageFeaturesZhHans
-    implements TranslationsBillDetailsPageFeaturesEn {
-  _TranslationsBillDetailsPageFeaturesZhHans._(this._root);
+class _TranslationsBillDetailsPageFeaturesZhHans implements TranslationsBillDetailsPageFeaturesEn {
+	_TranslationsBillDetailsPageFeaturesZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '等级功能';
-  @override
-  late final _TranslationsBillDetailsPageFeaturesRowsZhHans rows =
-      _TranslationsBillDetailsPageFeaturesRowsZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsZhHans columns =
-      _TranslationsBillDetailsPageFeaturesColumnsZhHans._(_root);
+	// Translations
+	@override String get title => '等级功能';
+	@override late final _TranslationsBillDetailsPageFeaturesRowsZhHans rows = _TranslationsBillDetailsPageFeaturesRowsZhHans._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsZhHans columns = _TranslationsBillDetailsPageFeaturesColumnsZhHans._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions
-class _TranslationsBillDetailsPagePricingOptionsZhHans
-    implements TranslationsBillDetailsPagePricingOptionsEn {
-  _TranslationsBillDetailsPagePricingOptionsZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsZhHans implements TranslationsBillDetailsPagePricingOptionsEn {
+	_TranslationsBillDetailsPagePricingOptionsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsOneDayZhHans oneDay =
-      _TranslationsBillDetailsPagePricingOptionsOneDayZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans
-      threeDays =
-      _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans fiveDays =
-      _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans
-      sevenDays =
-      _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsLifetimeZhHans lifetime =
-      _TranslationsBillDetailsPagePricingOptionsLifetimeZhHans._(_root);
+	// Translations
+	@override late final _TranslationsBillDetailsPagePricingOptionsOneDayZhHans oneDay = _TranslationsBillDetailsPagePricingOptionsOneDayZhHans._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans threeDays = _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans fiveDays = _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans sevenDays = _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsLifetimeZhHans lifetime = _TranslationsBillDetailsPagePricingOptionsLifetimeZhHans._(_root);
 }
 
 // Path: planDetailsPage.dateTime
-class _TranslationsPlanDetailsPageDateTimeZhHans
-    implements TranslationsPlanDetailsPageDateTimeEn {
-  _TranslationsPlanDetailsPageDateTimeZhHans._(this._root);
+class _TranslationsPlanDetailsPageDateTimeZhHans implements TranslationsPlanDetailsPageDateTimeEn {
+	_TranslationsPlanDetailsPageDateTimeZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String createOn({required Object date}) => '${date}创建的计划';
-  @override
-  String get dateFormat => 'yyyy年MM月dd日';
+	// Translations
+	@override String createOn({required Object date}) => '${date}创建的计划';
+	@override String get dateFormat => 'yyyy年MM月dd日';
 }
 
 // Path: planDetailsPage.item
-class _TranslationsPlanDetailsPageItemZhHans
-    implements TranslationsPlanDetailsPageItemEn {
-  _TranslationsPlanDetailsPageItemZhHans._(this._root);
+class _TranslationsPlanDetailsPageItemZhHans implements TranslationsPlanDetailsPageItemEn {
+	_TranslationsPlanDetailsPageItemZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get viewOnMap => '在地图上查看';
+	// Translations
+	@override String get viewOnMap => '在地图上查看';
 }
 
 // Path: planDetailsPage.snackBar
-class _TranslationsPlanDetailsPageSnackBarZhHans
-    implements TranslationsPlanDetailsPageSnackBarEn {
-  _TranslationsPlanDetailsPageSnackBarZhHans._(this._root);
+class _TranslationsPlanDetailsPageSnackBarZhHans implements TranslationsPlanDetailsPageSnackBarEn {
+	_TranslationsPlanDetailsPageSnackBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsPlanDetailsPageSnackBarErrorZhHans error =
-      _TranslationsPlanDetailsPageSnackBarErrorZhHans._(_root);
+	// Translations
+	@override late final _TranslationsPlanDetailsPageSnackBarErrorZhHans error = _TranslationsPlanDetailsPageSnackBarErrorZhHans._(_root);
 }
 
 // Path: authentication.signInPage.textFields
-class _TranslationsAuthenticationSignInPageTextFieldsZhHans
-    implements TranslationsAuthenticationSignInPageTextFieldsEn {
-  _TranslationsAuthenticationSignInPageTextFieldsZhHans._(this._root);
+class _TranslationsAuthenticationSignInPageTextFieldsZhHans implements TranslationsAuthenticationSignInPageTextFieldsEn {
+	_TranslationsAuthenticationSignInPageTextFieldsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => '电子邮件地址';
-  @override
-  String get password => '密码';
+	// Translations
+	@override String get email => '电子邮件地址';
+	@override String get password => '密码';
 }
 
 // Path: authentication.signInPage.buttons
-class _TranslationsAuthenticationSignInPageButtonsZhHans
-    implements TranslationsAuthenticationSignInPageButtonsEn {
-  _TranslationsAuthenticationSignInPageButtonsZhHans._(this._root);
+class _TranslationsAuthenticationSignInPageButtonsZhHans implements TranslationsAuthenticationSignInPageButtonsEn {
+	_TranslationsAuthenticationSignInPageButtonsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signIn => '登录';
-  @override
-  String get signUp => '注册';
-  @override
-  String get resetPassword => '忘记密码？';
-  @override
-  String get appleSignIn => '使用Apple登录';
-  @override
-  String get googleSignIn => '使用Google登录';
-  @override
-  String get signInAfter => '稍后注册';
+	// Translations
+	@override String get signIn => '登录';
+	@override String get signUp => '注册';
+	@override String get resetPassword => '忘记密码？';
+	@override String get appleSignIn => '使用Apple登录';
+	@override String get googleSignIn => '使用Google登录';
+	@override String get signInAfter => '稍后注册';
 }
 
 // Path: authentication.firebaseAuth.error
-class _TranslationsAuthenticationFirebaseAuthErrorZhHans
-    implements TranslationsAuthenticationFirebaseAuthErrorEn {
-  _TranslationsAuthenticationFirebaseAuthErrorZhHans._(this._root);
+class _TranslationsAuthenticationFirebaseAuthErrorZhHans implements TranslationsAuthenticationFirebaseAuthErrorEn {
+	_TranslationsAuthenticationFirebaseAuthErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get networkRequestFailed => '请在良好的网络环境中重试';
-  @override
-  String get weakPassword => '密码太短。请输入6个字符或更多';
-  @override
-  String get invalidEmail => '电子邮件地址格式不正确';
-  @override
-  String get userNotFound => '找不到帐户';
-  @override
-  String get wrongPassword => '密码错误';
-  @override
-  String get emailAlreadyInUse => '电子邮件地址已在使用中。请使用其他电子邮件地址登录或创建';
-  @override
-  String get unexpected => '发生错误。请在良好的网络环境中重试';
+	// Translations
+	@override String get networkRequestFailed => '请在良好的网络环境中重试';
+	@override String get weakPassword => '密码太短。请输入6个字符或更多';
+	@override String get invalidEmail => '电子邮件地址格式不正确';
+	@override String get userNotFound => '找不到帐户';
+	@override String get wrongPassword => '密码错误';
+	@override String get emailAlreadyInUse => '电子邮件地址已在使用中。请使用其他电子邮件地址登录或创建';
+	@override String get unexpected => '发生错误。请在良好的网络环境中重试';
 }
 
 // Path: authentication.resetPasswordPage.textFields
-class _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans
-    implements TranslationsAuthenticationResetPasswordPageTextFieldsEn {
-  _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans._(this._root);
+class _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans implements TranslationsAuthenticationResetPasswordPageTextFieldsEn {
+	_TranslationsAuthenticationResetPasswordPageTextFieldsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => '电子邮件地址';
+	// Translations
+	@override String get email => '电子邮件地址';
 }
 
 // Path: authentication.resetPasswordPage.buttons
-class _TranslationsAuthenticationResetPasswordPageButtonsZhHans
-    implements TranslationsAuthenticationResetPasswordPageButtonsEn {
-  _TranslationsAuthenticationResetPasswordPageButtonsZhHans._(this._root);
+class _TranslationsAuthenticationResetPasswordPageButtonsZhHans implements TranslationsAuthenticationResetPasswordPageButtonsEn {
+	_TranslationsAuthenticationResetPasswordPageButtonsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '发送';
+	// Translations
+	@override String get submit => '发送';
 }
 
 // Path: authentication.signUpPage.textFields
-class _TranslationsAuthenticationSignUpPageTextFieldsZhHans
-    implements TranslationsAuthenticationSignUpPageTextFieldsEn {
-  _TranslationsAuthenticationSignUpPageTextFieldsZhHans._(this._root);
+class _TranslationsAuthenticationSignUpPageTextFieldsZhHans implements TranslationsAuthenticationSignUpPageTextFieldsEn {
+	_TranslationsAuthenticationSignUpPageTextFieldsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => '邮箱地址';
-  @override
-  String get password => '密码';
+	// Translations
+	@override String get email => '邮箱地址';
+	@override String get password => '密码';
 }
 
 // Path: authentication.emailVerificationPage.buttons
-class _TranslationsAuthenticationEmailVerificationPageButtonsZhHans
-    implements TranslationsAuthenticationEmailVerificationPageButtonsEn {
-  _TranslationsAuthenticationEmailVerificationPageButtonsZhHans._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageButtonsZhHans implements TranslationsAuthenticationEmailVerificationPageButtonsEn {
+	_TranslationsAuthenticationEmailVerificationPageButtonsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get sendEmail => '发送确认邮件';
-  @override
-  String get resendEmail => '重新发送确认邮件';
-  @override
-  String get toNext => '下一步';
-  @override
-  String get retypeEmail => '修改邮箱地址';
+	// Translations
+	@override String get sendEmail => '发送确认邮件';
+	@override String get resendEmail => '重新发送确认邮件';
+	@override String get toNext => '下一步';
+	@override String get retypeEmail => '修改邮箱地址';
 }
 
 // Path: authentication.emailVerificationPage.snackBar
-class _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans
-    implements TranslationsAuthenticationEmailVerificationPageSnackBarEn {
-  _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans implements TranslationsAuthenticationEmailVerificationPageSnackBarEn {
+	_TranslationsAuthenticationEmailVerificationPageSnackBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get success => '发送成功';
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans
-      error =
-      _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans._(
-          _root);
+	// Translations
+	@override String get success => '发送成功';
+	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans error = _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans._(_root);
 }
 
 // Path: authentication.registerProfilePage.buttons
-class _TranslationsAuthenticationRegisterProfilePageButtonsZhHans
-    implements TranslationsAuthenticationRegisterProfilePageButtonsEn {
-  _TranslationsAuthenticationRegisterProfilePageButtonsZhHans._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageButtonsZhHans implements TranslationsAuthenticationRegisterProfilePageButtonsEn {
+	_TranslationsAuthenticationRegisterProfilePageButtonsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '完成';
-  @override
-  String get skip => '跳过';
+	// Translations
+	@override String get submit => '完成';
+	@override String get skip => '跳过';
 }
 
 // Path: authentication.registerProfilePage.snackBar
-class _TranslationsAuthenticationRegisterProfilePageSnackBarZhHans
-    implements TranslationsAuthenticationRegisterProfilePageSnackBarEn {
-  _TranslationsAuthenticationRegisterProfilePageSnackBarZhHans._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageSnackBarZhHans implements TranslationsAuthenticationRegisterProfilePageSnackBarEn {
+	_TranslationsAuthenticationRegisterProfilePageSnackBarZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans
-      error =
-      _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans._(
-          _root);
+	// Translations
+	@override late final _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans error = _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans._(_root);
 }
 
 // Path: authentication.completeSendEmailPage.buttons
-class _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans
-    implements TranslationsAuthenticationCompleteSendEmailPageButtonsEn {
-  _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans._(this._root);
+class _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans implements TranslationsAuthenticationCompleteSendEmailPageButtonsEn {
+	_TranslationsAuthenticationCompleteSendEmailPageButtonsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get toSignIn => '前往登录页面';
-  @override
-  String get resendEmail => '重新发送确认邮件';
-  @override
-  String get changeEmail => '更改电子邮件地址';
+	// Translations
+	@override String get toSignIn => '前往登录页面';
+	@override String get resendEmail => '重新发送确认邮件';
+	@override String get changeEmail => '更改电子邮件地址';
 }
 
 // Path: myPage.accountStatus.dateTime
-class _TranslationsMyPageAccountStatusDateTimeZhHans
-    implements TranslationsMyPageAccountStatusDateTimeEn {
-  _TranslationsMyPageAccountStatusDateTimeZhHans._(this._root);
+class _TranslationsMyPageAccountStatusDateTimeZhHans implements TranslationsMyPageAccountStatusDateTimeEn {
+	_TranslationsMyPageAccountStatusDateTimeZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String registeredOn({required Object date}) => '${date}注册于';
-  @override
-  String get registeredOnFormat => 'yyyy年MM月dd日';
-  @override
-  String validUntil({required Object date}) => '有效期至${date}';
-  @override
-  String get validUntilFormat => 'yyyy年MM月dd日 HH:mm';
+	// Translations
+	@override String registeredOn({required Object date}) => '${date}注册于';
+	@override String get registeredOnFormat => 'yyyy年MM月dd日';
+	@override String validUntil({required Object date}) => '有效期至${date}';
+	@override String get validUntilFormat => 'yyyy年MM月dd日 HH:mm';
 }
 
 // Path: buddyChatPage.snackBar.error
-class _TranslationsBuddyChatPageSnackBarErrorZhHans
-    implements TranslationsBuddyChatPageSnackBarErrorEn {
-  _TranslationsBuddyChatPageSnackBarErrorZhHans._(this._root);
+class _TranslationsBuddyChatPageSnackBarErrorZhHans implements TranslationsBuddyChatPageSnackBarErrorEn {
+	_TranslationsBuddyChatPageSnackBarErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get failedRecieveMessage => '未能接收回复，请稍后再试';
-  @override
-  String get failedCompleteCreatePlan => '未能完成创建计划，请稍后再试';
+	// Translations
+	@override String get failedRecieveMessage => '未能接收回复，请稍后再试';
+	@override String get failedCompleteCreatePlan => '未能完成创建计划，请稍后再试';
 }
 
 // Path: createPlanPage.snackBar.error
-class _TranslationsCreatePlanPageSnackBarErrorZhHans
-    implements TranslationsCreatePlanPageSnackBarErrorEn {
-  _TranslationsCreatePlanPageSnackBarErrorZhHans._(this._root);
+class _TranslationsCreatePlanPageSnackBarErrorZhHans implements TranslationsCreatePlanPageSnackBarErrorEn {
+	_TranslationsCreatePlanPageSnackBarErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get foundUnSelectedField => '存在未选择的项目，请选择所有项目';
+	// Translations
+	@override String get foundUnSelectedField => '存在未选择的项目，请选择所有项目';
 }
 
 // Path: editProfilePage.snackBar.error
-class _TranslationsEditProfilePageSnackBarErrorZhHans
-    implements TranslationsEditProfilePageSnackBarErrorEn {
-  _TranslationsEditProfilePageSnackBarErrorZhHans._(this._root);
+class _TranslationsEditProfilePageSnackBarErrorZhHans implements TranslationsEditProfilePageSnackBarErrorEn {
+	_TranslationsEditProfilePageSnackBarErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get noChange => '没有更改';
-  @override
-  String get failedToUpdate => '更新失败，请稍后再试';
-  @override
-  String get failedToPickImage => '选择图片失败，请稍后再试';
+	// Translations
+	@override String get noChange => '没有更改';
+	@override String get failedToUpdate => '更新失败，请稍后再试';
+	@override String get failedToPickImage => '选择图片失败，请稍后再试';
 }
 
 // Path: billDetailsPage.pricingPlan.columns
-class _TranslationsBillDetailsPagePricingPlanColumnsZhHans
-    implements TranslationsBillDetailsPagePricingPlanColumnsEn {
-  _TranslationsBillDetailsPagePricingPlanColumnsZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingPlanColumnsZhHans implements TranslationsBillDetailsPagePricingPlanColumnsEn {
+	_TranslationsBillDetailsPagePricingPlanColumnsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get standard => '标准';
-  @override
-  String get premium => '高级';
+	// Translations
+	@override String get standard => '标准';
+	@override String get premium => '高级';
 }
 
 // Path: billDetailsPage.pricingPlan.details
-class _TranslationsBillDetailsPagePricingPlanDetailsZhHans
-    implements TranslationsBillDetailsPagePricingPlanDetailsEn {
-  _TranslationsBillDetailsPagePricingPlanDetailsZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingPlanDetailsZhHans implements TranslationsBillDetailsPagePricingPlanDetailsEn {
+	_TranslationsBillDetailsPagePricingPlanDetailsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get free => '免费 🎉';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans
-      premiumPrice =
-      _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans._(_root);
+	// Translations
+	@override String get free => '免费 🎉';
+	@override late final _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans premiumPrice = _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans._(_root);
 }
 
 // Path: billDetailsPage.features.rows
-class _TranslationsBillDetailsPageFeaturesRowsZhHans
-    implements TranslationsBillDetailsPageFeaturesRowsEn {
-  _TranslationsBillDetailsPageFeaturesRowsZhHans._(this._root);
+class _TranslationsBillDetailsPageFeaturesRowsZhHans implements TranslationsBillDetailsPageFeaturesRowsEn {
+	_TranslationsBillDetailsPageFeaturesRowsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get planCreationLimit => '可创建的计划次数';
-  @override
-  String get chatLimit => '计划创建期间可用聊天次数';
-  @override
-  String get timelineAccess => '访问所有计划时间线';
-  @override
-  String get adFree => '无广告';
-  @override
-  String get exclusiveFeatures => '计划认证功能';
+	// Translations
+	@override String get planCreationLimit => '可创建的计划次数';
+	@override String get chatLimit => '计划创建期间可用聊天次数';
+	@override String get timelineAccess => '访问所有计划时间线';
+	@override String get adFree => '无广告';
+	@override String get exclusiveFeatures => '计划认证功能';
 }
 
 // Path: billDetailsPage.features.columns
-class _TranslationsBillDetailsPageFeaturesColumnsZhHans
-    implements TranslationsBillDetailsPageFeaturesColumnsEn {
-  _TranslationsBillDetailsPageFeaturesColumnsZhHans._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsZhHans implements TranslationsBillDetailsPageFeaturesColumnsEn {
+	_TranslationsBillDetailsPageFeaturesColumnsZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsStandardZhHans
-      standard =
-      _TranslationsBillDetailsPageFeaturesColumnsStandardZhHans._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans premium =
-      _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans._(_root);
+	// Translations
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsStandardZhHans standard = _TranslationsBillDetailsPageFeaturesColumnsStandardZhHans._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans premium = _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions.oneDay
-class _TranslationsBillDetailsPagePricingOptionsOneDayZhHans
-    implements TranslationsBillDetailsPagePricingOptionsOneDayEn {
-  _TranslationsBillDetailsPagePricingOptionsOneDayZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsOneDayZhHans implements TranslationsBillDetailsPagePricingOptionsOneDayEn {
+	_TranslationsBillDetailsPagePricingOptionsOneDayZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '1日';
-  @override
-  String get discount => '';
-  @override
-  String get price => '300日元';
+	// Translations
+	@override String get duration => '1日';
+	@override String get discount => '';
+	@override String get price => '300日元';
 }
 
 // Path: billDetailsPage.pricingOptions.threeDays
-class _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans
-    implements TranslationsBillDetailsPagePricingOptionsThreeDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans implements TranslationsBillDetailsPagePricingOptionsThreeDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsThreeDaysZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '3日';
-  @override
-  String get discount => '-5%';
-  @override
-  String get price => '890日元';
+	// Translations
+	@override String get duration => '3日';
+	@override String get discount => '-5%';
+	@override String get price => '890日元';
 }
 
 // Path: billDetailsPage.pricingOptions.fiveDays
-class _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans
-    implements TranslationsBillDetailsPagePricingOptionsFiveDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans implements TranslationsBillDetailsPagePricingOptionsFiveDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsFiveDaysZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '5日';
-  @override
-  String get discount => '-7.5%';
-  @override
-  String get price => '1,387日元';
+	// Translations
+	@override String get duration => '5日';
+	@override String get discount => '-7.5%';
+	@override String get price => '1,387日元';
 }
 
 // Path: billDetailsPage.pricingOptions.sevenDays
-class _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans
-    implements TranslationsBillDetailsPagePricingOptionsSevenDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans implements TranslationsBillDetailsPagePricingOptionsSevenDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsSevenDaysZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '7日';
-  @override
-  String get discount => '-10%';
-  @override
-  String get price => '2,070日元';
+	// Translations
+	@override String get duration => '7日';
+	@override String get discount => '-10%';
+	@override String get price => '2,070日元';
 }
 
 // Path: billDetailsPage.pricingOptions.lifetime
-class _TranslationsBillDetailsPagePricingOptionsLifetimeZhHans
-    implements TranslationsBillDetailsPagePricingOptionsLifetimeEn {
-  _TranslationsBillDetailsPagePricingOptionsLifetimeZhHans._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsLifetimeZhHans implements TranslationsBillDetailsPagePricingOptionsLifetimeEn {
+	_TranslationsBillDetailsPagePricingOptionsLifetimeZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '终身';
-  @override
-  String get discount => '';
-  @override
-  String get price => '25,800日元';
+	// Translations
+	@override String get duration => '终身';
+	@override String get discount => '';
+	@override String get price => '25,800日元';
 }
 
 // Path: planDetailsPage.snackBar.error
-class _TranslationsPlanDetailsPageSnackBarErrorZhHans
-    implements TranslationsPlanDetailsPageSnackBarErrorEn {
-  _TranslationsPlanDetailsPageSnackBarErrorZhHans._(this._root);
+class _TranslationsPlanDetailsPageSnackBarErrorZhHans implements TranslationsPlanDetailsPageSnackBarErrorEn {
+	_TranslationsPlanDetailsPageSnackBarErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get failedToUpdateBookmark => '更新书签失败，请稍后再试';
+	// Translations
+	@override String get failedToUpdateBookmark => '更新书签失败，请稍后再试';
 }
 
 // Path: authentication.emailVerificationPage.snackBar.error
-class _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans
-    implements TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn {
-  _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans._(
-      this._root);
+class _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans implements TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn {
+	_TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get unexpected => '发生错误，请稍后再试。';
+	// Translations
+	@override String get unexpected => '发生错误，请稍后再试。';
 }
 
 // Path: authentication.registerProfilePage.snackBar.error
-class _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans
-    implements TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn {
-  _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans._(
-      this._root);
+class _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans implements TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn {
+	_TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submitIfAllEmpty => '请输入信息';
-  @override
-  String get unexpected => '发生错误，请稍后再试。';
+	// Translations
+	@override String get submitIfAllEmpty => '请输入信息';
+	@override String get unexpected => '发生错误，请稍后再试。';
 }
 
 // Path: billDetailsPage.pricingPlan.details.premiumPrice
-class _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans
-    implements TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn {
-  _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans._(
-      this._root);
+class _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans implements TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn {
+	_TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get days => '按天数购买';
-  @override
-  String get daily => '・1日 300日元';
-  @override
-  String get threeDays => '・3日 855日元';
-  @override
-  String get fiveDays => '・5日 1,480日元';
-  @override
-  String get sevenDays => '・7日 2,070日元';
-  @override
-  String get or => '或者';
-  @override
-  String get lifetime => '终身';
-  @override
-  String get lifetimePrice => '25,800日元';
+	// Translations
+	@override String get days => '按天数购买';
+	@override String get daily => '・1日 300日元';
+	@override String get threeDays => '・3日 855日元';
+	@override String get fiveDays => '・5日 1,480日元';
+	@override String get sevenDays => '・7日 2,070日元';
+	@override String get or => '或者';
+	@override String get lifetime => '终身';
+	@override String get lifetimePrice => '25,800日元';
 }
 
 // Path: billDetailsPage.features.columns.standard
-class _TranslationsBillDetailsPageFeaturesColumnsStandardZhHans
-    implements TranslationsBillDetailsPageFeaturesColumnsStandardEn {
-  _TranslationsBillDetailsPageFeaturesColumnsStandardZhHans._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsStandardZhHans implements TranslationsBillDetailsPageFeaturesColumnsStandardEn {
+	_TranslationsBillDetailsPageFeaturesColumnsStandardZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get label => '标准';
-  @override
-  String get planCreationLimit => '2次';
-  @override
-  String get chatLimit => '3次';
+	// Translations
+	@override String get label => '标准';
+	@override String get planCreationLimit => '2次';
+	@override String get chatLimit => '3次';
 }
 
 // Path: billDetailsPage.features.columns.premium
-class _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans
-    implements TranslationsBillDetailsPageFeaturesColumnsPremiumEn {
-  _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans implements TranslationsBillDetailsPageFeaturesColumnsPremiumEn {
+	_TranslationsBillDetailsPageFeaturesColumnsPremiumZhHans._(this._root);
 
-  final TranslationsZhHans _root; // ignore: unused_field
+	final TranslationsZhHans _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get label => '高级';
-  @override
-  String get planCreationLimit => '无限制';
-  @override
-  String get chatLimit => '无限制';
+	// Translations
+	@override String get label => '高级';
+	@override String get planCreationLimit => '无限制';
+	@override String get chatLimit => '无限制';
 }
 
 /// Flat map(s) containing all translations.
 /// Only for edge cases! For simple maps, use the map function of this library.
 extension on TranslationsZhHans {
-  dynamic _flatMapFunction(String path) {
-    switch (path) {
-      case 'navigationBar.items.home':
-        return '首页';
-      case 'navigationBar.items.myPlan':
-        return '我的计划';
-      case 'navigationBar.items.myPage':
-        return '我的页面';
-      case 'homePage.popularPlans.title':
-        return '热门计划';
-      case 'homePage.popularTopics.title':
-        return '热门话题';
-      case 'homePage.popularTopics.numberOfTopics':
-        return ({required Object number}) => '${number}件~';
-      case 'homePage.recentPlans.title':
-        return '最近创建的计划';
-      case 'accountPage.title':
-        return '账户';
-      case 'accountPage.items.signOut':
-        return '退出登录';
-      case 'accountPage.items.linkedWithGoogle':
-        return '与Google连接';
-      case 'accountPage.items.linkedWithApple':
-        return '与Apple连接';
-      case 'accountPage.items.alreadyLinkedGoogle':
-        return '已与Google连接';
-      case 'accountPage.items.alreadyLinkedApple':
-        return '已与Apple连接';
-      case 'accountPage.snackBar.signOut':
-        return '已成功退出登录。';
-      case 'accountPage.snackBar.signOutFailure':
-        return '退出登录时发生错误。';
-      case 'accountPage.snackBar.successfulLinkage':
-        return '账户关联成功。';
-      case 'accountPage.snackBar.linkageFailure':
-        return '账户关联失败。';
-      case 'accountPage.snackBar.providerAlreadyLinked':
-        return '此账户已经关联。';
-      case 'accountPage.snackBar.accountDeactivation':
-        return '已解除账户关联。';
-      case 'accountPage.snackBar.invalidCredential':
-        return '请重新登录。';
-      case 'accountPage.snackBar.linkageCancelled':
-        return '账户关联已取消。';
-      case 'accountPage.snackBar.unlinkageFailure':
-        return '解除账户关联失败。';
-      case 'accountPage.snackBar.operationNotAllowed':
-        return '提供者无效。请联系开发者。';
-      case 'accountPage.snackBar.unknownError':
-        return '发生未知错误。';
-      case 'accountPage.diaLog.yes':
-        return '是';
-      case 'accountPage.diaLog.no':
-        return '否';
-      case 'accountPage.diaLog.title':
-        return '确认解除账户连接';
-      case 'accountPage.diaLog.googleText':
-        return '是否要解除当前账户与Google账户的连接？';
-      case 'accountPage.diaLog.appleText':
-        return '是否要解除当前账户与Apple账户的连接？';
-      case 'authentication.signInPage.title':
-        return '登录';
-      case 'authentication.signInPage.optionText':
-        return ' 或 ';
-      case 'authentication.signInPage.textFields.email':
-        return '电子邮件地址';
-      case 'authentication.signInPage.textFields.password':
-        return '密码';
-      case 'authentication.signInPage.buttons.signIn':
-        return '登录';
-      case 'authentication.signInPage.buttons.signUp':
-        return '注册';
-      case 'authentication.signInPage.buttons.resetPassword':
-        return '忘记密码？';
-      case 'authentication.signInPage.buttons.appleSignIn':
-        return '使用Apple登录';
-      case 'authentication.signInPage.buttons.googleSignIn':
-        return '使用Google登录';
-      case 'authentication.signInPage.buttons.signInAfter':
-        return '稍后注册';
-      case 'authentication.firebaseAuth.error.networkRequestFailed':
-        return '请在良好的网络环境中重试';
-      case 'authentication.firebaseAuth.error.weakPassword':
-        return '密码太短。请输入6个字符或更多';
-      case 'authentication.firebaseAuth.error.invalidEmail':
-        return '电子邮件地址格式不正确';
-      case 'authentication.firebaseAuth.error.userNotFound':
-        return '找不到帐户';
-      case 'authentication.firebaseAuth.error.wrongPassword':
-        return '密码错误';
-      case 'authentication.firebaseAuth.error.emailAlreadyInUse':
-        return '电子邮件地址已在使用中。请使用其他电子邮件地址登录或创建';
-      case 'authentication.firebaseAuth.error.unexpected':
-        return '发生错误。请在良好的网络环境中重试';
-      case 'authentication.resetPasswordPage.title':
-        return '重置密码';
-      case 'authentication.resetPasswordPage.description':
-        return '将向输入的电子邮件地址发送密码重置邮件';
-      case 'authentication.resetPasswordPage.textFields.email':
-        return '电子邮件地址';
-      case 'authentication.resetPasswordPage.buttons.submit':
-        return '发送';
-      case 'authentication.signUpPage.title':
-        return '注册';
-      case 'authentication.signUpPage.textFields.email':
-        return '邮箱地址';
-      case 'authentication.signUpPage.textFields.password':
-        return '密码';
-      case 'authentication.signUpPage.button':
-        return '注册';
-      case 'authentication.emailVerificationPage.title':
-        return '邮箱地址验证';
-      case 'authentication.emailVerificationPage.descriptionForDestination':
-        return ({required Object email}) => '将向输入的${email}发送确认邮件。';
-      case 'authentication.emailVerificationPage.descriptionForCoolDown':
-        return '确认邮件每60秒只能重新发送一次。';
-      case 'authentication.emailVerificationPage.buttons.sendEmail':
-        return '发送确认邮件';
-      case 'authentication.emailVerificationPage.buttons.resendEmail':
-        return '重新发送确认邮件';
-      case 'authentication.emailVerificationPage.buttons.toNext':
-        return '下一步';
-      case 'authentication.emailVerificationPage.buttons.retypeEmail':
-        return '修改邮箱地址';
-      case 'authentication.emailVerificationPage.snackBar.success':
-        return '发送成功';
-      case 'authentication.emailVerificationPage.snackBar.error.unexpected':
-        return '发生错误，请稍后再试。';
-      case 'authentication.registerProfilePage.title':
-        return '注册个人信息';
-      case 'authentication.registerProfilePage.textFields':
-        return '姓名';
-      case 'authentication.registerProfilePage.buttons.submit':
-        return '完成';
-      case 'authentication.registerProfilePage.buttons.skip':
-        return '跳过';
-      case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty':
-        return '请输入信息';
-      case 'authentication.registerProfilePage.snackBar.error.unexpected':
-        return '发生错误，请稍后再试。';
-      case 'authentication.completeSendEmailPage.title':
-        return '发送完成';
-      case 'authentication.completeSendEmailPage.description':
-        return ({required Object email}) => '密码重置邮件已发送到${email} \n 重置后请从登录页面登录';
-      case 'authentication.completeSendEmailPage.successResendEmail':
-        return '确认邮件已重新发送';
-      case 'authentication.completeSendEmailPage.buttons.toSignIn':
-        return '前往登录页面';
-      case 'authentication.completeSendEmailPage.buttons.resendEmail':
-        return '重新发送确认邮件';
-      case 'authentication.completeSendEmailPage.buttons.changeEmail':
-        return '更改电子邮件地址';
-      case 'validation.emailRequired':
-        return '请输入电子邮件地址';
-      case 'validation.emailInvalid':
-        return '电子邮件地址格式不正确';
-      case 'validation.passwordRequired':
-        return '请输入密码';
-      case 'validation.passwordShort':
-        return '密码至少需要8个字符';
-      case 'validation.passwordWeak':
-        return '密码应包含字母和数字的组合';
-      case 'validation.passwordMatch':
-        return '密码不匹配';
-      case 'validation.informationRequired':
-        return '请输入信息';
-      case 'validation.urlInvalid':
-        return 'URL格式不正确';
-      case 'myPage.unregisteredUserName':
-        return '未注册';
-      case 'myPage.editProfile':
-        return '编辑个人资料';
-      case 'myPage.premiumPlan':
-        return '高级计划';
-      case 'myPage.details':
-        return '详细';
-      case 'myPage.settings':
-        return '设置';
-      case 'myPage.account':
-        return '账户';
-      case 'myPage.language':
-        return '语言';
-      case 'myPage.theme':
-        return '主题';
-      case 'myPage.termsOfUsePrivacyPolicy':
-        return '使用条款和隐私政策';
-      case 'myPage.aboutThisApp':
-        return '关于本应用';
-      case 'myPage.aboutTheDeveloper':
-        return '关于开发者';
-      case 'myPage.accountStatus.dateTime.registeredOn':
-        return ({required Object date}) => '${date}注册于';
-      case 'myPage.accountStatus.dateTime.registeredOnFormat':
-        return 'yyyy年MM月dd日';
-      case 'myPage.accountStatus.dateTime.validUntil':
-        return ({required Object date}) => '有效期至${date}';
-      case 'myPage.accountStatus.dateTime.validUntilFormat':
-        return 'yyyy年MM月dd日 HH:mm';
-      case 'myPage.accountStatus.premium':
-        return '高级会员';
-      case 'myPage.accountStatus.standard':
-        return '标准会员';
-      case 'changeLanguagePage.title':
-        return '语言';
-      case 'changeLanguagePage.items.japanese':
-        return '日本人';
-      case 'changeLanguagePage.items.english':
-        return '英语';
-      case 'changeLanguagePage.items.simplifiedChinese':
-        return '中文（简体）';
-      case 'changeLanguagePage.items.traditionalChinese':
-        return '中文（繁体）';
-      case 'changeThemePage.title':
-        return '主题';
-      case 'changeThemePage.items.system':
-        return '系统';
-      case 'changeThemePage.items.light':
-        return '光';
-      case 'changeThemePage.items.dark':
-        return '暗处';
-      case 'myPlanPage.title':
-        return '我的计划';
-      case 'myPlanPage.tabs.createdPlans':
-        return '已创建计划';
-      case 'myPlanPage.tabs.bookmark':
-        return '书签';
-      case 'myPlanPage.bookmarkItems.nondata':
-        return '暂无收藏计划。';
-      case 'myPlanPage.bookmarkItems.reloading':
-        return '重新加载';
-      case 'myPlanPage.createdPlansItems.nondata':
-        return '开始创建计划吧！';
-      case 'myPlanPage.createdPlansItems.createaplan':
-        return '创建计划';
-      case 'myPlanPage.error.displayError':
-        return '显示计划时出现错误。';
-      case 'myPlanPage.error.failedGetId':
-        return '获取计划ID失败。';
-      case 'myPlanPage.error.failedGetPlanData':
-        return '获取计划数据时出现错误。';
-      case 'myPlanPage.error.failedUnBookmark':
-        return '取消收藏时出现错误。';
-      case 'buddyChatPage.title':
-        return 'Buddy的建议';
-      case 'buddyChatPage.possibleChatCount':
-        return ({required Object possibleChatCount}) =>
-            '消息还可以发送${possibleChatCount}次';
-      case 'buddyChatPage.textFields.message':
-        return '输入消息';
-      case 'buddyChatPage.buttons.send':
-        return '完成';
-      case 'buddyChatPage.placeCard.openingHours':
-        return '营业时间';
-      case 'buddyChatPage.placeCard.averageAmount':
-        return '平均预算';
-      case 'buddyChatPage.placeCard.website':
-        return '网站';
-      case 'buddyChatPage.snackBar.error.failedRecieveMessage':
-        return '未能接收回复，请稍后再试';
-      case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan':
-        return '未能完成创建计划，请稍后再试';
-      case 'popularTopics.sectionName':
-        return '热门话题';
-      case 'createPlanPage.title':
-        return '创建计划';
-      case 'createPlanPage.label.location':
-        return '目的地';
-      case 'createPlanPage.label.scheduleStart':
-        return '开始日期';
-      case 'createPlanPage.label.scheduleEnd':
-        return '结束日期';
-      case 'createPlanPage.label.numberOfPeople':
-        return '人数';
-      case 'createPlanPage.label.transport':
-        return '交通方式';
-      case 'createPlanPage.label.category':
-        return '类别';
-      case 'createPlanPage.label.topics':
-        return '旅行主题';
-      case 'createPlanPage.hintText.location':
-        return '涩谷';
-      case 'createPlanPage.modal.title':
-        return '选择日期';
-      case 'createPlanPage.numberOfPeopleOptions.0':
-        return '1人';
-      case 'createPlanPage.numberOfPeopleOptions.1':
-        return '2人';
-      case 'createPlanPage.numberOfPeopleOptions.2':
-        return '3人';
-      case 'createPlanPage.numberOfPeopleOptions.3':
-        return '4人';
-      case 'createPlanPage.numberOfPeopleOptions.4':
-        return '5人';
-      case 'createPlanPage.numberOfPeopleOptions.5':
-        return '6人以上';
-      case 'createPlanPage.transportOptions.0':
-        return '火车';
-      case 'createPlanPage.transportOptions.1':
-        return '步行';
-      case 'createPlanPage.transportOptions.2':
-        return '汽车';
-      case 'createPlanPage.transportOptions.3':
-        return '巴士';
-      case 'createPlanPage.categoryOptions.0':
-        return '亲子';
-      case 'createPlanPage.categoryOptions.1':
-        return '成人';
-      case 'createPlanPage.categoryOptions.2':
-        return '娱乐';
-      case 'createPlanPage.categoryOptions.3':
-        return '活动';
-      case 'createPlanPage.categoryOptions.4':
-        return '历史';
-      case 'createPlanPage.defaultTopics.0':
-        return '美食';
-      case 'createPlanPage.defaultTopics.1':
-        return '购物';
-      case 'createPlanPage.defaultTopics.2':
-        return '活动';
-      case 'createPlanPage.defaultTopics.3':
-        return '电影';
-      case 'createPlanPage.submitButton':
-        return '提交计划给AI';
-      case 'createPlanPage.snackBar.error.foundUnSelectedField':
-        return '存在未选择的项目，请选择所有项目';
-      case 'editProfilePage.title':
-        return '编辑个人资料';
-      case 'editProfilePage.textFields.name':
-        return '姓名';
-      case 'editProfilePage.buttons.submit':
-        return '保存';
-      case 'editProfilePage.snackBar.success':
-        return '更新成功';
-      case 'editProfilePage.snackBar.error.noChange':
-        return '没有更改';
-      case 'editProfilePage.snackBar.error.failedToUpdate':
-        return '更新失败，请稍后再试';
-      case 'editProfilePage.snackBar.error.failedToPickImage':
-        return '选择图片失败，请稍后再试';
-      case 'confirmDialog.answers.yes':
-        return '是';
-      case 'confirmDialog.answers.no':
-        return '否';
-      case 'confirmDialog.popPage.title':
-        return '要返回上一页吗？';
-      case 'confirmDialog.popPage.description':
-        return '当前内容不会被保存';
-      case 'confirmDialog.completeCreatePlan.title':
-        return '确定要保存计划吗？';
-      case 'confirmDialog.completeCreatePlan.description':
-        return '最后一条消息中的计划将被保存';
-      case 'prompt.planProposalMessage':
-        return '我考虑了这个计划！您觉得怎么样？';
-      case 'billDetailsPage.title':
-        return '高级计划';
-      case 'billDetailsPage.description':
-        return '订阅高级计划后，您可以更舒适地享受涩谷观光。';
-      case 'billDetailsPage.pricingPlan.title':
-        return '价格计划';
-      case 'billDetailsPage.pricingPlan.columns.standard':
-        return '标准';
-      case 'billDetailsPage.pricingPlan.columns.premium':
-        return '高级';
-      case 'billDetailsPage.pricingPlan.details.free':
-        return '免费 🎉';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.days':
-        return '按天数购买';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.daily':
-        return '・1日 300日元';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays':
-        return '・3日 855日元';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays':
-        return '・5日 1,480日元';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays':
-        return '・7日 2,070日元';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.or':
-        return '或者';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime':
-        return '终身';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice':
-        return '25,800日元';
-      case 'billDetailsPage.features.title':
-        return '等级功能';
-      case 'billDetailsPage.features.rows.planCreationLimit':
-        return '可创建的计划次数';
-      case 'billDetailsPage.features.rows.chatLimit':
-        return '计划创建期间可用聊天次数';
-      case 'billDetailsPage.features.rows.timelineAccess':
-        return '访问所有计划时间线';
-      case 'billDetailsPage.features.rows.adFree':
-        return '无广告';
-      case 'billDetailsPage.features.rows.exclusiveFeatures':
-        return '计划认证功能';
-      case 'billDetailsPage.features.columns.standard.label':
-        return '标准';
-      case 'billDetailsPage.features.columns.standard.planCreationLimit':
-        return '2次';
-      case 'billDetailsPage.features.columns.standard.chatLimit':
-        return '3次';
-      case 'billDetailsPage.features.columns.premium.label':
-        return '高级';
-      case 'billDetailsPage.features.columns.premium.planCreationLimit':
-        return '无限制';
-      case 'billDetailsPage.features.columns.premium.chatLimit':
-        return '无限制';
-      case 'billDetailsPage.pricingOptions.oneDay.duration':
-        return '1日';
-      case 'billDetailsPage.pricingOptions.oneDay.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.oneDay.price':
-        return '300日元';
-      case 'billDetailsPage.pricingOptions.threeDays.duration':
-        return '3日';
-      case 'billDetailsPage.pricingOptions.threeDays.discount':
-        return '-5%';
-      case 'billDetailsPage.pricingOptions.threeDays.price':
-        return '890日元';
-      case 'billDetailsPage.pricingOptions.fiveDays.duration':
-        return '5日';
-      case 'billDetailsPage.pricingOptions.fiveDays.discount':
-        return '-7.5%';
-      case 'billDetailsPage.pricingOptions.fiveDays.price':
-        return '1,387日元';
-      case 'billDetailsPage.pricingOptions.sevenDays.duration':
-        return '7日';
-      case 'billDetailsPage.pricingOptions.sevenDays.discount':
-        return '-10%';
-      case 'billDetailsPage.pricingOptions.sevenDays.price':
-        return '2,070日元';
-      case 'billDetailsPage.pricingOptions.lifetime.duration':
-        return '终身';
-      case 'billDetailsPage.pricingOptions.lifetime.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.lifetime.price':
-        return '25,800日元';
-      case 'billDetailsPage.upgradeButton':
-        return '升级到高级计划';
-      case 'planDetailsPage.dateTime.createOn':
-        return ({required Object date}) => '${date}创建的计划';
-      case 'planDetailsPage.dateTime.dateFormat':
-        return 'yyyy年MM月dd日';
-      case 'planDetailsPage.item.viewOnMap':
-        return '在地图上查看';
-      case 'planDetailsPage.snackBar.error.failedToUpdateBookmark':
-        return '更新书签失败，请稍后再试';
-      case 'locales.en':
-        return '英语';
-      case 'locales.ja':
-        return '日语';
-      case 'locales.zh':
-        return '中文';
-      case 'errorPage.title':
-        return '发生错误...';
-      case 'errorPage.message':
-        return '请检查您的网络连接并重试。';
-      case 'errorPage.retryButton':
-        return '重试';
-      case 'mapPage.title':
-        return '地图';
-      default:
-        return null;
-    }
-  }
+	dynamic _flatMapFunction(String path) {
+		switch (path) {
+			case 'navigationBar.items.home': return '首页';
+			case 'navigationBar.items.myPlan': return '我的计划';
+			case 'navigationBar.items.myPage': return '我的页面';
+			case 'homePage.popularPlans.title': return '热门计划';
+			case 'homePage.popularTopics.title': return '热门话题';
+			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number}件~';
+			case 'homePage.recentPlans.title': return '最近创建的计划';
+			case 'accountPage.title': return '账户';
+			case 'accountPage.items.signOut': return '退出登录';
+			case 'accountPage.items.linkedWithGoogle': return '与Google连接';
+			case 'accountPage.items.linkedWithApple': return '与Apple连接';
+			case 'accountPage.items.alreadyLinkedGoogle': return '已与Google连接';
+			case 'accountPage.items.alreadyLinkedApple': return '已与Apple连接';
+			case 'accountPage.snackBar.signOut': return '已成功退出登录。';
+			case 'accountPage.snackBar.signOutFailure': return '退出登录时发生错误。';
+			case 'accountPage.snackBar.successfulLinkage': return '账户关联成功。';
+			case 'accountPage.snackBar.linkageFailure': return '账户关联失败。';
+			case 'accountPage.snackBar.providerAlreadyLinked': return '此账户已经关联。';
+			case 'accountPage.snackBar.accountDeactivation': return '已解除账户关联。';
+			case 'accountPage.snackBar.invalidCredential': return '请重新登录。';
+			case 'accountPage.snackBar.linkageCancelled': return '账户关联已取消。';
+			case 'accountPage.snackBar.unlinkageFailure': return '解除账户关联失败。';
+			case 'accountPage.snackBar.operationNotAllowed': return '提供者无效。请联系开发者。';
+			case 'accountPage.snackBar.unknownError': return '发生未知错误。';
+			case 'accountPage.diaLog.yes': return '是';
+			case 'accountPage.diaLog.no': return '否';
+			case 'accountPage.diaLog.title': return '确认解除账户连接';
+			case 'accountPage.diaLog.googleText': return '是否要解除当前账户与Google账户的连接？';
+			case 'accountPage.diaLog.appleText': return '是否要解除当前账户与Apple账户的连接？';
+			case 'authentication.signInPage.title': return '登录';
+			case 'authentication.signInPage.optionText': return ' 或 ';
+			case 'authentication.signInPage.textFields.email': return '电子邮件地址';
+			case 'authentication.signInPage.textFields.password': return '密码';
+			case 'authentication.signInPage.buttons.signIn': return '登录';
+			case 'authentication.signInPage.buttons.signUp': return '注册';
+			case 'authentication.signInPage.buttons.resetPassword': return '忘记密码？';
+			case 'authentication.signInPage.buttons.appleSignIn': return '使用Apple登录';
+			case 'authentication.signInPage.buttons.googleSignIn': return '使用Google登录';
+			case 'authentication.signInPage.buttons.signInAfter': return '稍后注册';
+			case 'authentication.firebaseAuth.error.networkRequestFailed': return '请在良好的网络环境中重试';
+			case 'authentication.firebaseAuth.error.weakPassword': return '密码太短。请输入6个字符或更多';
+			case 'authentication.firebaseAuth.error.invalidEmail': return '电子邮件地址格式不正确';
+			case 'authentication.firebaseAuth.error.userNotFound': return '找不到帐户';
+			case 'authentication.firebaseAuth.error.wrongPassword': return '密码错误';
+			case 'authentication.firebaseAuth.error.emailAlreadyInUse': return '电子邮件地址已在使用中。请使用其他电子邮件地址登录或创建';
+			case 'authentication.firebaseAuth.error.unexpected': return '发生错误。请在良好的网络环境中重试';
+			case 'authentication.resetPasswordPage.title': return '重置密码';
+			case 'authentication.resetPasswordPage.description': return '将向输入的电子邮件地址发送密码重置邮件';
+			case 'authentication.resetPasswordPage.textFields.email': return '电子邮件地址';
+			case 'authentication.resetPasswordPage.buttons.submit': return '发送';
+			case 'authentication.signUpPage.title': return '注册';
+			case 'authentication.signUpPage.textFields.email': return '邮箱地址';
+			case 'authentication.signUpPage.textFields.password': return '密码';
+			case 'authentication.signUpPage.button': return '注册';
+			case 'authentication.emailVerificationPage.title': return '邮箱地址验证';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '将向输入的${email}发送确认邮件。';
+			case 'authentication.emailVerificationPage.descriptionForCoolDown': return '确认邮件每60秒只能重新发送一次。';
+			case 'authentication.emailVerificationPage.buttons.sendEmail': return '发送确认邮件';
+			case 'authentication.emailVerificationPage.buttons.resendEmail': return '重新发送确认邮件';
+			case 'authentication.emailVerificationPage.buttons.toNext': return '下一步';
+			case 'authentication.emailVerificationPage.buttons.retypeEmail': return '修改邮箱地址';
+			case 'authentication.emailVerificationPage.snackBar.success': return '发送成功';
+			case 'authentication.emailVerificationPage.snackBar.error.unexpected': return '发生错误，请稍后再试。';
+			case 'authentication.registerProfilePage.title': return '注册个人信息';
+			case 'authentication.registerProfilePage.textFields': return '姓名';
+			case 'authentication.registerProfilePage.buttons.submit': return '完成';
+			case 'authentication.registerProfilePage.buttons.skip': return '跳过';
+			case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty': return '请输入信息';
+			case 'authentication.registerProfilePage.snackBar.error.unexpected': return '发生错误，请稍后再试。';
+			case 'authentication.completeSendEmailPage.title': return '发送完成';
+			case 'authentication.completeSendEmailPage.description': return ({required Object email}) => '密码重置邮件已发送到${email} \n 重置后请从登录页面登录';
+			case 'authentication.completeSendEmailPage.successResendEmail': return '确认邮件已重新发送';
+			case 'authentication.completeSendEmailPage.buttons.toSignIn': return '前往登录页面';
+			case 'authentication.completeSendEmailPage.buttons.resendEmail': return '重新发送确认邮件';
+			case 'authentication.completeSendEmailPage.buttons.changeEmail': return '更改电子邮件地址';
+			case 'validation.emailRequired': return '请输入电子邮件地址';
+			case 'validation.emailInvalid': return '电子邮件地址格式不正确';
+			case 'validation.passwordRequired': return '请输入密码';
+			case 'validation.passwordShort': return '密码至少需要8个字符';
+			case 'validation.passwordWeak': return '密码应包含字母和数字的组合';
+			case 'validation.passwordMatch': return '密码不匹配';
+			case 'validation.informationRequired': return '请输入信息';
+			case 'validation.urlInvalid': return 'URL格式不正确';
+			case 'validation.userNameRequired': return '请输入您的用户名';
+			case 'validation.userNameMaxLength': return '用户名必须为8个字符或更少';
+			case 'myPage.unregisteredUserName': return '未注册';
+			case 'myPage.editProfile': return '编辑个人资料';
+			case 'myPage.premiumPlan': return '高级计划';
+			case 'myPage.details': return '详细';
+			case 'myPage.settings': return '设置';
+			case 'myPage.account': return '账户';
+			case 'myPage.language': return '语言';
+			case 'myPage.theme': return '主题';
+			case 'myPage.termsOfUsePrivacyPolicy': return '使用条款和隐私政策';
+			case 'myPage.aboutThisApp': return '关于本应用';
+			case 'myPage.aboutTheDeveloper': return '关于开发者';
+			case 'myPage.accountStatus.dateTime.registeredOn': return ({required Object date}) => '${date}注册于';
+			case 'myPage.accountStatus.dateTime.registeredOnFormat': return 'yyyy年MM月dd日';
+			case 'myPage.accountStatus.dateTime.validUntil': return ({required Object date}) => '有效期至${date}';
+			case 'myPage.accountStatus.dateTime.validUntilFormat': return 'yyyy年MM月dd日 HH:mm';
+			case 'myPage.accountStatus.premium': return '高级会员';
+			case 'myPage.accountStatus.standard': return '标准会员';
+			case 'changeLanguagePage.title': return '语言';
+			case 'changeLanguagePage.items.japanese': return '日本人';
+			case 'changeLanguagePage.items.english': return '英语';
+			case 'changeLanguagePage.items.simplifiedChinese': return '中文（简体）';
+			case 'changeLanguagePage.items.traditionalChinese': return '中文（繁体）';
+			case 'changeThemePage.title': return '主题';
+			case 'changeThemePage.items.system': return '系统';
+			case 'changeThemePage.items.light': return '光';
+			case 'changeThemePage.items.dark': return '暗处';
+			case 'myPlanPage.title': return '我的计划';
+			case 'myPlanPage.tabs.createdPlans': return '已创建计划';
+			case 'myPlanPage.tabs.bookmark': return '书签';
+			case 'myPlanPage.bookmarkItems.nondata': return '暂无收藏计划。';
+			case 'myPlanPage.bookmarkItems.reloading': return '重新加载';
+			case 'myPlanPage.createdPlansItems.nondata': return '开始创建计划吧！';
+			case 'myPlanPage.createdPlansItems.createaplan': return '创建计划';
+			case 'myPlanPage.error.displayError': return '显示计划时出现错误。';
+			case 'myPlanPage.error.failedGetId': return '获取计划ID失败。';
+			case 'myPlanPage.error.failedGetPlanData': return '获取计划数据时出现错误。';
+			case 'myPlanPage.error.failedUnBookmark': return '取消收藏时出现错误。';
+			case 'buddyChatPage.title': return 'Buddy的建议';
+			case 'buddyChatPage.possibleChatCount': return ({required Object possibleChatCount}) => '消息还可以发送${possibleChatCount}次';
+			case 'buddyChatPage.textFields.message': return '输入消息';
+			case 'buddyChatPage.buttons.send': return '完成';
+			case 'buddyChatPage.placeCard.openingHours': return '营业时间';
+			case 'buddyChatPage.placeCard.averageAmount': return '平均预算';
+			case 'buddyChatPage.placeCard.website': return '网站';
+			case 'buddyChatPage.snackBar.error.failedRecieveMessage': return '未能接收回复，请稍后再试';
+			case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan': return '未能完成创建计划，请稍后再试';
+			case 'popularTopics.sectionName': return '热门话题';
+			case 'createPlanPage.title': return '创建计划';
+			case 'createPlanPage.label.location': return '目的地';
+			case 'createPlanPage.label.scheduleStart': return '开始日期';
+			case 'createPlanPage.label.scheduleEnd': return '结束日期';
+			case 'createPlanPage.label.numberOfPeople': return '人数';
+			case 'createPlanPage.label.transport': return '交通方式';
+			case 'createPlanPage.label.category': return '类别';
+			case 'createPlanPage.label.topics': return '旅行主题';
+			case 'createPlanPage.hintText.location': return '涩谷';
+			case 'createPlanPage.modal.title': return '选择日期';
+			case 'createPlanPage.numberOfPeopleOptions.0': return '1人';
+			case 'createPlanPage.numberOfPeopleOptions.1': return '2人';
+			case 'createPlanPage.numberOfPeopleOptions.2': return '3人';
+			case 'createPlanPage.numberOfPeopleOptions.3': return '4人';
+			case 'createPlanPage.numberOfPeopleOptions.4': return '5人';
+			case 'createPlanPage.numberOfPeopleOptions.5': return '6人以上';
+			case 'createPlanPage.transportOptions.0': return '火车';
+			case 'createPlanPage.transportOptions.1': return '步行';
+			case 'createPlanPage.transportOptions.2': return '汽车';
+			case 'createPlanPage.transportOptions.3': return '巴士';
+			case 'createPlanPage.categoryOptions.0': return '亲子';
+			case 'createPlanPage.categoryOptions.1': return '成人';
+			case 'createPlanPage.categoryOptions.2': return '娱乐';
+			case 'createPlanPage.categoryOptions.3': return '活动';
+			case 'createPlanPage.categoryOptions.4': return '历史';
+			case 'createPlanPage.defaultTopics.0': return '美食';
+			case 'createPlanPage.defaultTopics.1': return '购物';
+			case 'createPlanPage.defaultTopics.2': return '活动';
+			case 'createPlanPage.defaultTopics.3': return '电影';
+			case 'createPlanPage.submitButton': return '提交计划给AI';
+			case 'createPlanPage.snackBar.error.foundUnSelectedField': return '存在未选择的项目，请选择所有项目';
+			case 'editProfilePage.title': return '编辑个人资料';
+			case 'editProfilePage.textFields.name': return '姓名';
+			case 'editProfilePage.buttons.submit': return '保存';
+			case 'editProfilePage.snackBar.success': return '更新成功';
+			case 'editProfilePage.snackBar.error.noChange': return '没有更改';
+			case 'editProfilePage.snackBar.error.failedToUpdate': return '更新失败，请稍后再试';
+			case 'editProfilePage.snackBar.error.failedToPickImage': return '选择图片失败，请稍后再试';
+			case 'confirmDialog.answers.yes': return '是';
+			case 'confirmDialog.answers.no': return '否';
+			case 'confirmDialog.popPage.title': return '要返回上一页吗？';
+			case 'confirmDialog.popPage.description': return '当前内容不会被保存';
+			case 'confirmDialog.completeCreatePlan.title': return '确定要保存计划吗？';
+			case 'confirmDialog.completeCreatePlan.description': return '最后一条消息中的计划将被保存';
+			case 'prompt.planProposalMessage': return '我考虑了这个计划！您觉得怎么样？';
+			case 'billDetailsPage.title': return '高级计划';
+			case 'billDetailsPage.description': return '订阅高级计划后，您可以更舒适地享受涩谷观光。';
+			case 'billDetailsPage.pricingPlan.title': return '价格计划';
+			case 'billDetailsPage.pricingPlan.columns.standard': return '标准';
+			case 'billDetailsPage.pricingPlan.columns.premium': return '高级';
+			case 'billDetailsPage.pricingPlan.details.free': return '免费 🎉';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.days': return '按天数购买';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.daily': return '・1日 300日元';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays': return '・3日 855日元';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays': return '・5日 1,480日元';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays': return '・7日 2,070日元';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.or': return '或者';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime': return '终身';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice': return '25,800日元';
+			case 'billDetailsPage.features.title': return '等级功能';
+			case 'billDetailsPage.features.rows.planCreationLimit': return '可创建的计划次数';
+			case 'billDetailsPage.features.rows.chatLimit': return '计划创建期间可用聊天次数';
+			case 'billDetailsPage.features.rows.timelineAccess': return '访问所有计划时间线';
+			case 'billDetailsPage.features.rows.adFree': return '无广告';
+			case 'billDetailsPage.features.rows.exclusiveFeatures': return '计划认证功能';
+			case 'billDetailsPage.features.columns.standard.label': return '标准';
+			case 'billDetailsPage.features.columns.standard.planCreationLimit': return '2次';
+			case 'billDetailsPage.features.columns.standard.chatLimit': return '3次';
+			case 'billDetailsPage.features.columns.premium.label': return '高级';
+			case 'billDetailsPage.features.columns.premium.planCreationLimit': return '无限制';
+			case 'billDetailsPage.features.columns.premium.chatLimit': return '无限制';
+			case 'billDetailsPage.pricingOptions.oneDay.duration': return '1日';
+			case 'billDetailsPage.pricingOptions.oneDay.discount': return '';
+			case 'billDetailsPage.pricingOptions.oneDay.price': return '300日元';
+			case 'billDetailsPage.pricingOptions.threeDays.duration': return '3日';
+			case 'billDetailsPage.pricingOptions.threeDays.discount': return '-5%';
+			case 'billDetailsPage.pricingOptions.threeDays.price': return '890日元';
+			case 'billDetailsPage.pricingOptions.fiveDays.duration': return '5日';
+			case 'billDetailsPage.pricingOptions.fiveDays.discount': return '-7.5%';
+			case 'billDetailsPage.pricingOptions.fiveDays.price': return '1,387日元';
+			case 'billDetailsPage.pricingOptions.sevenDays.duration': return '7日';
+			case 'billDetailsPage.pricingOptions.sevenDays.discount': return '-10%';
+			case 'billDetailsPage.pricingOptions.sevenDays.price': return '2,070日元';
+			case 'billDetailsPage.pricingOptions.lifetime.duration': return '终身';
+			case 'billDetailsPage.pricingOptions.lifetime.discount': return '';
+			case 'billDetailsPage.pricingOptions.lifetime.price': return '25,800日元';
+			case 'billDetailsPage.upgradeButton': return '升级到高级计划';
+			case 'planDetailsPage.dateTime.createOn': return ({required Object date}) => '${date}创建的计划';
+			case 'planDetailsPage.dateTime.dateFormat': return 'yyyy年MM月dd日';
+			case 'planDetailsPage.item.viewOnMap': return '在地图上查看';
+			case 'planDetailsPage.snackBar.error.failedToUpdateBookmark': return '更新书签失败，请稍后再试';
+			case 'locales.en': return '英语';
+			case 'locales.ja': return '日语';
+			case 'locales.zh': return '中文';
+			case 'errorPage.title': return '发生错误...';
+			case 'errorPage.message': return '请检查您的网络连接并重试。';
+			case 'errorPage.retryButton': return '重试';
+			case 'mapPage.title': return '地图';
+			default: return null;
+		}
+	}
 }
+

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -125,8 +125,8 @@ class _TranslationsValidationZhHant implements TranslationsValidationEn {
 	@override String get passwordMatch => '密碼不匹配';
 	@override String get informationRequired => '請輸入信息';
 	@override String get urlInvalid => 'URL格式不正確';
-	@override String get userNameRequired => '請輸入您的使用者名稱';
-	@override String get userNameMaxLength => '使用者名稱必須為8個字符或更少';
+	@override String get usernameRequired => '請輸入您的使用者名稱';
+	@override String get usernameMaxLength => '使用者名稱必須為8個字符或更少';
 }
 
 // Path: myPage
@@ -1263,8 +1263,8 @@ extension on TranslationsZhHant {
 			case 'validation.passwordMatch': return '密碼不匹配';
 			case 'validation.informationRequired': return '請輸入信息';
 			case 'validation.urlInvalid': return 'URL格式不正確';
-			case 'validation.userNameRequired': return '請輸入您的使用者名稱';
-			case 'validation.userNameMaxLength': return '使用者名稱必須為8個字符或更少';
+			case 'validation.usernameRequired': return '請輸入您的使用者名稱';
+			case 'validation.usernameMaxLength': return '使用者名稱必須為8個字符或更少';
 			case 'myPage.unregisteredUserName': return '未註冊';
 			case 'myPage.editProfile': return '編輯個人資料';
 			case 'myPage.premiumPlan': return '進階方案';

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -11,2132 +11,1407 @@ import 'strings.g.dart';
 
 // Path: <root>
 class TranslationsZhHant implements Translations {
-  /// You can call this constructor and build your own translation instance of this locale.
-  /// Constructing via the enum [AppLocale.build] is preferred.
-  TranslationsZhHant(
-      {Map<String, Node>? overrides,
-      PluralResolver? cardinalResolver,
-      PluralResolver? ordinalResolver})
-      : assert(overrides == null,
-            'Set "translation_overrides: true" in order to enable this feature.'),
-        $meta = TranslationMetadata(
-          locale: AppLocale.zhHant,
-          overrides: overrides ?? {},
-          cardinalResolver: cardinalResolver,
-          ordinalResolver: ordinalResolver,
-        ) {
-    $meta.setFlatMapFunction(_flatMapFunction);
-  }
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsZhHant({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = TranslationMetadata(
+		    locale: AppLocale.zhHant,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
 
-  /// Metadata for the translations of <zh-Hant>.
-  @override
-  final TranslationMetadata<AppLocale, Translations> $meta;
+	/// Metadata for the translations of <zh-Hant>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
 
-  /// Access flat map
-  @override
-  dynamic operator [](String key) => $meta.getTranslation(key);
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key);
 
-  late final TranslationsZhHant _root = this; // ignore: unused_field
+	late final TranslationsZhHant _root = this; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsNavigationBarZhHant navigationBar =
-      _TranslationsNavigationBarZhHant._(_root);
-  @override
-  late final _TranslationsHomePageZhHant homePage =
-      _TranslationsHomePageZhHant._(_root);
-  @override
-  late final _TranslationsAccountPageZhHant accountPage =
-      _TranslationsAccountPageZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationZhHant authentication =
-      _TranslationsAuthenticationZhHant._(_root);
-  @override
-  late final _TranslationsValidationZhHant validation =
-      _TranslationsValidationZhHant._(_root);
-  @override
-  late final _TranslationsMyPageZhHant myPage =
-      _TranslationsMyPageZhHant._(_root);
-  @override
-  late final _TranslationsChangeLanguagePageZhHant changeLanguagePage =
-      _TranslationsChangeLanguagePageZhHant._(_root);
-  @override
-  late final _TranslationsChangeThemePageZhHant changeThemePage =
-      _TranslationsChangeThemePageZhHant._(_root);
-  @override
-  late final _TranslationsMyPlanPageZhHant myPlanPage =
-      _TranslationsMyPlanPageZhHant._(_root);
-  @override
-  late final _TranslationsBuddyChatPageZhHant buddyChatPage =
-      _TranslationsBuddyChatPageZhHant._(_root);
-  @override
-  late final _TranslationsPopularTopicsZhHant popularTopics =
-      _TranslationsPopularTopicsZhHant._(_root);
-  @override
-  late final _TranslationsCreatePlanPageZhHant createPlanPage =
-      _TranslationsCreatePlanPageZhHant._(_root);
-  @override
-  late final _TranslationsEditProfilePageZhHant editProfilePage =
-      _TranslationsEditProfilePageZhHant._(_root);
-  @override
-  late final _TranslationsConfirmDialogZhHant confirmDialog =
-      _TranslationsConfirmDialogZhHant._(_root);
-  @override
-  late final _TranslationsPromptZhHant prompt =
-      _TranslationsPromptZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPageZhHant billDetailsPage =
-      _TranslationsBillDetailsPageZhHant._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageZhHant planDetailsPage =
-      _TranslationsPlanDetailsPageZhHant._(_root);
-  @override
-  Map<String, String> get locales => {
-        'en': '英語',
-        'ja': '日語',
-        'zh': '中文',
-      };
-  @override
-  late final _TranslationsErrorPageZhHant errorPage =
-      _TranslationsErrorPageZhHant._(_root);
-  @override
-  late final _TranslationsMapPageZhHant mapPage =
-      _TranslationsMapPageZhHant._(_root);
+	// Translations
+	@override late final _TranslationsNavigationBarZhHant navigationBar = _TranslationsNavigationBarZhHant._(_root);
+	@override late final _TranslationsHomePageZhHant homePage = _TranslationsHomePageZhHant._(_root);
+	@override late final _TranslationsAccountPageZhHant accountPage = _TranslationsAccountPageZhHant._(_root);
+	@override late final _TranslationsAuthenticationZhHant authentication = _TranslationsAuthenticationZhHant._(_root);
+	@override late final _TranslationsValidationZhHant validation = _TranslationsValidationZhHant._(_root);
+	@override late final _TranslationsMyPageZhHant myPage = _TranslationsMyPageZhHant._(_root);
+	@override late final _TranslationsChangeLanguagePageZhHant changeLanguagePage = _TranslationsChangeLanguagePageZhHant._(_root);
+	@override late final _TranslationsChangeThemePageZhHant changeThemePage = _TranslationsChangeThemePageZhHant._(_root);
+	@override late final _TranslationsMyPlanPageZhHant myPlanPage = _TranslationsMyPlanPageZhHant._(_root);
+	@override late final _TranslationsBuddyChatPageZhHant buddyChatPage = _TranslationsBuddyChatPageZhHant._(_root);
+	@override late final _TranslationsPopularTopicsZhHant popularTopics = _TranslationsPopularTopicsZhHant._(_root);
+	@override late final _TranslationsCreatePlanPageZhHant createPlanPage = _TranslationsCreatePlanPageZhHant._(_root);
+	@override late final _TranslationsEditProfilePageZhHant editProfilePage = _TranslationsEditProfilePageZhHant._(_root);
+	@override late final _TranslationsConfirmDialogZhHant confirmDialog = _TranslationsConfirmDialogZhHant._(_root);
+	@override late final _TranslationsPromptZhHant prompt = _TranslationsPromptZhHant._(_root);
+	@override late final _TranslationsBillDetailsPageZhHant billDetailsPage = _TranslationsBillDetailsPageZhHant._(_root);
+	@override late final _TranslationsPlanDetailsPageZhHant planDetailsPage = _TranslationsPlanDetailsPageZhHant._(_root);
+	@override Map<String, String> get locales => {
+		'en': '英語',
+		'ja': '日語',
+		'zh': '中文',
+	};
+	@override late final _TranslationsErrorPageZhHant errorPage = _TranslationsErrorPageZhHant._(_root);
+	@override late final _TranslationsMapPageZhHant mapPage = _TranslationsMapPageZhHant._(_root);
 }
 
 // Path: navigationBar
 class _TranslationsNavigationBarZhHant implements TranslationsNavigationBarEn {
-  _TranslationsNavigationBarZhHant._(this._root);
+	_TranslationsNavigationBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsNavigationBarItemsZhHant items =
-      _TranslationsNavigationBarItemsZhHant._(_root);
+	// Translations
+	@override late final _TranslationsNavigationBarItemsZhHant items = _TranslationsNavigationBarItemsZhHant._(_root);
 }
 
 // Path: homePage
 class _TranslationsHomePageZhHant implements TranslationsHomePageEn {
-  _TranslationsHomePageZhHant._(this._root);
+	_TranslationsHomePageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsHomePagePopularPlansZhHant popularPlans =
-      _TranslationsHomePagePopularPlansZhHant._(_root);
-  @override
-  late final _TranslationsHomePagePopularTopicsZhHant popularTopics =
-      _TranslationsHomePagePopularTopicsZhHant._(_root);
-  @override
-  late final _TranslationsHomePageRecentPlansZhHant recentPlans =
-      _TranslationsHomePageRecentPlansZhHant._(_root);
+	// Translations
+	@override late final _TranslationsHomePagePopularPlansZhHant popularPlans = _TranslationsHomePagePopularPlansZhHant._(_root);
+	@override late final _TranslationsHomePagePopularTopicsZhHant popularTopics = _TranslationsHomePagePopularTopicsZhHant._(_root);
+	@override late final _TranslationsHomePageRecentPlansZhHant recentPlans = _TranslationsHomePageRecentPlansZhHant._(_root);
 }
 
 // Path: accountPage
 class _TranslationsAccountPageZhHant implements TranslationsAccountPageEn {
-  _TranslationsAccountPageZhHant._(this._root);
+	_TranslationsAccountPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '帳戶';
-  @override
-  late final _TranslationsAccountPageItemsZhHant items =
-      _TranslationsAccountPageItemsZhHant._(_root);
-  @override
-  late final _TranslationsAccountPageSnackBarZhHant snackBar =
-      _TranslationsAccountPageSnackBarZhHant._(_root);
-  @override
-  late final _TranslationsAccountPageDiaLogZhHant diaLog =
-      _TranslationsAccountPageDiaLogZhHant._(_root);
+	// Translations
+	@override String get title => '帳戶';
+	@override late final _TranslationsAccountPageItemsZhHant items = _TranslationsAccountPageItemsZhHant._(_root);
+	@override late final _TranslationsAccountPageSnackBarZhHant snackBar = _TranslationsAccountPageSnackBarZhHant._(_root);
+	@override late final _TranslationsAccountPageDiaLogZhHant diaLog = _TranslationsAccountPageDiaLogZhHant._(_root);
 }
 
 // Path: authentication
-class _TranslationsAuthenticationZhHant
-    implements TranslationsAuthenticationEn {
-  _TranslationsAuthenticationZhHant._(this._root);
+class _TranslationsAuthenticationZhHant implements TranslationsAuthenticationEn {
+	_TranslationsAuthenticationZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationSignInPageZhHant signInPage =
-      _TranslationsAuthenticationSignInPageZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationFirebaseAuthZhHant firebaseAuth =
-      _TranslationsAuthenticationFirebaseAuthZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageZhHant
-      resetPasswordPage =
-      _TranslationsAuthenticationResetPasswordPageZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationSignUpPageZhHant signUpPage =
-      _TranslationsAuthenticationSignUpPageZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageZhHant
-      emailVerificationPage =
-      _TranslationsAuthenticationEmailVerificationPageZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageZhHant
-      registerProfilePage =
-      _TranslationsAuthenticationRegisterProfilePageZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationCompleteSendEmailPageZhHant
-      completeSendEmailPage =
-      _TranslationsAuthenticationCompleteSendEmailPageZhHant._(_root);
+	// Translations
+	@override late final _TranslationsAuthenticationSignInPageZhHant signInPage = _TranslationsAuthenticationSignInPageZhHant._(_root);
+	@override late final _TranslationsAuthenticationFirebaseAuthZhHant firebaseAuth = _TranslationsAuthenticationFirebaseAuthZhHant._(_root);
+	@override late final _TranslationsAuthenticationResetPasswordPageZhHant resetPasswordPage = _TranslationsAuthenticationResetPasswordPageZhHant._(_root);
+	@override late final _TranslationsAuthenticationSignUpPageZhHant signUpPage = _TranslationsAuthenticationSignUpPageZhHant._(_root);
+	@override late final _TranslationsAuthenticationEmailVerificationPageZhHant emailVerificationPage = _TranslationsAuthenticationEmailVerificationPageZhHant._(_root);
+	@override late final _TranslationsAuthenticationRegisterProfilePageZhHant registerProfilePage = _TranslationsAuthenticationRegisterProfilePageZhHant._(_root);
+	@override late final _TranslationsAuthenticationCompleteSendEmailPageZhHant completeSendEmailPage = _TranslationsAuthenticationCompleteSendEmailPageZhHant._(_root);
 }
 
 // Path: validation
 class _TranslationsValidationZhHant implements TranslationsValidationEn {
-  _TranslationsValidationZhHant._(this._root);
+	_TranslationsValidationZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get emailRequired => '請輸入電子郵件地址';
-  @override
-  String get emailInvalid => '電子郵件地址格式不正確';
-  @override
-  String get passwordRequired => '請輸入密碼';
-  @override
-  String get passwordShort => '密碼必須至少8個字符';
-  @override
-  String get passwordWeak => '密碼應包含字母和數字的組合';
-  @override
-  String get passwordMatch => '密碼不匹配';
-  @override
-  String get informationRequired => '請輸入信息';
-  @override
-  String get urlInvalid => 'URL格式不正確';
+	// Translations
+	@override String get emailRequired => '請輸入電子郵件地址';
+	@override String get emailInvalid => '電子郵件地址格式不正確';
+	@override String get passwordRequired => '請輸入密碼';
+	@override String get passwordShort => '密碼必須至少8個字符';
+	@override String get passwordWeak => '密碼應包含字母和數字的組合';
+	@override String get passwordMatch => '密碼不匹配';
+	@override String get informationRequired => '請輸入信息';
+	@override String get urlInvalid => 'URL格式不正確';
+	@override String get userNameRequired => '請輸入您的使用者名稱';
+	@override String get userNameMaxLength => '使用者名稱必須為8個字符或更少';
 }
 
 // Path: myPage
 class _TranslationsMyPageZhHant implements TranslationsMyPageEn {
-  _TranslationsMyPageZhHant._(this._root);
+	_TranslationsMyPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get unregisteredUserName => '未註冊';
-  @override
-  String get editProfile => '編輯個人資料';
-  @override
-  String get premiumPlan => '進階方案';
-  @override
-  String get details => '詳細';
-  @override
-  String get settings => '設定';
-  @override
-  String get account => '帳戶';
-  @override
-  String get language => '語言';
-  @override
-  String get theme => '主題';
-  @override
-  String get termsOfUsePrivacyPolicy => '使用條款和隱私政策';
-  @override
-  String get aboutThisApp => '關於本應用';
-  @override
-  String get aboutTheDeveloper => '關於開發者';
-  @override
-  late final _TranslationsMyPageAccountStatusZhHant accountStatus =
-      _TranslationsMyPageAccountStatusZhHant._(_root);
+	// Translations
+	@override String get unregisteredUserName => '未註冊';
+	@override String get editProfile => '編輯個人資料';
+	@override String get premiumPlan => '進階方案';
+	@override String get details => '詳細';
+	@override String get settings => '設定';
+	@override String get account => '帳戶';
+	@override String get language => '語言';
+	@override String get theme => '主題';
+	@override String get termsOfUsePrivacyPolicy => '使用條款和隱私政策';
+	@override String get aboutThisApp => '關於本應用';
+	@override String get aboutTheDeveloper => '關於開發者';
+	@override late final _TranslationsMyPageAccountStatusZhHant accountStatus = _TranslationsMyPageAccountStatusZhHant._(_root);
 }
 
 // Path: changeLanguagePage
-class _TranslationsChangeLanguagePageZhHant
-    implements TranslationsChangeLanguagePageEn {
-  _TranslationsChangeLanguagePageZhHant._(this._root);
+class _TranslationsChangeLanguagePageZhHant implements TranslationsChangeLanguagePageEn {
+	_TranslationsChangeLanguagePageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '語言';
-  @override
-  late final _TranslationsChangeLanguagePageItemsZhHant items =
-      _TranslationsChangeLanguagePageItemsZhHant._(_root);
+	// Translations
+	@override String get title => '語言';
+	@override late final _TranslationsChangeLanguagePageItemsZhHant items = _TranslationsChangeLanguagePageItemsZhHant._(_root);
 }
 
 // Path: changeThemePage
-class _TranslationsChangeThemePageZhHant
-    implements TranslationsChangeThemePageEn {
-  _TranslationsChangeThemePageZhHant._(this._root);
+class _TranslationsChangeThemePageZhHant implements TranslationsChangeThemePageEn {
+	_TranslationsChangeThemePageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '主题';
-  @override
-  late final _TranslationsChangeThemePageItemsZhHant items =
-      _TranslationsChangeThemePageItemsZhHant._(_root);
+	// Translations
+	@override String get title => '主题';
+	@override late final _TranslationsChangeThemePageItemsZhHant items = _TranslationsChangeThemePageItemsZhHant._(_root);
 }
 
 // Path: myPlanPage
 class _TranslationsMyPlanPageZhHant implements TranslationsMyPlanPageEn {
-  _TranslationsMyPlanPageZhHant._(this._root);
+	_TranslationsMyPlanPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '我的方案';
-  @override
-  late final _TranslationsMyPlanPageTabsZhHant tabs =
-      _TranslationsMyPlanPageTabsZhHant._(_root);
-  @override
-  late final _TranslationsMyPlanPageBookmarkItemsZhHant bookmarkItems =
-      _TranslationsMyPlanPageBookmarkItemsZhHant._(_root);
-  @override
-  late final _TranslationsMyPlanPageCreatedPlansItemsZhHant createdPlansItems =
-      _TranslationsMyPlanPageCreatedPlansItemsZhHant._(_root);
-  @override
-  late final _TranslationsMyPlanPageErrorZhHant error =
-      _TranslationsMyPlanPageErrorZhHant._(_root);
+	// Translations
+	@override String get title => '我的方案';
+	@override late final _TranslationsMyPlanPageTabsZhHant tabs = _TranslationsMyPlanPageTabsZhHant._(_root);
+	@override late final _TranslationsMyPlanPageBookmarkItemsZhHant bookmarkItems = _TranslationsMyPlanPageBookmarkItemsZhHant._(_root);
+	@override late final _TranslationsMyPlanPageCreatedPlansItemsZhHant createdPlansItems = _TranslationsMyPlanPageCreatedPlansItemsZhHant._(_root);
+	@override late final _TranslationsMyPlanPageErrorZhHant error = _TranslationsMyPlanPageErrorZhHant._(_root);
 }
 
 // Path: buddyChatPage
 class _TranslationsBuddyChatPageZhHant implements TranslationsBuddyChatPageEn {
-  _TranslationsBuddyChatPageZhHant._(this._root);
+	_TranslationsBuddyChatPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => 'Buddy的建議';
-  @override
-  String possibleChatCount({required Object possibleChatCount}) =>
-      '訊息還可以發送${possibleChatCount}次';
-  @override
-  late final _TranslationsBuddyChatPageTextFieldsZhHant textFields =
-      _TranslationsBuddyChatPageTextFieldsZhHant._(_root);
-  @override
-  late final _TranslationsBuddyChatPageButtonsZhHant buttons =
-      _TranslationsBuddyChatPageButtonsZhHant._(_root);
-  @override
-  late final _TranslationsBuddyChatPagePlaceCardZhHant placeCard =
-      _TranslationsBuddyChatPagePlaceCardZhHant._(_root);
-  @override
-  late final _TranslationsBuddyChatPageSnackBarZhHant snackBar =
-      _TranslationsBuddyChatPageSnackBarZhHant._(_root);
+	// Translations
+	@override String get title => 'Buddy的建議';
+	@override String possibleChatCount({required Object possibleChatCount}) => '訊息還可以發送${possibleChatCount}次';
+	@override late final _TranslationsBuddyChatPageTextFieldsZhHant textFields = _TranslationsBuddyChatPageTextFieldsZhHant._(_root);
+	@override late final _TranslationsBuddyChatPageButtonsZhHant buttons = _TranslationsBuddyChatPageButtonsZhHant._(_root);
+	@override late final _TranslationsBuddyChatPagePlaceCardZhHant placeCard = _TranslationsBuddyChatPagePlaceCardZhHant._(_root);
+	@override late final _TranslationsBuddyChatPageSnackBarZhHant snackBar = _TranslationsBuddyChatPageSnackBarZhHant._(_root);
 }
 
 // Path: popularTopics
 class _TranslationsPopularTopicsZhHant implements TranslationsPopularTopicsEn {
-  _TranslationsPopularTopicsZhHant._(this._root);
+	_TranslationsPopularTopicsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get sectionName => '熱門話題';
+	// Translations
+	@override String get sectionName => '熱門話題';
 }
 
 // Path: createPlanPage
-class _TranslationsCreatePlanPageZhHant
-    implements TranslationsCreatePlanPageEn {
-  _TranslationsCreatePlanPageZhHant._(this._root);
+class _TranslationsCreatePlanPageZhHant implements TranslationsCreatePlanPageEn {
+	_TranslationsCreatePlanPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '建立計劃';
-  @override
-  late final _TranslationsCreatePlanPageLabelZhHant label =
-      _TranslationsCreatePlanPageLabelZhHant._(_root);
-  @override
-  late final _TranslationsCreatePlanPageHintTextZhHant hintText =
-      _TranslationsCreatePlanPageHintTextZhHant._(_root);
-  @override
-  late final _TranslationsCreatePlanPageModalZhHant modal =
-      _TranslationsCreatePlanPageModalZhHant._(_root);
-  @override
-  List<String> get numberOfPeopleOptions => [
-        '1人',
-        '2人',
-        '3人',
-        '4人',
-        '5人',
-        '6人以上',
-      ];
-  @override
-  List<String> get transportOptions => [
-        '火車',
-        '步行',
-        '汽車',
-        '巴士',
-      ];
-  @override
-  List<String> get categoryOptions => [
-        '親子',
-        '成人',
-        '娛樂',
-        '活動',
-        '歷史',
-      ];
-  @override
-  List<String> get defaultTopics => [
-        '美食',
-        '購物',
-        '活動',
-        '電影',
-      ];
-  @override
-  String get submitButton => '提交計劃給AI';
-  @override
-  late final _TranslationsCreatePlanPageSnackBarZhHant snackBar =
-      _TranslationsCreatePlanPageSnackBarZhHant._(_root);
+	// Translations
+	@override String get title => '建立計劃';
+	@override late final _TranslationsCreatePlanPageLabelZhHant label = _TranslationsCreatePlanPageLabelZhHant._(_root);
+	@override late final _TranslationsCreatePlanPageHintTextZhHant hintText = _TranslationsCreatePlanPageHintTextZhHant._(_root);
+	@override late final _TranslationsCreatePlanPageModalZhHant modal = _TranslationsCreatePlanPageModalZhHant._(_root);
+	@override List<String> get numberOfPeopleOptions => [
+		'1人',
+		'2人',
+		'3人',
+		'4人',
+		'5人',
+		'6人以上',
+	];
+	@override List<String> get transportOptions => [
+		'火車',
+		'步行',
+		'汽車',
+		'巴士',
+	];
+	@override List<String> get categoryOptions => [
+		'親子',
+		'成人',
+		'娛樂',
+		'活動',
+		'歷史',
+	];
+	@override List<String> get defaultTopics => [
+		'美食',
+		'購物',
+		'活動',
+		'電影',
+	];
+	@override String get submitButton => '提交計劃給AI';
+	@override late final _TranslationsCreatePlanPageSnackBarZhHant snackBar = _TranslationsCreatePlanPageSnackBarZhHant._(_root);
 }
 
 // Path: editProfilePage
-class _TranslationsEditProfilePageZhHant
-    implements TranslationsEditProfilePageEn {
-  _TranslationsEditProfilePageZhHant._(this._root);
+class _TranslationsEditProfilePageZhHant implements TranslationsEditProfilePageEn {
+	_TranslationsEditProfilePageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '編輯個人資料';
-  @override
-  late final _TranslationsEditProfilePageTextFieldsZhHant textFields =
-      _TranslationsEditProfilePageTextFieldsZhHant._(_root);
-  @override
-  late final _TranslationsEditProfilePageButtonsZhHant buttons =
-      _TranslationsEditProfilePageButtonsZhHant._(_root);
-  @override
-  late final _TranslationsEditProfilePageSnackBarZhHant snackBar =
-      _TranslationsEditProfilePageSnackBarZhHant._(_root);
+	// Translations
+	@override String get title => '編輯個人資料';
+	@override late final _TranslationsEditProfilePageTextFieldsZhHant textFields = _TranslationsEditProfilePageTextFieldsZhHant._(_root);
+	@override late final _TranslationsEditProfilePageButtonsZhHant buttons = _TranslationsEditProfilePageButtonsZhHant._(_root);
+	@override late final _TranslationsEditProfilePageSnackBarZhHant snackBar = _TranslationsEditProfilePageSnackBarZhHant._(_root);
 }
 
 // Path: confirmDialog
 class _TranslationsConfirmDialogZhHant implements TranslationsConfirmDialogEn {
-  _TranslationsConfirmDialogZhHant._(this._root);
+	_TranslationsConfirmDialogZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsConfirmDialogAnswersZhHant answers =
-      _TranslationsConfirmDialogAnswersZhHant._(_root);
-  @override
-  late final _TranslationsConfirmDialogPopPageZhHant popPage =
-      _TranslationsConfirmDialogPopPageZhHant._(_root);
-  @override
-  late final _TranslationsConfirmDialogCompleteCreatePlanZhHant
-      completeCreatePlan =
-      _TranslationsConfirmDialogCompleteCreatePlanZhHant._(_root);
+	// Translations
+	@override late final _TranslationsConfirmDialogAnswersZhHant answers = _TranslationsConfirmDialogAnswersZhHant._(_root);
+	@override late final _TranslationsConfirmDialogPopPageZhHant popPage = _TranslationsConfirmDialogPopPageZhHant._(_root);
+	@override late final _TranslationsConfirmDialogCompleteCreatePlanZhHant completeCreatePlan = _TranslationsConfirmDialogCompleteCreatePlanZhHant._(_root);
 }
 
 // Path: prompt
 class _TranslationsPromptZhHant implements TranslationsPromptEn {
-  _TranslationsPromptZhHant._(this._root);
+	_TranslationsPromptZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get planProposalMessage => '我考慮了這個計劃！您覺得怎麼樣？';
+	// Translations
+	@override String get planProposalMessage => '我考慮了這個計劃！您覺得怎麼樣？';
 }
 
 // Path: billDetailsPage
-class _TranslationsBillDetailsPageZhHant
-    implements TranslationsBillDetailsPageEn {
-  _TranslationsBillDetailsPageZhHant._(this._root);
+class _TranslationsBillDetailsPageZhHant implements TranslationsBillDetailsPageEn {
+	_TranslationsBillDetailsPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '高級方案';
-  @override
-  String get description => '訂閱高級方案後，您可以更舒適地享受澀谷觀光。';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanZhHant pricingPlan =
-      _TranslationsBillDetailsPagePricingPlanZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesZhHant features =
-      _TranslationsBillDetailsPageFeaturesZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsZhHant pricingOptions =
-      _TranslationsBillDetailsPagePricingOptionsZhHant._(_root);
-  @override
-  String get upgradeButton => '升級到高級方案';
+	// Translations
+	@override String get title => '高級方案';
+	@override String get description => '訂閱高級方案後，您可以更舒適地享受澀谷觀光。';
+	@override late final _TranslationsBillDetailsPagePricingPlanZhHant pricingPlan = _TranslationsBillDetailsPagePricingPlanZhHant._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesZhHant features = _TranslationsBillDetailsPageFeaturesZhHant._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsZhHant pricingOptions = _TranslationsBillDetailsPagePricingOptionsZhHant._(_root);
+	@override String get upgradeButton => '升級到高級方案';
 }
 
 // Path: planDetailsPage
-class _TranslationsPlanDetailsPageZhHant
-    implements TranslationsPlanDetailsPageEn {
-  _TranslationsPlanDetailsPageZhHant._(this._root);
+class _TranslationsPlanDetailsPageZhHant implements TranslationsPlanDetailsPageEn {
+	_TranslationsPlanDetailsPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsPlanDetailsPageDateTimeZhHant dateTime =
-      _TranslationsPlanDetailsPageDateTimeZhHant._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageItemZhHant item =
-      _TranslationsPlanDetailsPageItemZhHant._(_root);
-  @override
-  late final _TranslationsPlanDetailsPageSnackBarZhHant snackBar =
-      _TranslationsPlanDetailsPageSnackBarZhHant._(_root);
+	// Translations
+	@override late final _TranslationsPlanDetailsPageDateTimeZhHant dateTime = _TranslationsPlanDetailsPageDateTimeZhHant._(_root);
+	@override late final _TranslationsPlanDetailsPageItemZhHant item = _TranslationsPlanDetailsPageItemZhHant._(_root);
+	@override late final _TranslationsPlanDetailsPageSnackBarZhHant snackBar = _TranslationsPlanDetailsPageSnackBarZhHant._(_root);
 }
 
 // Path: errorPage
 class _TranslationsErrorPageZhHant implements TranslationsErrorPageEn {
-  _TranslationsErrorPageZhHant._(this._root);
+	_TranslationsErrorPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '發生錯誤...';
-  @override
-  String get message => '請檢查您的網絡連接並重試。';
-  @override
-  String get retryButton => '重試';
+	// Translations
+	@override String get title => '發生錯誤...';
+	@override String get message => '請檢查您的網絡連接並重試。';
+	@override String get retryButton => '重試';
 }
 
 // Path: mapPage
 class _TranslationsMapPageZhHant implements TranslationsMapPageEn {
-  _TranslationsMapPageZhHant._(this._root);
+	_TranslationsMapPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '地圖';
+	// Translations
+	@override String get title => '地圖';
 }
 
 // Path: navigationBar.items
-class _TranslationsNavigationBarItemsZhHant
-    implements TranslationsNavigationBarItemsEn {
-  _TranslationsNavigationBarItemsZhHant._(this._root);
+class _TranslationsNavigationBarItemsZhHant implements TranslationsNavigationBarItemsEn {
+	_TranslationsNavigationBarItemsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get home => '首頁';
-  @override
-  String get myPlan => '我的計劃';
-  @override
-  String get myPage => '我的頁面';
+	// Translations
+	@override String get home => '首頁';
+	@override String get myPlan => '我的計劃';
+	@override String get myPage => '我的頁面';
 }
 
 // Path: homePage.popularPlans
-class _TranslationsHomePagePopularPlansZhHant
-    implements TranslationsHomePagePopularPlansEn {
-  _TranslationsHomePagePopularPlansZhHant._(this._root);
+class _TranslationsHomePagePopularPlansZhHant implements TranslationsHomePagePopularPlansEn {
+	_TranslationsHomePagePopularPlansZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '熱門計畫';
+	// Translations
+	@override String get title => '熱門計畫';
 }
 
 // Path: homePage.popularTopics
-class _TranslationsHomePagePopularTopicsZhHant
-    implements TranslationsHomePagePopularTopicsEn {
-  _TranslationsHomePagePopularTopicsZhHant._(this._root);
+class _TranslationsHomePagePopularTopicsZhHant implements TranslationsHomePagePopularTopicsEn {
+	_TranslationsHomePagePopularTopicsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '熱門話題';
-  @override
-  String numberOfTopics({required Object number}) => '${number}件~';
+	// Translations
+	@override String get title => '熱門話題';
+	@override String numberOfTopics({required Object number}) => '${number}件~';
 }
 
 // Path: homePage.recentPlans
-class _TranslationsHomePageRecentPlansZhHant
-    implements TranslationsHomePageRecentPlansEn {
-  _TranslationsHomePageRecentPlansZhHant._(this._root);
+class _TranslationsHomePageRecentPlansZhHant implements TranslationsHomePageRecentPlansEn {
+	_TranslationsHomePageRecentPlansZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '最近創建的計畫';
+	// Translations
+	@override String get title => '最近創建的計畫';
 }
 
 // Path: accountPage.items
-class _TranslationsAccountPageItemsZhHant
-    implements TranslationsAccountPageItemsEn {
-  _TranslationsAccountPageItemsZhHant._(this._root);
+class _TranslationsAccountPageItemsZhHant implements TranslationsAccountPageItemsEn {
+	_TranslationsAccountPageItemsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signOut => '登出';
-  @override
-  String get linkedWithGoogle => '與Google連結';
-  @override
-  String get linkedWithApple => '與Apple連結';
-  @override
-  String get alreadyLinkedGoogle => '已與Google連結';
-  @override
-  String get alreadyLinkedApple => '已與Apple連結';
+	// Translations
+	@override String get signOut => '登出';
+	@override String get linkedWithGoogle => '與Google連結';
+	@override String get linkedWithApple => '與Apple連結';
+	@override String get alreadyLinkedGoogle => '已與Google連結';
+	@override String get alreadyLinkedApple => '已與Apple連結';
 }
 
 // Path: accountPage.snackBar
-class _TranslationsAccountPageSnackBarZhHant
-    implements TranslationsAccountPageSnackBarEn {
-  _TranslationsAccountPageSnackBarZhHant._(this._root);
+class _TranslationsAccountPageSnackBarZhHant implements TranslationsAccountPageSnackBarEn {
+	_TranslationsAccountPageSnackBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signOut => '已成功登出。';
-  @override
-  String get signOutFailure => '登出時發生錯誤。';
-  @override
-  String get successfulLinkage => '帳戶連結成功。';
-  @override
-  String get linkageFailure => '帳戶連結失敗。';
-  @override
-  String get providerAlreadyLinked => '此帳戶已經連結。';
-  @override
-  String get accountDeactivation => '已解除帳戶連結。';
-  @override
-  String get invalidCredential => '請重新登入。';
-  @override
-  String get linkageCancelled => '帳戶連結已取消。';
-  @override
-  String get unlinkageFailure => '解除帳戶連結失敗。';
-  @override
-  String get operationNotAllowed => '提供者無效。請聯絡開發者。';
-  @override
-  String get unknownError => '發生未知錯誤。';
+	// Translations
+	@override String get signOut => '已成功登出。';
+	@override String get signOutFailure => '登出時發生錯誤。';
+	@override String get successfulLinkage => '帳戶連結成功。';
+	@override String get linkageFailure => '帳戶連結失敗。';
+	@override String get providerAlreadyLinked => '此帳戶已經連結。';
+	@override String get accountDeactivation => '已解除帳戶連結。';
+	@override String get invalidCredential => '請重新登入。';
+	@override String get linkageCancelled => '帳戶連結已取消。';
+	@override String get unlinkageFailure => '解除帳戶連結失敗。';
+	@override String get operationNotAllowed => '提供者無效。請聯絡開發者。';
+	@override String get unknownError => '發生未知錯誤。';
 }
 
 // Path: accountPage.diaLog
-class _TranslationsAccountPageDiaLogZhHant
-    implements TranslationsAccountPageDiaLogEn {
-  _TranslationsAccountPageDiaLogZhHant._(this._root);
+class _TranslationsAccountPageDiaLogZhHant implements TranslationsAccountPageDiaLogEn {
+	_TranslationsAccountPageDiaLogZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get yes => '是';
-  @override
-  String get no => '否';
-  @override
-  String get title => '確認解除帳戶連結';
-  @override
-  String get googleText => '是否要解除目前帳戶與Google帳戶的連結？';
-  @override
-  String get appleText => '是否要解除目前帳戶與Apple帳戶的連結？';
+	// Translations
+	@override String get yes => '是';
+	@override String get no => '否';
+	@override String get title => '確認解除帳戶連結';
+	@override String get googleText => '是否要解除目前帳戶與Google帳戶的連結？';
+	@override String get appleText => '是否要解除目前帳戶與Apple帳戶的連結？';
 }
 
 // Path: authentication.signInPage
-class _TranslationsAuthenticationSignInPageZhHant
-    implements TranslationsAuthenticationSignInPageEn {
-  _TranslationsAuthenticationSignInPageZhHant._(this._root);
+class _TranslationsAuthenticationSignInPageZhHant implements TranslationsAuthenticationSignInPageEn {
+	_TranslationsAuthenticationSignInPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '登入';
-  @override
-  String get optionText => ' 或 ';
-  @override
-  late final _TranslationsAuthenticationSignInPageTextFieldsZhHant textFields =
-      _TranslationsAuthenticationSignInPageTextFieldsZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationSignInPageButtonsZhHant buttons =
-      _TranslationsAuthenticationSignInPageButtonsZhHant._(_root);
+	// Translations
+	@override String get title => '登入';
+	@override String get optionText => ' 或 ';
+	@override late final _TranslationsAuthenticationSignInPageTextFieldsZhHant textFields = _TranslationsAuthenticationSignInPageTextFieldsZhHant._(_root);
+	@override late final _TranslationsAuthenticationSignInPageButtonsZhHant buttons = _TranslationsAuthenticationSignInPageButtonsZhHant._(_root);
 }
 
 // Path: authentication.firebaseAuth
-class _TranslationsAuthenticationFirebaseAuthZhHant
-    implements TranslationsAuthenticationFirebaseAuthEn {
-  _TranslationsAuthenticationFirebaseAuthZhHant._(this._root);
+class _TranslationsAuthenticationFirebaseAuthZhHant implements TranslationsAuthenticationFirebaseAuthEn {
+	_TranslationsAuthenticationFirebaseAuthZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationFirebaseAuthErrorZhHant error =
-      _TranslationsAuthenticationFirebaseAuthErrorZhHant._(_root);
+	// Translations
+	@override late final _TranslationsAuthenticationFirebaseAuthErrorZhHant error = _TranslationsAuthenticationFirebaseAuthErrorZhHant._(_root);
 }
 
 // Path: authentication.resetPasswordPage
-class _TranslationsAuthenticationResetPasswordPageZhHant
-    implements TranslationsAuthenticationResetPasswordPageEn {
-  _TranslationsAuthenticationResetPasswordPageZhHant._(this._root);
+class _TranslationsAuthenticationResetPasswordPageZhHant implements TranslationsAuthenticationResetPasswordPageEn {
+	_TranslationsAuthenticationResetPasswordPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '重設密碼';
-  @override
-  String get description => '將發送密碼重設郵件到輸入的電子郵件地址';
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageTextFieldsZhHant
-      textFields =
-      _TranslationsAuthenticationResetPasswordPageTextFieldsZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationResetPasswordPageButtonsZhHant buttons =
-      _TranslationsAuthenticationResetPasswordPageButtonsZhHant._(_root);
+	// Translations
+	@override String get title => '重設密碼';
+	@override String get description => '將發送密碼重設郵件到輸入的電子郵件地址';
+	@override late final _TranslationsAuthenticationResetPasswordPageTextFieldsZhHant textFields = _TranslationsAuthenticationResetPasswordPageTextFieldsZhHant._(_root);
+	@override late final _TranslationsAuthenticationResetPasswordPageButtonsZhHant buttons = _TranslationsAuthenticationResetPasswordPageButtonsZhHant._(_root);
 }
 
 // Path: authentication.signUpPage
-class _TranslationsAuthenticationSignUpPageZhHant
-    implements TranslationsAuthenticationSignUpPageEn {
-  _TranslationsAuthenticationSignUpPageZhHant._(this._root);
+class _TranslationsAuthenticationSignUpPageZhHant implements TranslationsAuthenticationSignUpPageEn {
+	_TranslationsAuthenticationSignUpPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '註冊';
-  @override
-  late final _TranslationsAuthenticationSignUpPageTextFieldsZhHant textFields =
-      _TranslationsAuthenticationSignUpPageTextFieldsZhHant._(_root);
-  @override
-  String get button => '註冊';
+	// Translations
+	@override String get title => '註冊';
+	@override late final _TranslationsAuthenticationSignUpPageTextFieldsZhHant textFields = _TranslationsAuthenticationSignUpPageTextFieldsZhHant._(_root);
+	@override String get button => '註冊';
 }
 
 // Path: authentication.emailVerificationPage
-class _TranslationsAuthenticationEmailVerificationPageZhHant
-    implements TranslationsAuthenticationEmailVerificationPageEn {
-  _TranslationsAuthenticationEmailVerificationPageZhHant._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageZhHant implements TranslationsAuthenticationEmailVerificationPageEn {
+	_TranslationsAuthenticationEmailVerificationPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '電子郵件地址驗證';
-  @override
-  String descriptionForDestination({required Object email}) =>
-      '將向輸入的${email}發送確認郵件。';
-  @override
-  String get descriptionForCoolDown => '確認郵件每60秒只能重新發送一次。';
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageButtonsZhHant
-      buttons =
-      _TranslationsAuthenticationEmailVerificationPageButtonsZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant
-      snackBar =
-      _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant._(_root);
+	// Translations
+	@override String get title => '電子郵件地址驗證';
+	@override String descriptionForDestination({required Object email}) => '將向輸入的${email}發送確認郵件。';
+	@override String get descriptionForCoolDown => '確認郵件每60秒只能重新發送一次。';
+	@override late final _TranslationsAuthenticationEmailVerificationPageButtonsZhHant buttons = _TranslationsAuthenticationEmailVerificationPageButtonsZhHant._(_root);
+	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant snackBar = _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant._(_root);
 }
 
 // Path: authentication.registerProfilePage
-class _TranslationsAuthenticationRegisterProfilePageZhHant
-    implements TranslationsAuthenticationRegisterProfilePageEn {
-  _TranslationsAuthenticationRegisterProfilePageZhHant._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageZhHant implements TranslationsAuthenticationRegisterProfilePageEn {
+	_TranslationsAuthenticationRegisterProfilePageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '註冊個人資訊';
-  @override
-  String get textFields => '姓名';
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageButtonsZhHant
-      buttons =
-      _TranslationsAuthenticationRegisterProfilePageButtonsZhHant._(_root);
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageSnackBarZhHant
-      snackBar =
-      _TranslationsAuthenticationRegisterProfilePageSnackBarZhHant._(_root);
+	// Translations
+	@override String get title => '註冊個人資訊';
+	@override String get textFields => '姓名';
+	@override late final _TranslationsAuthenticationRegisterProfilePageButtonsZhHant buttons = _TranslationsAuthenticationRegisterProfilePageButtonsZhHant._(_root);
+	@override late final _TranslationsAuthenticationRegisterProfilePageSnackBarZhHant snackBar = _TranslationsAuthenticationRegisterProfilePageSnackBarZhHant._(_root);
 }
 
 // Path: authentication.completeSendEmailPage
-class _TranslationsAuthenticationCompleteSendEmailPageZhHant
-    implements TranslationsAuthenticationCompleteSendEmailPageEn {
-  _TranslationsAuthenticationCompleteSendEmailPageZhHant._(this._root);
+class _TranslationsAuthenticationCompleteSendEmailPageZhHant implements TranslationsAuthenticationCompleteSendEmailPageEn {
+	_TranslationsAuthenticationCompleteSendEmailPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '發送完成';
-  @override
-  String description({required Object email}) =>
-      '密碼重設郵件已發送到${email} \n 重設後請從登入畫面登入';
-  @override
-  String get successResendEmail => '確認郵件已重新發送';
-  @override
-  late final _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant
-      buttons =
-      _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant._(_root);
+	// Translations
+	@override String get title => '發送完成';
+	@override String description({required Object email}) => '密碼重設郵件已發送到${email} \n 重設後請從登入畫面登入';
+	@override String get successResendEmail => '確認郵件已重新發送';
+	@override late final _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant buttons = _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant._(_root);
 }
 
 // Path: myPage.accountStatus
-class _TranslationsMyPageAccountStatusZhHant
-    implements TranslationsMyPageAccountStatusEn {
-  _TranslationsMyPageAccountStatusZhHant._(this._root);
+class _TranslationsMyPageAccountStatusZhHant implements TranslationsMyPageAccountStatusEn {
+	_TranslationsMyPageAccountStatusZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsMyPageAccountStatusDateTimeZhHant dateTime =
-      _TranslationsMyPageAccountStatusDateTimeZhHant._(_root);
-  @override
-  String get premium => '進階會員';
-  @override
-  String get standard => '標準會員';
+	// Translations
+	@override late final _TranslationsMyPageAccountStatusDateTimeZhHant dateTime = _TranslationsMyPageAccountStatusDateTimeZhHant._(_root);
+	@override String get premium => '進階會員';
+	@override String get standard => '標準會員';
 }
 
 // Path: changeLanguagePage.items
-class _TranslationsChangeLanguagePageItemsZhHant
-    implements TranslationsChangeLanguagePageItemsEn {
-  _TranslationsChangeLanguagePageItemsZhHant._(this._root);
+class _TranslationsChangeLanguagePageItemsZhHant implements TranslationsChangeLanguagePageItemsEn {
+	_TranslationsChangeLanguagePageItemsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get japanese => '日语';
-  @override
-  String get english => '英语';
-  @override
-  String get simplifiedChinese => '中文(简体字)';
-  @override
-  String get traditionalChinese => '中文(繁体字)';
+	// Translations
+	@override String get japanese => '日语';
+	@override String get english => '英语';
+	@override String get simplifiedChinese => '中文(简体字)';
+	@override String get traditionalChinese => '中文(繁体字)';
 }
 
 // Path: changeThemePage.items
-class _TranslationsChangeThemePageItemsZhHant
-    implements TranslationsChangeThemePageItemsEn {
-  _TranslationsChangeThemePageItemsZhHant._(this._root);
+class _TranslationsChangeThemePageItemsZhHant implements TranslationsChangeThemePageItemsEn {
+	_TranslationsChangeThemePageItemsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get system => '系统';
-  @override
-  String get light => '光';
-  @override
-  String get dark => '黑暗';
+	// Translations
+	@override String get system => '系统';
+	@override String get light => '光';
+	@override String get dark => '黑暗';
 }
 
 // Path: myPlanPage.tabs
-class _TranslationsMyPlanPageTabsZhHant
-    implements TranslationsMyPlanPageTabsEn {
-  _TranslationsMyPlanPageTabsZhHant._(this._root);
+class _TranslationsMyPlanPageTabsZhHant implements TranslationsMyPlanPageTabsEn {
+	_TranslationsMyPlanPageTabsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get createdPlans => '已建立方案';
-  @override
-  String get bookmark => '書籤';
+	// Translations
+	@override String get createdPlans => '已建立方案';
+	@override String get bookmark => '書籤';
 }
 
 // Path: myPlanPage.bookmarkItems
-class _TranslationsMyPlanPageBookmarkItemsZhHant
-    implements TranslationsMyPlanPageBookmarkItemsEn {
-  _TranslationsMyPlanPageBookmarkItemsZhHant._(this._root);
+class _TranslationsMyPlanPageBookmarkItemsZhHant implements TranslationsMyPlanPageBookmarkItemsEn {
+	_TranslationsMyPlanPageBookmarkItemsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get nondata => '暫無收藏方案。';
-  @override
-  String get reloading => '重新載入';
+	// Translations
+	@override String get nondata => '暫無收藏方案。';
+	@override String get reloading => '重新載入';
 }
 
 // Path: myPlanPage.createdPlansItems
-class _TranslationsMyPlanPageCreatedPlansItemsZhHant
-    implements TranslationsMyPlanPageCreatedPlansItemsEn {
-  _TranslationsMyPlanPageCreatedPlansItemsZhHant._(this._root);
+class _TranslationsMyPlanPageCreatedPlansItemsZhHant implements TranslationsMyPlanPageCreatedPlansItemsEn {
+	_TranslationsMyPlanPageCreatedPlansItemsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get nondata => '開始建立方案吧！';
-  @override
-  String get createaplan => '建立方案';
+	// Translations
+	@override String get nondata => '開始建立方案吧！';
+	@override String get createaplan => '建立方案';
 }
 
 // Path: myPlanPage.error
-class _TranslationsMyPlanPageErrorZhHant
-    implements TranslationsMyPlanPageErrorEn {
-  _TranslationsMyPlanPageErrorZhHant._(this._root);
+class _TranslationsMyPlanPageErrorZhHant implements TranslationsMyPlanPageErrorEn {
+	_TranslationsMyPlanPageErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get displayError => '顯示方案時發生錯誤。';
-  @override
-  String get failedGetId => '取得方案ID失敗。';
-  @override
-  String get failedGetPlanData => '取得方案資料時發生錯誤。';
-  @override
-  String get failedUnBookmark => '取消收藏時發生錯誤。';
+	// Translations
+	@override String get displayError => '顯示方案時發生錯誤。';
+	@override String get failedGetId => '取得方案ID失敗。';
+	@override String get failedGetPlanData => '取得方案資料時發生錯誤。';
+	@override String get failedUnBookmark => '取消收藏時發生錯誤。';
 }
 
 // Path: buddyChatPage.textFields
-class _TranslationsBuddyChatPageTextFieldsZhHant
-    implements TranslationsBuddyChatPageTextFieldsEn {
-  _TranslationsBuddyChatPageTextFieldsZhHant._(this._root);
+class _TranslationsBuddyChatPageTextFieldsZhHant implements TranslationsBuddyChatPageTextFieldsEn {
+	_TranslationsBuddyChatPageTextFieldsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get message => '輸入訊息';
+	// Translations
+	@override String get message => '輸入訊息';
 }
 
 // Path: buddyChatPage.buttons
-class _TranslationsBuddyChatPageButtonsZhHant
-    implements TranslationsBuddyChatPageButtonsEn {
-  _TranslationsBuddyChatPageButtonsZhHant._(this._root);
+class _TranslationsBuddyChatPageButtonsZhHant implements TranslationsBuddyChatPageButtonsEn {
+	_TranslationsBuddyChatPageButtonsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get send => '完成';
+	// Translations
+	@override String get send => '完成';
 }
 
 // Path: buddyChatPage.placeCard
-class _TranslationsBuddyChatPagePlaceCardZhHant
-    implements TranslationsBuddyChatPagePlaceCardEn {
-  _TranslationsBuddyChatPagePlaceCardZhHant._(this._root);
+class _TranslationsBuddyChatPagePlaceCardZhHant implements TranslationsBuddyChatPagePlaceCardEn {
+	_TranslationsBuddyChatPagePlaceCardZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get openingHours => '營業時間';
-  @override
-  String get averageAmount => '平均預算';
-  @override
-  String get website => '網站';
+	// Translations
+	@override String get openingHours => '營業時間';
+	@override String get averageAmount => '平均預算';
+	@override String get website => '網站';
 }
 
 // Path: buddyChatPage.snackBar
-class _TranslationsBuddyChatPageSnackBarZhHant
-    implements TranslationsBuddyChatPageSnackBarEn {
-  _TranslationsBuddyChatPageSnackBarZhHant._(this._root);
+class _TranslationsBuddyChatPageSnackBarZhHant implements TranslationsBuddyChatPageSnackBarEn {
+	_TranslationsBuddyChatPageSnackBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBuddyChatPageSnackBarErrorZhHant error =
-      _TranslationsBuddyChatPageSnackBarErrorZhHant._(_root);
+	// Translations
+	@override late final _TranslationsBuddyChatPageSnackBarErrorZhHant error = _TranslationsBuddyChatPageSnackBarErrorZhHant._(_root);
 }
 
 // Path: createPlanPage.label
-class _TranslationsCreatePlanPageLabelZhHant
-    implements TranslationsCreatePlanPageLabelEn {
-  _TranslationsCreatePlanPageLabelZhHant._(this._root);
+class _TranslationsCreatePlanPageLabelZhHant implements TranslationsCreatePlanPageLabelEn {
+	_TranslationsCreatePlanPageLabelZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get location => '目的地';
-  @override
-  String get scheduleStart => '開始日期';
-  @override
-  String get scheduleEnd => '結束日期';
-  @override
-  String get numberOfPeople => '人數';
-  @override
-  String get transport => '交通方式';
-  @override
-  String get category => '類別';
-  @override
-  String get topics => '旅行主題';
+	// Translations
+	@override String get location => '目的地';
+	@override String get scheduleStart => '開始日期';
+	@override String get scheduleEnd => '結束日期';
+	@override String get numberOfPeople => '人數';
+	@override String get transport => '交通方式';
+	@override String get category => '類別';
+	@override String get topics => '旅行主題';
 }
 
 // Path: createPlanPage.hintText
-class _TranslationsCreatePlanPageHintTextZhHant
-    implements TranslationsCreatePlanPageHintTextEn {
-  _TranslationsCreatePlanPageHintTextZhHant._(this._root);
+class _TranslationsCreatePlanPageHintTextZhHant implements TranslationsCreatePlanPageHintTextEn {
+	_TranslationsCreatePlanPageHintTextZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get location => '澀谷';
+	// Translations
+	@override String get location => '澀谷';
 }
 
 // Path: createPlanPage.modal
-class _TranslationsCreatePlanPageModalZhHant
-    implements TranslationsCreatePlanPageModalEn {
-  _TranslationsCreatePlanPageModalZhHant._(this._root);
+class _TranslationsCreatePlanPageModalZhHant implements TranslationsCreatePlanPageModalEn {
+	_TranslationsCreatePlanPageModalZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '選擇日期';
+	// Translations
+	@override String get title => '選擇日期';
 }
 
 // Path: createPlanPage.snackBar
-class _TranslationsCreatePlanPageSnackBarZhHant
-    implements TranslationsCreatePlanPageSnackBarEn {
-  _TranslationsCreatePlanPageSnackBarZhHant._(this._root);
+class _TranslationsCreatePlanPageSnackBarZhHant implements TranslationsCreatePlanPageSnackBarEn {
+	_TranslationsCreatePlanPageSnackBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsCreatePlanPageSnackBarErrorZhHant error =
-      _TranslationsCreatePlanPageSnackBarErrorZhHant._(_root);
+	// Translations
+	@override late final _TranslationsCreatePlanPageSnackBarErrorZhHant error = _TranslationsCreatePlanPageSnackBarErrorZhHant._(_root);
 }
 
 // Path: editProfilePage.textFields
-class _TranslationsEditProfilePageTextFieldsZhHant
-    implements TranslationsEditProfilePageTextFieldsEn {
-  _TranslationsEditProfilePageTextFieldsZhHant._(this._root);
+class _TranslationsEditProfilePageTextFieldsZhHant implements TranslationsEditProfilePageTextFieldsEn {
+	_TranslationsEditProfilePageTextFieldsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get name => '姓名';
+	// Translations
+	@override String get name => '姓名';
 }
 
 // Path: editProfilePage.buttons
-class _TranslationsEditProfilePageButtonsZhHant
-    implements TranslationsEditProfilePageButtonsEn {
-  _TranslationsEditProfilePageButtonsZhHant._(this._root);
+class _TranslationsEditProfilePageButtonsZhHant implements TranslationsEditProfilePageButtonsEn {
+	_TranslationsEditProfilePageButtonsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '儲存';
+	// Translations
+	@override String get submit => '儲存';
 }
 
 // Path: editProfilePage.snackBar
-class _TranslationsEditProfilePageSnackBarZhHant
-    implements TranslationsEditProfilePageSnackBarEn {
-  _TranslationsEditProfilePageSnackBarZhHant._(this._root);
+class _TranslationsEditProfilePageSnackBarZhHant implements TranslationsEditProfilePageSnackBarEn {
+	_TranslationsEditProfilePageSnackBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get success => '更新成功';
-  @override
-  late final _TranslationsEditProfilePageSnackBarErrorZhHant error =
-      _TranslationsEditProfilePageSnackBarErrorZhHant._(_root);
+	// Translations
+	@override String get success => '更新成功';
+	@override late final _TranslationsEditProfilePageSnackBarErrorZhHant error = _TranslationsEditProfilePageSnackBarErrorZhHant._(_root);
 }
 
 // Path: confirmDialog.answers
-class _TranslationsConfirmDialogAnswersZhHant
-    implements TranslationsConfirmDialogAnswersEn {
-  _TranslationsConfirmDialogAnswersZhHant._(this._root);
+class _TranslationsConfirmDialogAnswersZhHant implements TranslationsConfirmDialogAnswersEn {
+	_TranslationsConfirmDialogAnswersZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get yes => '是';
-  @override
-  String get no => '否';
+	// Translations
+	@override String get yes => '是';
+	@override String get no => '否';
 }
 
 // Path: confirmDialog.popPage
-class _TranslationsConfirmDialogPopPageZhHant
-    implements TranslationsConfirmDialogPopPageEn {
-  _TranslationsConfirmDialogPopPageZhHant._(this._root);
+class _TranslationsConfirmDialogPopPageZhHant implements TranslationsConfirmDialogPopPageEn {
+	_TranslationsConfirmDialogPopPageZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '要返回上一頁嗎？';
-  @override
-  String get description => '當前內容不會被保存';
+	// Translations
+	@override String get title => '要返回上一頁嗎？';
+	@override String get description => '當前內容不會被保存';
 }
 
 // Path: confirmDialog.completeCreatePlan
-class _TranslationsConfirmDialogCompleteCreatePlanZhHant
-    implements TranslationsConfirmDialogCompleteCreatePlanEn {
-  _TranslationsConfirmDialogCompleteCreatePlanZhHant._(this._root);
+class _TranslationsConfirmDialogCompleteCreatePlanZhHant implements TranslationsConfirmDialogCompleteCreatePlanEn {
+	_TranslationsConfirmDialogCompleteCreatePlanZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '確定要保存計劃嗎？';
-  @override
-  String get description => '最後一條訊息中的計劃將被保存';
+	// Translations
+	@override String get title => '確定要保存計劃嗎？';
+	@override String get description => '最後一條訊息中的計劃將被保存';
 }
 
 // Path: billDetailsPage.pricingPlan
-class _TranslationsBillDetailsPagePricingPlanZhHant
-    implements TranslationsBillDetailsPagePricingPlanEn {
-  _TranslationsBillDetailsPagePricingPlanZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingPlanZhHant implements TranslationsBillDetailsPagePricingPlanEn {
+	_TranslationsBillDetailsPagePricingPlanZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '價格方案';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanColumnsZhHant columns =
-      _TranslationsBillDetailsPagePricingPlanColumnsZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanDetailsZhHant details =
-      _TranslationsBillDetailsPagePricingPlanDetailsZhHant._(_root);
+	// Translations
+	@override String get title => '價格方案';
+	@override late final _TranslationsBillDetailsPagePricingPlanColumnsZhHant columns = _TranslationsBillDetailsPagePricingPlanColumnsZhHant._(_root);
+	@override late final _TranslationsBillDetailsPagePricingPlanDetailsZhHant details = _TranslationsBillDetailsPagePricingPlanDetailsZhHant._(_root);
 }
 
 // Path: billDetailsPage.features
-class _TranslationsBillDetailsPageFeaturesZhHant
-    implements TranslationsBillDetailsPageFeaturesEn {
-  _TranslationsBillDetailsPageFeaturesZhHant._(this._root);
+class _TranslationsBillDetailsPageFeaturesZhHant implements TranslationsBillDetailsPageFeaturesEn {
+	_TranslationsBillDetailsPageFeaturesZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get title => '等級功能';
-  @override
-  late final _TranslationsBillDetailsPageFeaturesRowsZhHant rows =
-      _TranslationsBillDetailsPageFeaturesRowsZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsZhHant columns =
-      _TranslationsBillDetailsPageFeaturesColumnsZhHant._(_root);
+	// Translations
+	@override String get title => '等級功能';
+	@override late final _TranslationsBillDetailsPageFeaturesRowsZhHant rows = _TranslationsBillDetailsPageFeaturesRowsZhHant._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsZhHant columns = _TranslationsBillDetailsPageFeaturesColumnsZhHant._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions
-class _TranslationsBillDetailsPagePricingOptionsZhHant
-    implements TranslationsBillDetailsPagePricingOptionsEn {
-  _TranslationsBillDetailsPagePricingOptionsZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsZhHant implements TranslationsBillDetailsPagePricingOptionsEn {
+	_TranslationsBillDetailsPagePricingOptionsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsOneDayZhHant oneDay =
-      _TranslationsBillDetailsPagePricingOptionsOneDayZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant
-      threeDays =
-      _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant fiveDays =
-      _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant
-      sevenDays =
-      _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPagePricingOptionsLifetimeZhHant lifetime =
-      _TranslationsBillDetailsPagePricingOptionsLifetimeZhHant._(_root);
+	// Translations
+	@override late final _TranslationsBillDetailsPagePricingOptionsOneDayZhHant oneDay = _TranslationsBillDetailsPagePricingOptionsOneDayZhHant._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant threeDays = _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant fiveDays = _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant sevenDays = _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant._(_root);
+	@override late final _TranslationsBillDetailsPagePricingOptionsLifetimeZhHant lifetime = _TranslationsBillDetailsPagePricingOptionsLifetimeZhHant._(_root);
 }
 
 // Path: planDetailsPage.dateTime
-class _TranslationsPlanDetailsPageDateTimeZhHant
-    implements TranslationsPlanDetailsPageDateTimeEn {
-  _TranslationsPlanDetailsPageDateTimeZhHant._(this._root);
+class _TranslationsPlanDetailsPageDateTimeZhHant implements TranslationsPlanDetailsPageDateTimeEn {
+	_TranslationsPlanDetailsPageDateTimeZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String createOn({required Object date}) => '${date}建立的方案';
-  @override
-  String get dateFormat => 'yyyy年MM月dd日';
+	// Translations
+	@override String createOn({required Object date}) => '${date}建立的方案';
+	@override String get dateFormat => 'yyyy年MM月dd日';
 }
 
 // Path: planDetailsPage.item
-class _TranslationsPlanDetailsPageItemZhHant
-    implements TranslationsPlanDetailsPageItemEn {
-  _TranslationsPlanDetailsPageItemZhHant._(this._root);
+class _TranslationsPlanDetailsPageItemZhHant implements TranslationsPlanDetailsPageItemEn {
+	_TranslationsPlanDetailsPageItemZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get viewOnMap => '在地圖上查看';
+	// Translations
+	@override String get viewOnMap => '在地圖上查看';
 }
 
 // Path: planDetailsPage.snackBar
-class _TranslationsPlanDetailsPageSnackBarZhHant
-    implements TranslationsPlanDetailsPageSnackBarEn {
-  _TranslationsPlanDetailsPageSnackBarZhHant._(this._root);
+class _TranslationsPlanDetailsPageSnackBarZhHant implements TranslationsPlanDetailsPageSnackBarEn {
+	_TranslationsPlanDetailsPageSnackBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsPlanDetailsPageSnackBarErrorZhHant error =
-      _TranslationsPlanDetailsPageSnackBarErrorZhHant._(_root);
+	// Translations
+	@override late final _TranslationsPlanDetailsPageSnackBarErrorZhHant error = _TranslationsPlanDetailsPageSnackBarErrorZhHant._(_root);
 }
 
 // Path: authentication.signInPage.textFields
-class _TranslationsAuthenticationSignInPageTextFieldsZhHant
-    implements TranslationsAuthenticationSignInPageTextFieldsEn {
-  _TranslationsAuthenticationSignInPageTextFieldsZhHant._(this._root);
+class _TranslationsAuthenticationSignInPageTextFieldsZhHant implements TranslationsAuthenticationSignInPageTextFieldsEn {
+	_TranslationsAuthenticationSignInPageTextFieldsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => '電子郵件地址';
-  @override
-  String get password => '密碼';
+	// Translations
+	@override String get email => '電子郵件地址';
+	@override String get password => '密碼';
 }
 
 // Path: authentication.signInPage.buttons
-class _TranslationsAuthenticationSignInPageButtonsZhHant
-    implements TranslationsAuthenticationSignInPageButtonsEn {
-  _TranslationsAuthenticationSignInPageButtonsZhHant._(this._root);
+class _TranslationsAuthenticationSignInPageButtonsZhHant implements TranslationsAuthenticationSignInPageButtonsEn {
+	_TranslationsAuthenticationSignInPageButtonsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get signIn => '登入';
-  @override
-  String get signUp => '註冊';
-  @override
-  String get resetPassword => '忘記密碼？';
-  @override
-  String get appleSignIn => '使用Apple登入';
-  @override
-  String get googleSignIn => '使用Google登入';
-  @override
-  String get signInAfter => '稍後註冊';
+	// Translations
+	@override String get signIn => '登入';
+	@override String get signUp => '註冊';
+	@override String get resetPassword => '忘記密碼？';
+	@override String get appleSignIn => '使用Apple登入';
+	@override String get googleSignIn => '使用Google登入';
+	@override String get signInAfter => '稍後註冊';
 }
 
 // Path: authentication.firebaseAuth.error
-class _TranslationsAuthenticationFirebaseAuthErrorZhHant
-    implements TranslationsAuthenticationFirebaseAuthErrorEn {
-  _TranslationsAuthenticationFirebaseAuthErrorZhHant._(this._root);
+class _TranslationsAuthenticationFirebaseAuthErrorZhHant implements TranslationsAuthenticationFirebaseAuthErrorEn {
+	_TranslationsAuthenticationFirebaseAuthErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get networkRequestFailed => '請在良好的網絡環境中重試';
-  @override
-  String get weakPassword => '密碼太短。請輸入6個字符或更多';
-  @override
-  String get invalidEmail => '電子郵件地址格式不正確';
-  @override
-  String get userNotFound => '找不到帳戶';
-  @override
-  String get wrongPassword => '密碼錯誤';
-  @override
-  String get emailAlreadyInUse => '電子郵件地址已在使用中。請使用其他電子郵件地址登錄或創建';
-  @override
-  String get unexpected => '發生錯誤。請在良好的網絡環境中重試';
+	// Translations
+	@override String get networkRequestFailed => '請在良好的網絡環境中重試';
+	@override String get weakPassword => '密碼太短。請輸入6個字符或更多';
+	@override String get invalidEmail => '電子郵件地址格式不正確';
+	@override String get userNotFound => '找不到帳戶';
+	@override String get wrongPassword => '密碼錯誤';
+	@override String get emailAlreadyInUse => '電子郵件地址已在使用中。請使用其他電子郵件地址登錄或創建';
+	@override String get unexpected => '發生錯誤。請在良好的網絡環境中重試';
 }
 
 // Path: authentication.resetPasswordPage.textFields
-class _TranslationsAuthenticationResetPasswordPageTextFieldsZhHant
-    implements TranslationsAuthenticationResetPasswordPageTextFieldsEn {
-  _TranslationsAuthenticationResetPasswordPageTextFieldsZhHant._(this._root);
+class _TranslationsAuthenticationResetPasswordPageTextFieldsZhHant implements TranslationsAuthenticationResetPasswordPageTextFieldsEn {
+	_TranslationsAuthenticationResetPasswordPageTextFieldsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => '電子郵件地址';
+	// Translations
+	@override String get email => '電子郵件地址';
 }
 
 // Path: authentication.resetPasswordPage.buttons
-class _TranslationsAuthenticationResetPasswordPageButtonsZhHant
-    implements TranslationsAuthenticationResetPasswordPageButtonsEn {
-  _TranslationsAuthenticationResetPasswordPageButtonsZhHant._(this._root);
+class _TranslationsAuthenticationResetPasswordPageButtonsZhHant implements TranslationsAuthenticationResetPasswordPageButtonsEn {
+	_TranslationsAuthenticationResetPasswordPageButtonsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '發送';
+	// Translations
+	@override String get submit => '發送';
 }
 
 // Path: authentication.signUpPage.textFields
-class _TranslationsAuthenticationSignUpPageTextFieldsZhHant
-    implements TranslationsAuthenticationSignUpPageTextFieldsEn {
-  _TranslationsAuthenticationSignUpPageTextFieldsZhHant._(this._root);
+class _TranslationsAuthenticationSignUpPageTextFieldsZhHant implements TranslationsAuthenticationSignUpPageTextFieldsEn {
+	_TranslationsAuthenticationSignUpPageTextFieldsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get email => '電子郵件地址';
-  @override
-  String get password => '密碼';
+	// Translations
+	@override String get email => '電子郵件地址';
+	@override String get password => '密碼';
 }
 
 // Path: authentication.emailVerificationPage.buttons
-class _TranslationsAuthenticationEmailVerificationPageButtonsZhHant
-    implements TranslationsAuthenticationEmailVerificationPageButtonsEn {
-  _TranslationsAuthenticationEmailVerificationPageButtonsZhHant._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageButtonsZhHant implements TranslationsAuthenticationEmailVerificationPageButtonsEn {
+	_TranslationsAuthenticationEmailVerificationPageButtonsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get sendEmail => '發送確認郵件';
-  @override
-  String get resendEmail => '重新發送確認郵件';
-  @override
-  String get toNext => '下一步';
-  @override
-  String get retypeEmail => '修改電子郵件地址';
+	// Translations
+	@override String get sendEmail => '發送確認郵件';
+	@override String get resendEmail => '重新發送確認郵件';
+	@override String get toNext => '下一步';
+	@override String get retypeEmail => '修改電子郵件地址';
 }
 
 // Path: authentication.emailVerificationPage.snackBar
-class _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant
-    implements TranslationsAuthenticationEmailVerificationPageSnackBarEn {
-  _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant._(this._root);
+class _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant implements TranslationsAuthenticationEmailVerificationPageSnackBarEn {
+	_TranslationsAuthenticationEmailVerificationPageSnackBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get success => '發送成功';
-  @override
-  late final _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant
-      error =
-      _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant._(
-          _root);
+	// Translations
+	@override String get success => '發送成功';
+	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant error = _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant._(_root);
 }
 
 // Path: authentication.registerProfilePage.buttons
-class _TranslationsAuthenticationRegisterProfilePageButtonsZhHant
-    implements TranslationsAuthenticationRegisterProfilePageButtonsEn {
-  _TranslationsAuthenticationRegisterProfilePageButtonsZhHant._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageButtonsZhHant implements TranslationsAuthenticationRegisterProfilePageButtonsEn {
+	_TranslationsAuthenticationRegisterProfilePageButtonsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submit => '完成';
-  @override
-  String get skip => '跳過';
+	// Translations
+	@override String get submit => '完成';
+	@override String get skip => '跳過';
 }
 
 // Path: authentication.registerProfilePage.snackBar
-class _TranslationsAuthenticationRegisterProfilePageSnackBarZhHant
-    implements TranslationsAuthenticationRegisterProfilePageSnackBarEn {
-  _TranslationsAuthenticationRegisterProfilePageSnackBarZhHant._(this._root);
+class _TranslationsAuthenticationRegisterProfilePageSnackBarZhHant implements TranslationsAuthenticationRegisterProfilePageSnackBarEn {
+	_TranslationsAuthenticationRegisterProfilePageSnackBarZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant
-      error =
-      _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant._(
-          _root);
+	// Translations
+	@override late final _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant error = _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant._(_root);
 }
 
 // Path: authentication.completeSendEmailPage.buttons
-class _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant
-    implements TranslationsAuthenticationCompleteSendEmailPageButtonsEn {
-  _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant._(this._root);
+class _TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant implements TranslationsAuthenticationCompleteSendEmailPageButtonsEn {
+	_TranslationsAuthenticationCompleteSendEmailPageButtonsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get toSignIn => '前往登入畫面';
-  @override
-  String get resendEmail => '重新發送確認郵件';
-  @override
-  String get changeEmail => '更改電子郵件地址';
+	// Translations
+	@override String get toSignIn => '前往登入畫面';
+	@override String get resendEmail => '重新發送確認郵件';
+	@override String get changeEmail => '更改電子郵件地址';
 }
 
 // Path: myPage.accountStatus.dateTime
-class _TranslationsMyPageAccountStatusDateTimeZhHant
-    implements TranslationsMyPageAccountStatusDateTimeEn {
-  _TranslationsMyPageAccountStatusDateTimeZhHant._(this._root);
+class _TranslationsMyPageAccountStatusDateTimeZhHant implements TranslationsMyPageAccountStatusDateTimeEn {
+	_TranslationsMyPageAccountStatusDateTimeZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String registeredOn({required Object date}) => '${date}註冊於';
-  @override
-  String get registeredOnFormat => 'yyyy年MM月dd日';
-  @override
-  String validUntil({required Object date}) => '有效期至${date}';
-  @override
-  String get validUntilFormat => 'yyyy年MM月dd日 HH:mm';
+	// Translations
+	@override String registeredOn({required Object date}) => '${date}註冊於';
+	@override String get registeredOnFormat => 'yyyy年MM月dd日';
+	@override String validUntil({required Object date}) => '有效期至${date}';
+	@override String get validUntilFormat => 'yyyy年MM月dd日 HH:mm';
 }
 
 // Path: buddyChatPage.snackBar.error
-class _TranslationsBuddyChatPageSnackBarErrorZhHant
-    implements TranslationsBuddyChatPageSnackBarErrorEn {
-  _TranslationsBuddyChatPageSnackBarErrorZhHant._(this._root);
+class _TranslationsBuddyChatPageSnackBarErrorZhHant implements TranslationsBuddyChatPageSnackBarErrorEn {
+	_TranslationsBuddyChatPageSnackBarErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get failedRecieveMessage => '無法接收回覆，請稍後再試';
-  @override
-  String get failedCompleteCreatePlan => '無法完成建立計劃，請稍後再試';
+	// Translations
+	@override String get failedRecieveMessage => '無法接收回覆，請稍後再試';
+	@override String get failedCompleteCreatePlan => '無法完成建立計劃，請稍後再試';
 }
 
 // Path: createPlanPage.snackBar.error
-class _TranslationsCreatePlanPageSnackBarErrorZhHant
-    implements TranslationsCreatePlanPageSnackBarErrorEn {
-  _TranslationsCreatePlanPageSnackBarErrorZhHant._(this._root);
+class _TranslationsCreatePlanPageSnackBarErrorZhHant implements TranslationsCreatePlanPageSnackBarErrorEn {
+	_TranslationsCreatePlanPageSnackBarErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get foundUnSelectedField => '存在未選擇的項目，請選擇所有項目';
+	// Translations
+	@override String get foundUnSelectedField => '存在未選擇的項目，請選擇所有項目';
 }
 
 // Path: editProfilePage.snackBar.error
-class _TranslationsEditProfilePageSnackBarErrorZhHant
-    implements TranslationsEditProfilePageSnackBarErrorEn {
-  _TranslationsEditProfilePageSnackBarErrorZhHant._(this._root);
+class _TranslationsEditProfilePageSnackBarErrorZhHant implements TranslationsEditProfilePageSnackBarErrorEn {
+	_TranslationsEditProfilePageSnackBarErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get noChange => '沒有變更';
-  @override
-  String get failedToUpdate => '更新失敗，請稍後再試';
-  @override
-  String get failedToPickImage => '選擇圖片失敗，請稍後再試';
+	// Translations
+	@override String get noChange => '沒有變更';
+	@override String get failedToUpdate => '更新失敗，請稍後再試';
+	@override String get failedToPickImage => '選擇圖片失敗，請稍後再試';
 }
 
 // Path: billDetailsPage.pricingPlan.columns
-class _TranslationsBillDetailsPagePricingPlanColumnsZhHant
-    implements TranslationsBillDetailsPagePricingPlanColumnsEn {
-  _TranslationsBillDetailsPagePricingPlanColumnsZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingPlanColumnsZhHant implements TranslationsBillDetailsPagePricingPlanColumnsEn {
+	_TranslationsBillDetailsPagePricingPlanColumnsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get standard => '標準';
-  @override
-  String get premium => '高級';
+	// Translations
+	@override String get standard => '標準';
+	@override String get premium => '高級';
 }
 
 // Path: billDetailsPage.pricingPlan.details
-class _TranslationsBillDetailsPagePricingPlanDetailsZhHant
-    implements TranslationsBillDetailsPagePricingPlanDetailsEn {
-  _TranslationsBillDetailsPagePricingPlanDetailsZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingPlanDetailsZhHant implements TranslationsBillDetailsPagePricingPlanDetailsEn {
+	_TranslationsBillDetailsPagePricingPlanDetailsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get free => '免費 🎉';
-  @override
-  late final _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant
-      premiumPrice =
-      _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant._(_root);
+	// Translations
+	@override String get free => '免費 🎉';
+	@override late final _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant premiumPrice = _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant._(_root);
 }
 
 // Path: billDetailsPage.features.rows
-class _TranslationsBillDetailsPageFeaturesRowsZhHant
-    implements TranslationsBillDetailsPageFeaturesRowsEn {
-  _TranslationsBillDetailsPageFeaturesRowsZhHant._(this._root);
+class _TranslationsBillDetailsPageFeaturesRowsZhHant implements TranslationsBillDetailsPageFeaturesRowsEn {
+	_TranslationsBillDetailsPageFeaturesRowsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get planCreationLimit => '可創建的方案次數';
-  @override
-  String get chatLimit => '方案創建期間可用聊天次數';
-  @override
-  String get timelineAccess => '訪問所有方案時間表';
-  @override
-  String get adFree => '無廣告';
-  @override
-  String get exclusiveFeatures => '方案認證功能';
+	// Translations
+	@override String get planCreationLimit => '可創建的方案次數';
+	@override String get chatLimit => '方案創建期間可用聊天次數';
+	@override String get timelineAccess => '訪問所有方案時間表';
+	@override String get adFree => '無廣告';
+	@override String get exclusiveFeatures => '方案認證功能';
 }
 
 // Path: billDetailsPage.features.columns
-class _TranslationsBillDetailsPageFeaturesColumnsZhHant
-    implements TranslationsBillDetailsPageFeaturesColumnsEn {
-  _TranslationsBillDetailsPageFeaturesColumnsZhHant._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsZhHant implements TranslationsBillDetailsPageFeaturesColumnsEn {
+	_TranslationsBillDetailsPageFeaturesColumnsZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsStandardZhHant
-      standard =
-      _TranslationsBillDetailsPageFeaturesColumnsStandardZhHant._(_root);
-  @override
-  late final _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant premium =
-      _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant._(_root);
+	// Translations
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsStandardZhHant standard = _TranslationsBillDetailsPageFeaturesColumnsStandardZhHant._(_root);
+	@override late final _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant premium = _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant._(_root);
 }
 
 // Path: billDetailsPage.pricingOptions.oneDay
-class _TranslationsBillDetailsPagePricingOptionsOneDayZhHant
-    implements TranslationsBillDetailsPagePricingOptionsOneDayEn {
-  _TranslationsBillDetailsPagePricingOptionsOneDayZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsOneDayZhHant implements TranslationsBillDetailsPagePricingOptionsOneDayEn {
+	_TranslationsBillDetailsPagePricingOptionsOneDayZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '1日';
-  @override
-  String get discount => '';
-  @override
-  String get price => '300日圓';
+	// Translations
+	@override String get duration => '1日';
+	@override String get discount => '';
+	@override String get price => '300日圓';
 }
 
 // Path: billDetailsPage.pricingOptions.threeDays
-class _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant
-    implements TranslationsBillDetailsPagePricingOptionsThreeDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant implements TranslationsBillDetailsPagePricingOptionsThreeDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsThreeDaysZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '3日';
-  @override
-  String get discount => '-5%';
-  @override
-  String get price => '890日圓';
+	// Translations
+	@override String get duration => '3日';
+	@override String get discount => '-5%';
+	@override String get price => '890日圓';
 }
 
 // Path: billDetailsPage.pricingOptions.fiveDays
-class _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant
-    implements TranslationsBillDetailsPagePricingOptionsFiveDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant implements TranslationsBillDetailsPagePricingOptionsFiveDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsFiveDaysZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '5日';
-  @override
-  String get discount => '-7.5%';
-  @override
-  String get price => '1,387日圓';
+	// Translations
+	@override String get duration => '5日';
+	@override String get discount => '-7.5%';
+	@override String get price => '1,387日圓';
 }
 
 // Path: billDetailsPage.pricingOptions.sevenDays
-class _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant
-    implements TranslationsBillDetailsPagePricingOptionsSevenDaysEn {
-  _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant implements TranslationsBillDetailsPagePricingOptionsSevenDaysEn {
+	_TranslationsBillDetailsPagePricingOptionsSevenDaysZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '7日';
-  @override
-  String get discount => '-10%';
-  @override
-  String get price => '2,070日圓';
+	// Translations
+	@override String get duration => '7日';
+	@override String get discount => '-10%';
+	@override String get price => '2,070日圓';
 }
 
 // Path: billDetailsPage.pricingOptions.lifetime
-class _TranslationsBillDetailsPagePricingOptionsLifetimeZhHant
-    implements TranslationsBillDetailsPagePricingOptionsLifetimeEn {
-  _TranslationsBillDetailsPagePricingOptionsLifetimeZhHant._(this._root);
+class _TranslationsBillDetailsPagePricingOptionsLifetimeZhHant implements TranslationsBillDetailsPagePricingOptionsLifetimeEn {
+	_TranslationsBillDetailsPagePricingOptionsLifetimeZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get duration => '終身';
-  @override
-  String get discount => '';
-  @override
-  String get price => '25,800日圓';
+	// Translations
+	@override String get duration => '終身';
+	@override String get discount => '';
+	@override String get price => '25,800日圓';
 }
 
 // Path: planDetailsPage.snackBar.error
-class _TranslationsPlanDetailsPageSnackBarErrorZhHant
-    implements TranslationsPlanDetailsPageSnackBarErrorEn {
-  _TranslationsPlanDetailsPageSnackBarErrorZhHant._(this._root);
+class _TranslationsPlanDetailsPageSnackBarErrorZhHant implements TranslationsPlanDetailsPageSnackBarErrorEn {
+	_TranslationsPlanDetailsPageSnackBarErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get failedToUpdateBookmark => '更新書籤失敗，請稍後再試';
+	// Translations
+	@override String get failedToUpdateBookmark => '更新書籤失敗，請稍後再試';
 }
 
 // Path: authentication.emailVerificationPage.snackBar.error
-class _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant
-    implements TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn {
-  _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant._(
-      this._root);
+class _TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant implements TranslationsAuthenticationEmailVerificationPageSnackBarErrorEn {
+	_TranslationsAuthenticationEmailVerificationPageSnackBarErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get unexpected => '發生錯誤，請稍後再試。';
+	// Translations
+	@override String get unexpected => '發生錯誤，請稍後再試。';
 }
 
 // Path: authentication.registerProfilePage.snackBar.error
-class _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant
-    implements TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn {
-  _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant._(
-      this._root);
+class _TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant implements TranslationsAuthenticationRegisterProfilePageSnackBarErrorEn {
+	_TranslationsAuthenticationRegisterProfilePageSnackBarErrorZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get submitIfAllEmpty => '請輸入信息';
-  @override
-  String get unexpected => '發生錯誤，請稍後再試。';
+	// Translations
+	@override String get submitIfAllEmpty => '請輸入信息';
+	@override String get unexpected => '發生錯誤，請稍後再試。';
 }
 
 // Path: billDetailsPage.pricingPlan.details.premiumPrice
-class _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant
-    implements TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn {
-  _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant._(
-      this._root);
+class _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant implements TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceEn {
+	_TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get days => '按天數購買';
-  @override
-  String get daily => '・1日 300日圓';
-  @override
-  String get threeDays => '・3日 855日圓';
-  @override
-  String get fiveDays => '・5日 1,480日圓';
-  @override
-  String get sevenDays => '・7日 2,070日圓';
-  @override
-  String get or => '或者';
-  @override
-  String get lifetime => '終身';
-  @override
-  String get lifetimePrice => '25,800日圓';
+	// Translations
+	@override String get days => '按天數購買';
+	@override String get daily => '・1日 300日圓';
+	@override String get threeDays => '・3日 855日圓';
+	@override String get fiveDays => '・5日 1,480日圓';
+	@override String get sevenDays => '・7日 2,070日圓';
+	@override String get or => '或者';
+	@override String get lifetime => '終身';
+	@override String get lifetimePrice => '25,800日圓';
 }
 
 // Path: billDetailsPage.features.columns.standard
-class _TranslationsBillDetailsPageFeaturesColumnsStandardZhHant
-    implements TranslationsBillDetailsPageFeaturesColumnsStandardEn {
-  _TranslationsBillDetailsPageFeaturesColumnsStandardZhHant._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsStandardZhHant implements TranslationsBillDetailsPageFeaturesColumnsStandardEn {
+	_TranslationsBillDetailsPageFeaturesColumnsStandardZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get label => '標準';
-  @override
-  String get planCreationLimit => '2次';
-  @override
-  String get chatLimit => '3次';
+	// Translations
+	@override String get label => '標準';
+	@override String get planCreationLimit => '2次';
+	@override String get chatLimit => '3次';
 }
 
 // Path: billDetailsPage.features.columns.premium
-class _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant
-    implements TranslationsBillDetailsPageFeaturesColumnsPremiumEn {
-  _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant._(this._root);
+class _TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant implements TranslationsBillDetailsPageFeaturesColumnsPremiumEn {
+	_TranslationsBillDetailsPageFeaturesColumnsPremiumZhHant._(this._root);
 
-  final TranslationsZhHant _root; // ignore: unused_field
+	final TranslationsZhHant _root; // ignore: unused_field
 
-  // Translations
-  @override
-  String get label => '高級';
-  @override
-  String get planCreationLimit => '無限制';
-  @override
-  String get chatLimit => '無限制';
+	// Translations
+	@override String get label => '高級';
+	@override String get planCreationLimit => '無限制';
+	@override String get chatLimit => '無限制';
 }
 
 /// Flat map(s) containing all translations.
 /// Only for edge cases! For simple maps, use the map function of this library.
 extension on TranslationsZhHant {
-  dynamic _flatMapFunction(String path) {
-    switch (path) {
-      case 'navigationBar.items.home':
-        return '首頁';
-      case 'navigationBar.items.myPlan':
-        return '我的計劃';
-      case 'navigationBar.items.myPage':
-        return '我的頁面';
-      case 'homePage.popularPlans.title':
-        return '熱門計畫';
-      case 'homePage.popularTopics.title':
-        return '熱門話題';
-      case 'homePage.popularTopics.numberOfTopics':
-        return ({required Object number}) => '${number}件~';
-      case 'homePage.recentPlans.title':
-        return '最近創建的計畫';
-      case 'accountPage.title':
-        return '帳戶';
-      case 'accountPage.items.signOut':
-        return '登出';
-      case 'accountPage.items.linkedWithGoogle':
-        return '與Google連結';
-      case 'accountPage.items.linkedWithApple':
-        return '與Apple連結';
-      case 'accountPage.items.alreadyLinkedGoogle':
-        return '已與Google連結';
-      case 'accountPage.items.alreadyLinkedApple':
-        return '已與Apple連結';
-      case 'accountPage.snackBar.signOut':
-        return '已成功登出。';
-      case 'accountPage.snackBar.signOutFailure':
-        return '登出時發生錯誤。';
-      case 'accountPage.snackBar.successfulLinkage':
-        return '帳戶連結成功。';
-      case 'accountPage.snackBar.linkageFailure':
-        return '帳戶連結失敗。';
-      case 'accountPage.snackBar.providerAlreadyLinked':
-        return '此帳戶已經連結。';
-      case 'accountPage.snackBar.accountDeactivation':
-        return '已解除帳戶連結。';
-      case 'accountPage.snackBar.invalidCredential':
-        return '請重新登入。';
-      case 'accountPage.snackBar.linkageCancelled':
-        return '帳戶連結已取消。';
-      case 'accountPage.snackBar.unlinkageFailure':
-        return '解除帳戶連結失敗。';
-      case 'accountPage.snackBar.operationNotAllowed':
-        return '提供者無效。請聯絡開發者。';
-      case 'accountPage.snackBar.unknownError':
-        return '發生未知錯誤。';
-      case 'accountPage.diaLog.yes':
-        return '是';
-      case 'accountPage.diaLog.no':
-        return '否';
-      case 'accountPage.diaLog.title':
-        return '確認解除帳戶連結';
-      case 'accountPage.diaLog.googleText':
-        return '是否要解除目前帳戶與Google帳戶的連結？';
-      case 'accountPage.diaLog.appleText':
-        return '是否要解除目前帳戶與Apple帳戶的連結？';
-      case 'authentication.signInPage.title':
-        return '登入';
-      case 'authentication.signInPage.optionText':
-        return ' 或 ';
-      case 'authentication.signInPage.textFields.email':
-        return '電子郵件地址';
-      case 'authentication.signInPage.textFields.password':
-        return '密碼';
-      case 'authentication.signInPage.buttons.signIn':
-        return '登入';
-      case 'authentication.signInPage.buttons.signUp':
-        return '註冊';
-      case 'authentication.signInPage.buttons.resetPassword':
-        return '忘記密碼？';
-      case 'authentication.signInPage.buttons.appleSignIn':
-        return '使用Apple登入';
-      case 'authentication.signInPage.buttons.googleSignIn':
-        return '使用Google登入';
-      case 'authentication.signInPage.buttons.signInAfter':
-        return '稍後註冊';
-      case 'authentication.firebaseAuth.error.networkRequestFailed':
-        return '請在良好的網絡環境中重試';
-      case 'authentication.firebaseAuth.error.weakPassword':
-        return '密碼太短。請輸入6個字符或更多';
-      case 'authentication.firebaseAuth.error.invalidEmail':
-        return '電子郵件地址格式不正確';
-      case 'authentication.firebaseAuth.error.userNotFound':
-        return '找不到帳戶';
-      case 'authentication.firebaseAuth.error.wrongPassword':
-        return '密碼錯誤';
-      case 'authentication.firebaseAuth.error.emailAlreadyInUse':
-        return '電子郵件地址已在使用中。請使用其他電子郵件地址登錄或創建';
-      case 'authentication.firebaseAuth.error.unexpected':
-        return '發生錯誤。請在良好的網絡環境中重試';
-      case 'authentication.resetPasswordPage.title':
-        return '重設密碼';
-      case 'authentication.resetPasswordPage.description':
-        return '將發送密碼重設郵件到輸入的電子郵件地址';
-      case 'authentication.resetPasswordPage.textFields.email':
-        return '電子郵件地址';
-      case 'authentication.resetPasswordPage.buttons.submit':
-        return '發送';
-      case 'authentication.signUpPage.title':
-        return '註冊';
-      case 'authentication.signUpPage.textFields.email':
-        return '電子郵件地址';
-      case 'authentication.signUpPage.textFields.password':
-        return '密碼';
-      case 'authentication.signUpPage.button':
-        return '註冊';
-      case 'authentication.emailVerificationPage.title':
-        return '電子郵件地址驗證';
-      case 'authentication.emailVerificationPage.descriptionForDestination':
-        return ({required Object email}) => '將向輸入的${email}發送確認郵件。';
-      case 'authentication.emailVerificationPage.descriptionForCoolDown':
-        return '確認郵件每60秒只能重新發送一次。';
-      case 'authentication.emailVerificationPage.buttons.sendEmail':
-        return '發送確認郵件';
-      case 'authentication.emailVerificationPage.buttons.resendEmail':
-        return '重新發送確認郵件';
-      case 'authentication.emailVerificationPage.buttons.toNext':
-        return '下一步';
-      case 'authentication.emailVerificationPage.buttons.retypeEmail':
-        return '修改電子郵件地址';
-      case 'authentication.emailVerificationPage.snackBar.success':
-        return '發送成功';
-      case 'authentication.emailVerificationPage.snackBar.error.unexpected':
-        return '發生錯誤，請稍後再試。';
-      case 'authentication.registerProfilePage.title':
-        return '註冊個人資訊';
-      case 'authentication.registerProfilePage.textFields':
-        return '姓名';
-      case 'authentication.registerProfilePage.buttons.submit':
-        return '完成';
-      case 'authentication.registerProfilePage.buttons.skip':
-        return '跳過';
-      case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty':
-        return '請輸入信息';
-      case 'authentication.registerProfilePage.snackBar.error.unexpected':
-        return '發生錯誤，請稍後再試。';
-      case 'authentication.completeSendEmailPage.title':
-        return '發送完成';
-      case 'authentication.completeSendEmailPage.description':
-        return ({required Object email}) => '密碼重設郵件已發送到${email} \n 重設後請從登入畫面登入';
-      case 'authentication.completeSendEmailPage.successResendEmail':
-        return '確認郵件已重新發送';
-      case 'authentication.completeSendEmailPage.buttons.toSignIn':
-        return '前往登入畫面';
-      case 'authentication.completeSendEmailPage.buttons.resendEmail':
-        return '重新發送確認郵件';
-      case 'authentication.completeSendEmailPage.buttons.changeEmail':
-        return '更改電子郵件地址';
-      case 'validation.emailRequired':
-        return '請輸入電子郵件地址';
-      case 'validation.emailInvalid':
-        return '電子郵件地址格式不正確';
-      case 'validation.passwordRequired':
-        return '請輸入密碼';
-      case 'validation.passwordShort':
-        return '密碼必須至少8個字符';
-      case 'validation.passwordWeak':
-        return '密碼應包含字母和數字的組合';
-      case 'validation.passwordMatch':
-        return '密碼不匹配';
-      case 'validation.informationRequired':
-        return '請輸入信息';
-      case 'validation.urlInvalid':
-        return 'URL格式不正確';
-      case 'myPage.unregisteredUserName':
-        return '未註冊';
-      case 'myPage.editProfile':
-        return '編輯個人資料';
-      case 'myPage.premiumPlan':
-        return '進階方案';
-      case 'myPage.details':
-        return '詳細';
-      case 'myPage.settings':
-        return '設定';
-      case 'myPage.account':
-        return '帳戶';
-      case 'myPage.language':
-        return '語言';
-      case 'myPage.theme':
-        return '主題';
-      case 'myPage.termsOfUsePrivacyPolicy':
-        return '使用條款和隱私政策';
-      case 'myPage.aboutThisApp':
-        return '關於本應用';
-      case 'myPage.aboutTheDeveloper':
-        return '關於開發者';
-      case 'myPage.accountStatus.dateTime.registeredOn':
-        return ({required Object date}) => '${date}註冊於';
-      case 'myPage.accountStatus.dateTime.registeredOnFormat':
-        return 'yyyy年MM月dd日';
-      case 'myPage.accountStatus.dateTime.validUntil':
-        return ({required Object date}) => '有效期至${date}';
-      case 'myPage.accountStatus.dateTime.validUntilFormat':
-        return 'yyyy年MM月dd日 HH:mm';
-      case 'myPage.accountStatus.premium':
-        return '進階會員';
-      case 'myPage.accountStatus.standard':
-        return '標準會員';
-      case 'changeLanguagePage.title':
-        return '語言';
-      case 'changeLanguagePage.items.japanese':
-        return '日语';
-      case 'changeLanguagePage.items.english':
-        return '英语';
-      case 'changeLanguagePage.items.simplifiedChinese':
-        return '中文(简体字)';
-      case 'changeLanguagePage.items.traditionalChinese':
-        return '中文(繁体字)';
-      case 'changeThemePage.title':
-        return '主题';
-      case 'changeThemePage.items.system':
-        return '系统';
-      case 'changeThemePage.items.light':
-        return '光';
-      case 'changeThemePage.items.dark':
-        return '黑暗';
-      case 'myPlanPage.title':
-        return '我的方案';
-      case 'myPlanPage.tabs.createdPlans':
-        return '已建立方案';
-      case 'myPlanPage.tabs.bookmark':
-        return '書籤';
-      case 'myPlanPage.bookmarkItems.nondata':
-        return '暫無收藏方案。';
-      case 'myPlanPage.bookmarkItems.reloading':
-        return '重新載入';
-      case 'myPlanPage.createdPlansItems.nondata':
-        return '開始建立方案吧！';
-      case 'myPlanPage.createdPlansItems.createaplan':
-        return '建立方案';
-      case 'myPlanPage.error.displayError':
-        return '顯示方案時發生錯誤。';
-      case 'myPlanPage.error.failedGetId':
-        return '取得方案ID失敗。';
-      case 'myPlanPage.error.failedGetPlanData':
-        return '取得方案資料時發生錯誤。';
-      case 'myPlanPage.error.failedUnBookmark':
-        return '取消收藏時發生錯誤。';
-      case 'buddyChatPage.title':
-        return 'Buddy的建議';
-      case 'buddyChatPage.possibleChatCount':
-        return ({required Object possibleChatCount}) =>
-            '訊息還可以發送${possibleChatCount}次';
-      case 'buddyChatPage.textFields.message':
-        return '輸入訊息';
-      case 'buddyChatPage.buttons.send':
-        return '完成';
-      case 'buddyChatPage.placeCard.openingHours':
-        return '營業時間';
-      case 'buddyChatPage.placeCard.averageAmount':
-        return '平均預算';
-      case 'buddyChatPage.placeCard.website':
-        return '網站';
-      case 'buddyChatPage.snackBar.error.failedRecieveMessage':
-        return '無法接收回覆，請稍後再試';
-      case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan':
-        return '無法完成建立計劃，請稍後再試';
-      case 'popularTopics.sectionName':
-        return '熱門話題';
-      case 'createPlanPage.title':
-        return '建立計劃';
-      case 'createPlanPage.label.location':
-        return '目的地';
-      case 'createPlanPage.label.scheduleStart':
-        return '開始日期';
-      case 'createPlanPage.label.scheduleEnd':
-        return '結束日期';
-      case 'createPlanPage.label.numberOfPeople':
-        return '人數';
-      case 'createPlanPage.label.transport':
-        return '交通方式';
-      case 'createPlanPage.label.category':
-        return '類別';
-      case 'createPlanPage.label.topics':
-        return '旅行主題';
-      case 'createPlanPage.hintText.location':
-        return '澀谷';
-      case 'createPlanPage.modal.title':
-        return '選擇日期';
-      case 'createPlanPage.numberOfPeopleOptions.0':
-        return '1人';
-      case 'createPlanPage.numberOfPeopleOptions.1':
-        return '2人';
-      case 'createPlanPage.numberOfPeopleOptions.2':
-        return '3人';
-      case 'createPlanPage.numberOfPeopleOptions.3':
-        return '4人';
-      case 'createPlanPage.numberOfPeopleOptions.4':
-        return '5人';
-      case 'createPlanPage.numberOfPeopleOptions.5':
-        return '6人以上';
-      case 'createPlanPage.transportOptions.0':
-        return '火車';
-      case 'createPlanPage.transportOptions.1':
-        return '步行';
-      case 'createPlanPage.transportOptions.2':
-        return '汽車';
-      case 'createPlanPage.transportOptions.3':
-        return '巴士';
-      case 'createPlanPage.categoryOptions.0':
-        return '親子';
-      case 'createPlanPage.categoryOptions.1':
-        return '成人';
-      case 'createPlanPage.categoryOptions.2':
-        return '娛樂';
-      case 'createPlanPage.categoryOptions.3':
-        return '活動';
-      case 'createPlanPage.categoryOptions.4':
-        return '歷史';
-      case 'createPlanPage.defaultTopics.0':
-        return '美食';
-      case 'createPlanPage.defaultTopics.1':
-        return '購物';
-      case 'createPlanPage.defaultTopics.2':
-        return '活動';
-      case 'createPlanPage.defaultTopics.3':
-        return '電影';
-      case 'createPlanPage.submitButton':
-        return '提交計劃給AI';
-      case 'createPlanPage.snackBar.error.foundUnSelectedField':
-        return '存在未選擇的項目，請選擇所有項目';
-      case 'editProfilePage.title':
-        return '編輯個人資料';
-      case 'editProfilePage.textFields.name':
-        return '姓名';
-      case 'editProfilePage.buttons.submit':
-        return '儲存';
-      case 'editProfilePage.snackBar.success':
-        return '更新成功';
-      case 'editProfilePage.snackBar.error.noChange':
-        return '沒有變更';
-      case 'editProfilePage.snackBar.error.failedToUpdate':
-        return '更新失敗，請稍後再試';
-      case 'editProfilePage.snackBar.error.failedToPickImage':
-        return '選擇圖片失敗，請稍後再試';
-      case 'confirmDialog.answers.yes':
-        return '是';
-      case 'confirmDialog.answers.no':
-        return '否';
-      case 'confirmDialog.popPage.title':
-        return '要返回上一頁嗎？';
-      case 'confirmDialog.popPage.description':
-        return '當前內容不會被保存';
-      case 'confirmDialog.completeCreatePlan.title':
-        return '確定要保存計劃嗎？';
-      case 'confirmDialog.completeCreatePlan.description':
-        return '最後一條訊息中的計劃將被保存';
-      case 'prompt.planProposalMessage':
-        return '我考慮了這個計劃！您覺得怎麼樣？';
-      case 'billDetailsPage.title':
-        return '高級方案';
-      case 'billDetailsPage.description':
-        return '訂閱高級方案後，您可以更舒適地享受澀谷觀光。';
-      case 'billDetailsPage.pricingPlan.title':
-        return '價格方案';
-      case 'billDetailsPage.pricingPlan.columns.standard':
-        return '標準';
-      case 'billDetailsPage.pricingPlan.columns.premium':
-        return '高級';
-      case 'billDetailsPage.pricingPlan.details.free':
-        return '免費 🎉';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.days':
-        return '按天數購買';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.daily':
-        return '・1日 300日圓';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays':
-        return '・3日 855日圓';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays':
-        return '・5日 1,480日圓';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays':
-        return '・7日 2,070日圓';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.or':
-        return '或者';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime':
-        return '終身';
-      case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice':
-        return '25,800日圓';
-      case 'billDetailsPage.features.title':
-        return '等級功能';
-      case 'billDetailsPage.features.rows.planCreationLimit':
-        return '可創建的方案次數';
-      case 'billDetailsPage.features.rows.chatLimit':
-        return '方案創建期間可用聊天次數';
-      case 'billDetailsPage.features.rows.timelineAccess':
-        return '訪問所有方案時間表';
-      case 'billDetailsPage.features.rows.adFree':
-        return '無廣告';
-      case 'billDetailsPage.features.rows.exclusiveFeatures':
-        return '方案認證功能';
-      case 'billDetailsPage.features.columns.standard.label':
-        return '標準';
-      case 'billDetailsPage.features.columns.standard.planCreationLimit':
-        return '2次';
-      case 'billDetailsPage.features.columns.standard.chatLimit':
-        return '3次';
-      case 'billDetailsPage.features.columns.premium.label':
-        return '高級';
-      case 'billDetailsPage.features.columns.premium.planCreationLimit':
-        return '無限制';
-      case 'billDetailsPage.features.columns.premium.chatLimit':
-        return '無限制';
-      case 'billDetailsPage.pricingOptions.oneDay.duration':
-        return '1日';
-      case 'billDetailsPage.pricingOptions.oneDay.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.oneDay.price':
-        return '300日圓';
-      case 'billDetailsPage.pricingOptions.threeDays.duration':
-        return '3日';
-      case 'billDetailsPage.pricingOptions.threeDays.discount':
-        return '-5%';
-      case 'billDetailsPage.pricingOptions.threeDays.price':
-        return '890日圓';
-      case 'billDetailsPage.pricingOptions.fiveDays.duration':
-        return '5日';
-      case 'billDetailsPage.pricingOptions.fiveDays.discount':
-        return '-7.5%';
-      case 'billDetailsPage.pricingOptions.fiveDays.price':
-        return '1,387日圓';
-      case 'billDetailsPage.pricingOptions.sevenDays.duration':
-        return '7日';
-      case 'billDetailsPage.pricingOptions.sevenDays.discount':
-        return '-10%';
-      case 'billDetailsPage.pricingOptions.sevenDays.price':
-        return '2,070日圓';
-      case 'billDetailsPage.pricingOptions.lifetime.duration':
-        return '終身';
-      case 'billDetailsPage.pricingOptions.lifetime.discount':
-        return '';
-      case 'billDetailsPage.pricingOptions.lifetime.price':
-        return '25,800日圓';
-      case 'billDetailsPage.upgradeButton':
-        return '升級到高級方案';
-      case 'planDetailsPage.dateTime.createOn':
-        return ({required Object date}) => '${date}建立的方案';
-      case 'planDetailsPage.dateTime.dateFormat':
-        return 'yyyy年MM月dd日';
-      case 'planDetailsPage.item.viewOnMap':
-        return '在地圖上查看';
-      case 'planDetailsPage.snackBar.error.failedToUpdateBookmark':
-        return '更新書籤失敗，請稍後再試';
-      case 'locales.en':
-        return '英語';
-      case 'locales.ja':
-        return '日語';
-      case 'locales.zh':
-        return '中文';
-      case 'errorPage.title':
-        return '發生錯誤...';
-      case 'errorPage.message':
-        return '請檢查您的網絡連接並重試。';
-      case 'errorPage.retryButton':
-        return '重試';
-      case 'mapPage.title':
-        return '地圖';
-      default:
-        return null;
-    }
-  }
+	dynamic _flatMapFunction(String path) {
+		switch (path) {
+			case 'navigationBar.items.home': return '首頁';
+			case 'navigationBar.items.myPlan': return '我的計劃';
+			case 'navigationBar.items.myPage': return '我的頁面';
+			case 'homePage.popularPlans.title': return '熱門計畫';
+			case 'homePage.popularTopics.title': return '熱門話題';
+			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number}件~';
+			case 'homePage.recentPlans.title': return '最近創建的計畫';
+			case 'accountPage.title': return '帳戶';
+			case 'accountPage.items.signOut': return '登出';
+			case 'accountPage.items.linkedWithGoogle': return '與Google連結';
+			case 'accountPage.items.linkedWithApple': return '與Apple連結';
+			case 'accountPage.items.alreadyLinkedGoogle': return '已與Google連結';
+			case 'accountPage.items.alreadyLinkedApple': return '已與Apple連結';
+			case 'accountPage.snackBar.signOut': return '已成功登出。';
+			case 'accountPage.snackBar.signOutFailure': return '登出時發生錯誤。';
+			case 'accountPage.snackBar.successfulLinkage': return '帳戶連結成功。';
+			case 'accountPage.snackBar.linkageFailure': return '帳戶連結失敗。';
+			case 'accountPage.snackBar.providerAlreadyLinked': return '此帳戶已經連結。';
+			case 'accountPage.snackBar.accountDeactivation': return '已解除帳戶連結。';
+			case 'accountPage.snackBar.invalidCredential': return '請重新登入。';
+			case 'accountPage.snackBar.linkageCancelled': return '帳戶連結已取消。';
+			case 'accountPage.snackBar.unlinkageFailure': return '解除帳戶連結失敗。';
+			case 'accountPage.snackBar.operationNotAllowed': return '提供者無效。請聯絡開發者。';
+			case 'accountPage.snackBar.unknownError': return '發生未知錯誤。';
+			case 'accountPage.diaLog.yes': return '是';
+			case 'accountPage.diaLog.no': return '否';
+			case 'accountPage.diaLog.title': return '確認解除帳戶連結';
+			case 'accountPage.diaLog.googleText': return '是否要解除目前帳戶與Google帳戶的連結？';
+			case 'accountPage.diaLog.appleText': return '是否要解除目前帳戶與Apple帳戶的連結？';
+			case 'authentication.signInPage.title': return '登入';
+			case 'authentication.signInPage.optionText': return ' 或 ';
+			case 'authentication.signInPage.textFields.email': return '電子郵件地址';
+			case 'authentication.signInPage.textFields.password': return '密碼';
+			case 'authentication.signInPage.buttons.signIn': return '登入';
+			case 'authentication.signInPage.buttons.signUp': return '註冊';
+			case 'authentication.signInPage.buttons.resetPassword': return '忘記密碼？';
+			case 'authentication.signInPage.buttons.appleSignIn': return '使用Apple登入';
+			case 'authentication.signInPage.buttons.googleSignIn': return '使用Google登入';
+			case 'authentication.signInPage.buttons.signInAfter': return '稍後註冊';
+			case 'authentication.firebaseAuth.error.networkRequestFailed': return '請在良好的網絡環境中重試';
+			case 'authentication.firebaseAuth.error.weakPassword': return '密碼太短。請輸入6個字符或更多';
+			case 'authentication.firebaseAuth.error.invalidEmail': return '電子郵件地址格式不正確';
+			case 'authentication.firebaseAuth.error.userNotFound': return '找不到帳戶';
+			case 'authentication.firebaseAuth.error.wrongPassword': return '密碼錯誤';
+			case 'authentication.firebaseAuth.error.emailAlreadyInUse': return '電子郵件地址已在使用中。請使用其他電子郵件地址登錄或創建';
+			case 'authentication.firebaseAuth.error.unexpected': return '發生錯誤。請在良好的網絡環境中重試';
+			case 'authentication.resetPasswordPage.title': return '重設密碼';
+			case 'authentication.resetPasswordPage.description': return '將發送密碼重設郵件到輸入的電子郵件地址';
+			case 'authentication.resetPasswordPage.textFields.email': return '電子郵件地址';
+			case 'authentication.resetPasswordPage.buttons.submit': return '發送';
+			case 'authentication.signUpPage.title': return '註冊';
+			case 'authentication.signUpPage.textFields.email': return '電子郵件地址';
+			case 'authentication.signUpPage.textFields.password': return '密碼';
+			case 'authentication.signUpPage.button': return '註冊';
+			case 'authentication.emailVerificationPage.title': return '電子郵件地址驗證';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '將向輸入的${email}發送確認郵件。';
+			case 'authentication.emailVerificationPage.descriptionForCoolDown': return '確認郵件每60秒只能重新發送一次。';
+			case 'authentication.emailVerificationPage.buttons.sendEmail': return '發送確認郵件';
+			case 'authentication.emailVerificationPage.buttons.resendEmail': return '重新發送確認郵件';
+			case 'authentication.emailVerificationPage.buttons.toNext': return '下一步';
+			case 'authentication.emailVerificationPage.buttons.retypeEmail': return '修改電子郵件地址';
+			case 'authentication.emailVerificationPage.snackBar.success': return '發送成功';
+			case 'authentication.emailVerificationPage.snackBar.error.unexpected': return '發生錯誤，請稍後再試。';
+			case 'authentication.registerProfilePage.title': return '註冊個人資訊';
+			case 'authentication.registerProfilePage.textFields': return '姓名';
+			case 'authentication.registerProfilePage.buttons.submit': return '完成';
+			case 'authentication.registerProfilePage.buttons.skip': return '跳過';
+			case 'authentication.registerProfilePage.snackBar.error.submitIfAllEmpty': return '請輸入信息';
+			case 'authentication.registerProfilePage.snackBar.error.unexpected': return '發生錯誤，請稍後再試。';
+			case 'authentication.completeSendEmailPage.title': return '發送完成';
+			case 'authentication.completeSendEmailPage.description': return ({required Object email}) => '密碼重設郵件已發送到${email} \n 重設後請從登入畫面登入';
+			case 'authentication.completeSendEmailPage.successResendEmail': return '確認郵件已重新發送';
+			case 'authentication.completeSendEmailPage.buttons.toSignIn': return '前往登入畫面';
+			case 'authentication.completeSendEmailPage.buttons.resendEmail': return '重新發送確認郵件';
+			case 'authentication.completeSendEmailPage.buttons.changeEmail': return '更改電子郵件地址';
+			case 'validation.emailRequired': return '請輸入電子郵件地址';
+			case 'validation.emailInvalid': return '電子郵件地址格式不正確';
+			case 'validation.passwordRequired': return '請輸入密碼';
+			case 'validation.passwordShort': return '密碼必須至少8個字符';
+			case 'validation.passwordWeak': return '密碼應包含字母和數字的組合';
+			case 'validation.passwordMatch': return '密碼不匹配';
+			case 'validation.informationRequired': return '請輸入信息';
+			case 'validation.urlInvalid': return 'URL格式不正確';
+			case 'validation.userNameRequired': return '請輸入您的使用者名稱';
+			case 'validation.userNameMaxLength': return '使用者名稱必須為8個字符或更少';
+			case 'myPage.unregisteredUserName': return '未註冊';
+			case 'myPage.editProfile': return '編輯個人資料';
+			case 'myPage.premiumPlan': return '進階方案';
+			case 'myPage.details': return '詳細';
+			case 'myPage.settings': return '設定';
+			case 'myPage.account': return '帳戶';
+			case 'myPage.language': return '語言';
+			case 'myPage.theme': return '主題';
+			case 'myPage.termsOfUsePrivacyPolicy': return '使用條款和隱私政策';
+			case 'myPage.aboutThisApp': return '關於本應用';
+			case 'myPage.aboutTheDeveloper': return '關於開發者';
+			case 'myPage.accountStatus.dateTime.registeredOn': return ({required Object date}) => '${date}註冊於';
+			case 'myPage.accountStatus.dateTime.registeredOnFormat': return 'yyyy年MM月dd日';
+			case 'myPage.accountStatus.dateTime.validUntil': return ({required Object date}) => '有效期至${date}';
+			case 'myPage.accountStatus.dateTime.validUntilFormat': return 'yyyy年MM月dd日 HH:mm';
+			case 'myPage.accountStatus.premium': return '進階會員';
+			case 'myPage.accountStatus.standard': return '標準會員';
+			case 'changeLanguagePage.title': return '語言';
+			case 'changeLanguagePage.items.japanese': return '日语';
+			case 'changeLanguagePage.items.english': return '英语';
+			case 'changeLanguagePage.items.simplifiedChinese': return '中文(简体字)';
+			case 'changeLanguagePage.items.traditionalChinese': return '中文(繁体字)';
+			case 'changeThemePage.title': return '主题';
+			case 'changeThemePage.items.system': return '系统';
+			case 'changeThemePage.items.light': return '光';
+			case 'changeThemePage.items.dark': return '黑暗';
+			case 'myPlanPage.title': return '我的方案';
+			case 'myPlanPage.tabs.createdPlans': return '已建立方案';
+			case 'myPlanPage.tabs.bookmark': return '書籤';
+			case 'myPlanPage.bookmarkItems.nondata': return '暫無收藏方案。';
+			case 'myPlanPage.bookmarkItems.reloading': return '重新載入';
+			case 'myPlanPage.createdPlansItems.nondata': return '開始建立方案吧！';
+			case 'myPlanPage.createdPlansItems.createaplan': return '建立方案';
+			case 'myPlanPage.error.displayError': return '顯示方案時發生錯誤。';
+			case 'myPlanPage.error.failedGetId': return '取得方案ID失敗。';
+			case 'myPlanPage.error.failedGetPlanData': return '取得方案資料時發生錯誤。';
+			case 'myPlanPage.error.failedUnBookmark': return '取消收藏時發生錯誤。';
+			case 'buddyChatPage.title': return 'Buddy的建議';
+			case 'buddyChatPage.possibleChatCount': return ({required Object possibleChatCount}) => '訊息還可以發送${possibleChatCount}次';
+			case 'buddyChatPage.textFields.message': return '輸入訊息';
+			case 'buddyChatPage.buttons.send': return '完成';
+			case 'buddyChatPage.placeCard.openingHours': return '營業時間';
+			case 'buddyChatPage.placeCard.averageAmount': return '平均預算';
+			case 'buddyChatPage.placeCard.website': return '網站';
+			case 'buddyChatPage.snackBar.error.failedRecieveMessage': return '無法接收回覆，請稍後再試';
+			case 'buddyChatPage.snackBar.error.failedCompleteCreatePlan': return '無法完成建立計劃，請稍後再試';
+			case 'popularTopics.sectionName': return '熱門話題';
+			case 'createPlanPage.title': return '建立計劃';
+			case 'createPlanPage.label.location': return '目的地';
+			case 'createPlanPage.label.scheduleStart': return '開始日期';
+			case 'createPlanPage.label.scheduleEnd': return '結束日期';
+			case 'createPlanPage.label.numberOfPeople': return '人數';
+			case 'createPlanPage.label.transport': return '交通方式';
+			case 'createPlanPage.label.category': return '類別';
+			case 'createPlanPage.label.topics': return '旅行主題';
+			case 'createPlanPage.hintText.location': return '澀谷';
+			case 'createPlanPage.modal.title': return '選擇日期';
+			case 'createPlanPage.numberOfPeopleOptions.0': return '1人';
+			case 'createPlanPage.numberOfPeopleOptions.1': return '2人';
+			case 'createPlanPage.numberOfPeopleOptions.2': return '3人';
+			case 'createPlanPage.numberOfPeopleOptions.3': return '4人';
+			case 'createPlanPage.numberOfPeopleOptions.4': return '5人';
+			case 'createPlanPage.numberOfPeopleOptions.5': return '6人以上';
+			case 'createPlanPage.transportOptions.0': return '火車';
+			case 'createPlanPage.transportOptions.1': return '步行';
+			case 'createPlanPage.transportOptions.2': return '汽車';
+			case 'createPlanPage.transportOptions.3': return '巴士';
+			case 'createPlanPage.categoryOptions.0': return '親子';
+			case 'createPlanPage.categoryOptions.1': return '成人';
+			case 'createPlanPage.categoryOptions.2': return '娛樂';
+			case 'createPlanPage.categoryOptions.3': return '活動';
+			case 'createPlanPage.categoryOptions.4': return '歷史';
+			case 'createPlanPage.defaultTopics.0': return '美食';
+			case 'createPlanPage.defaultTopics.1': return '購物';
+			case 'createPlanPage.defaultTopics.2': return '活動';
+			case 'createPlanPage.defaultTopics.3': return '電影';
+			case 'createPlanPage.submitButton': return '提交計劃給AI';
+			case 'createPlanPage.snackBar.error.foundUnSelectedField': return '存在未選擇的項目，請選擇所有項目';
+			case 'editProfilePage.title': return '編輯個人資料';
+			case 'editProfilePage.textFields.name': return '姓名';
+			case 'editProfilePage.buttons.submit': return '儲存';
+			case 'editProfilePage.snackBar.success': return '更新成功';
+			case 'editProfilePage.snackBar.error.noChange': return '沒有變更';
+			case 'editProfilePage.snackBar.error.failedToUpdate': return '更新失敗，請稍後再試';
+			case 'editProfilePage.snackBar.error.failedToPickImage': return '選擇圖片失敗，請稍後再試';
+			case 'confirmDialog.answers.yes': return '是';
+			case 'confirmDialog.answers.no': return '否';
+			case 'confirmDialog.popPage.title': return '要返回上一頁嗎？';
+			case 'confirmDialog.popPage.description': return '當前內容不會被保存';
+			case 'confirmDialog.completeCreatePlan.title': return '確定要保存計劃嗎？';
+			case 'confirmDialog.completeCreatePlan.description': return '最後一條訊息中的計劃將被保存';
+			case 'prompt.planProposalMessage': return '我考慮了這個計劃！您覺得怎麼樣？';
+			case 'billDetailsPage.title': return '高級方案';
+			case 'billDetailsPage.description': return '訂閱高級方案後，您可以更舒適地享受澀谷觀光。';
+			case 'billDetailsPage.pricingPlan.title': return '價格方案';
+			case 'billDetailsPage.pricingPlan.columns.standard': return '標準';
+			case 'billDetailsPage.pricingPlan.columns.premium': return '高級';
+			case 'billDetailsPage.pricingPlan.details.free': return '免費 🎉';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.days': return '按天數購買';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.daily': return '・1日 300日圓';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays': return '・3日 855日圓';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays': return '・5日 1,480日圓';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays': return '・7日 2,070日圓';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.or': return '或者';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime': return '終身';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice': return '25,800日圓';
+			case 'billDetailsPage.features.title': return '等級功能';
+			case 'billDetailsPage.features.rows.planCreationLimit': return '可創建的方案次數';
+			case 'billDetailsPage.features.rows.chatLimit': return '方案創建期間可用聊天次數';
+			case 'billDetailsPage.features.rows.timelineAccess': return '訪問所有方案時間表';
+			case 'billDetailsPage.features.rows.adFree': return '無廣告';
+			case 'billDetailsPage.features.rows.exclusiveFeatures': return '方案認證功能';
+			case 'billDetailsPage.features.columns.standard.label': return '標準';
+			case 'billDetailsPage.features.columns.standard.planCreationLimit': return '2次';
+			case 'billDetailsPage.features.columns.standard.chatLimit': return '3次';
+			case 'billDetailsPage.features.columns.premium.label': return '高級';
+			case 'billDetailsPage.features.columns.premium.planCreationLimit': return '無限制';
+			case 'billDetailsPage.features.columns.premium.chatLimit': return '無限制';
+			case 'billDetailsPage.pricingOptions.oneDay.duration': return '1日';
+			case 'billDetailsPage.pricingOptions.oneDay.discount': return '';
+			case 'billDetailsPage.pricingOptions.oneDay.price': return '300日圓';
+			case 'billDetailsPage.pricingOptions.threeDays.duration': return '3日';
+			case 'billDetailsPage.pricingOptions.threeDays.discount': return '-5%';
+			case 'billDetailsPage.pricingOptions.threeDays.price': return '890日圓';
+			case 'billDetailsPage.pricingOptions.fiveDays.duration': return '5日';
+			case 'billDetailsPage.pricingOptions.fiveDays.discount': return '-7.5%';
+			case 'billDetailsPage.pricingOptions.fiveDays.price': return '1,387日圓';
+			case 'billDetailsPage.pricingOptions.sevenDays.duration': return '7日';
+			case 'billDetailsPage.pricingOptions.sevenDays.discount': return '-10%';
+			case 'billDetailsPage.pricingOptions.sevenDays.price': return '2,070日圓';
+			case 'billDetailsPage.pricingOptions.lifetime.duration': return '終身';
+			case 'billDetailsPage.pricingOptions.lifetime.discount': return '';
+			case 'billDetailsPage.pricingOptions.lifetime.price': return '25,800日圓';
+			case 'billDetailsPage.upgradeButton': return '升級到高級方案';
+			case 'planDetailsPage.dateTime.createOn': return ({required Object date}) => '${date}建立的方案';
+			case 'planDetailsPage.dateTime.dateFormat': return 'yyyy年MM月dd日';
+			case 'planDetailsPage.item.viewOnMap': return '在地圖上查看';
+			case 'planDetailsPage.snackBar.error.failedToUpdateBookmark': return '更新書籤失敗，請稍後再試';
+			case 'locales.en': return '英語';
+			case 'locales.ja': return '日語';
+			case 'locales.zh': return '中文';
+			case 'errorPage.title': return '發生錯誤...';
+			case 'errorPage.message': return '請檢查您的網絡連接並重試。';
+			case 'errorPage.retryButton': return '重試';
+			case 'mapPage.title': return '地圖';
+			default: return null;
+		}
+	}
 }
+

--- a/lib/presentation/components/simple_text_field.dart
+++ b/lib/presentation/components/simple_text_field.dart
@@ -37,7 +37,7 @@ class SimpleTextField extends StatelessWidget {
       keyboardType: keyboardType,
       textInputAction: textInputAction,
       obscureText: obscureText,
-      validator: (value) => validateMaxBytes(value, maxBytes),
+      validator: validator,
       cursorColor: AppColor.blue800Secondary,
       style: AppTextStyle.textStyle.copyWith(
         color: AppColor.black,
@@ -70,17 +70,4 @@ class SimpleTextField extends StatelessWidget {
       ),
     );
   }
-}
-
-// バイト数計算をする関数
-String? validateMaxBytes(String? value, int? maxBytes) {
-  if (maxBytes != null && value != null) {
-    final byteCount = value.runes.fold(0, (sum, char) {
-      return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
-    });
-    if (byteCount > maxBytes) {
-      return '入力は最大8字までです';
-    }
-  }
-  return null;
 }

--- a/lib/presentation/components/simple_text_field.dart
+++ b/lib/presentation/components/simple_text_field.dart
@@ -15,7 +15,9 @@ class SimpleTextField extends StatelessWidget {
     required this.onFieldSubmitted,
     this.icon,
     required this.label,
+    this.maxBytes,
   });
+
   final TextEditingController controller;
   final FocusNode? focusNode;
   final TextInputType keyboardType;
@@ -25,6 +27,7 @@ class SimpleTextField extends StatelessWidget {
   final void Function(String) onFieldSubmitted;
   final Widget? icon;
   final String label;
+  final int? maxBytes;
 
   @override
   Widget build(BuildContext context) {
@@ -39,6 +42,31 @@ class SimpleTextField extends StatelessWidget {
       style: AppTextStyle.textStyle.copyWith(
         color: AppColor.black,
       ),
+      onChanged: (value) {
+        if (maxBytes != null) {
+          final byteCount = value.runes.fold(0, (sum, char) {
+            return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
+          });
+          if (byteCount > maxBytes!) {
+            // 制限を超えた場合にトリミング
+            var truncatedValue = '';
+            var currentByteCount = 0;
+            for (final char in value.runes) {
+              final charBytes = char > 255 ? 2 : 1;
+              if (currentByteCount + charBytes <= maxBytes!) {
+                truncatedValue += String.fromCharCode(char);
+              }
+              currentByteCount += charBytes;
+            }
+            controller
+              ..text = truncatedValue
+              ..selection = TextSelection.fromPosition(
+                TextPosition(offset: truncatedValue.length),
+              );
+          }
+        }
+      },
+      onFieldSubmitted: onFieldSubmitted,
       decoration: InputDecoration(
         suffixIcon: icon,
         border: const OutlineInputBorder(

--- a/lib/presentation/components/simple_text_field.dart
+++ b/lib/presentation/components/simple_text_field.dart
@@ -83,7 +83,8 @@ class SimpleTextField extends StatelessWidget {
       }
     }
   }
- // バイト数が制限を超えた場合のトリミング処理
+
+  // バイト数が制限を超えた場合のトリミング処理
   void _trimInputToMaxBytes(String value) {
     var truncatedValue = '';
     var currentByteCount = 0;

--- a/lib/presentation/components/simple_text_field.dart
+++ b/lib/presentation/components/simple_text_field.dart
@@ -42,30 +42,7 @@ class SimpleTextField extends StatelessWidget {
       style: AppTextStyle.textStyle.copyWith(
         color: AppColor.black,
       ),
-      onChanged: (value) {
-        if (maxBytes != null) {
-          final byteCount = value.runes.fold(0, (sum, char) {
-            return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
-          });
-          if (byteCount > maxBytes!) {
-            // 制限を超えた場合にトリミング
-            var truncatedValue = '';
-            var currentByteCount = 0;
-            for (final char in value.runes) {
-              final charBytes = char > 255 ? 2 : 1;
-              if (currentByteCount + charBytes <= maxBytes!) {
-                truncatedValue += String.fromCharCode(char);
-              }
-              currentByteCount += charBytes;
-            }
-            controller
-              ..text = truncatedValue
-              ..selection = TextSelection.fromPosition(
-                TextPosition(offset: truncatedValue.length),
-              );
-          }
-        }
-      },
+      onChanged: _handleInputChange,
       onFieldSubmitted: onFieldSubmitted,
       decoration: InputDecoration(
         suffixIcon: icon,
@@ -93,5 +70,34 @@ class SimpleTextField extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  // 必要に応じて、バイト数チェックを行う
+  void _handleInputChange(String value) {
+    if (maxBytes != null) {
+      final byteCount = value.runes.fold(0, (sum, char) {
+        return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
+      });
+      if (byteCount > maxBytes!) {
+        _trimInputToMaxBytes(value);
+      }
+    }
+  }
+ // バイト数が制限を超えた場合のトリミング処理
+  void _trimInputToMaxBytes(String value) {
+    var truncatedValue = '';
+    var currentByteCount = 0;
+    for (final char in value.runes) {
+      final charBytes = char > 255 ? 2 : 1;
+      if (currentByteCount + charBytes <= maxBytes!) {
+        truncatedValue += String.fromCharCode(char);
+      }
+      currentByteCount += charBytes;
+    }
+    controller
+      ..text = truncatedValue
+      ..selection = TextSelection.fromPosition(
+        TextPosition(offset: truncatedValue.length),
+      );
   }
 }

--- a/lib/presentation/components/simple_text_field.dart
+++ b/lib/presentation/components/simple_text_field.dart
@@ -37,12 +37,11 @@ class SimpleTextField extends StatelessWidget {
       keyboardType: keyboardType,
       textInputAction: textInputAction,
       obscureText: obscureText,
-      validator: validator,
+      validator: (value) => validateMaxBytes(value, maxBytes),
       cursorColor: AppColor.blue800Secondary,
       style: AppTextStyle.textStyle.copyWith(
         color: AppColor.black,
       ),
-      onChanged: _handleInputChange,
       onFieldSubmitted: onFieldSubmitted,
       decoration: InputDecoration(
         suffixIcon: icon,
@@ -71,34 +70,17 @@ class SimpleTextField extends StatelessWidget {
       ),
     );
   }
+}
 
-  // 必要に応じて、バイト数チェックを行う
-  void _handleInputChange(String value) {
-    if (maxBytes != null) {
-      final byteCount = value.runes.fold(0, (sum, char) {
-        return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
-      });
-      if (byteCount > maxBytes!) {
-        _trimInputToMaxBytes(value);
-      }
+// バイト数計算をする関数
+String? validateMaxBytes(String? value, int? maxBytes) {
+  if (maxBytes != null && value != null) {
+    final byteCount = value.runes.fold(0, (sum, char) {
+      return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
+    });
+    if (byteCount > maxBytes) {
+      return '入力は最大8字までです';
     }
   }
-
-  // バイト数が制限を超えた場合のトリミング処理
-  void _trimInputToMaxBytes(String value) {
-    var truncatedValue = '';
-    var currentByteCount = 0;
-    for (final char in value.runes) {
-      final charBytes = char > 255 ? 2 : 1;
-      if (currentByteCount + charBytes <= maxBytes!) {
-        truncatedValue += String.fromCharCode(char);
-      }
-      currentByteCount += charBytes;
-    }
-    controller
-      ..text = truncatedValue
-      ..selection = TextSelection.fromPosition(
-        TextPosition(offset: truncatedValue.length),
-      );
-  }
+  return null;
 }

--- a/lib/presentation/mypage/components/account_status.dart
+++ b/lib/presentation/mypage/components/account_status.dart
@@ -63,17 +63,22 @@ class AccountStatus extends StatelessWidget {
                         ),
                 ),
                 const SizedBox(width: 8),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 3),
-                  child: Text(
-                    user.name ?? myPageItemi18n.unregisteredUserName,
-                    style: AppTextStyle.textStyle.copyWith(
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 3),
+                    child: Text(
+                      user.name ?? myPageItemi18n.unregisteredUserName,
+                      style: AppTextStyle.textStyle.copyWith(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      softWrap: false,
                     ),
                   ),
                 ),
-                const Spacer(),
+                const SizedBox(width: 8),
                 Text(
                   acountStatusi18n.dateTime.registeredOn(date: createFormat),
                   style: AppTextStyle.textStyle.copyWith(

--- a/lib/presentation/mypage/edit_profile/edit_profile_page.dart
+++ b/lib/presentation/mypage/edit_profile/edit_profile_page.dart
@@ -70,6 +70,7 @@ class EditProfilePage extends HookConsumerWidget {
                         validator: Validator.common,
                         onFieldSubmitted: (_) {},
                         label: t.editProfilePage.textFields.name,
+                        maxBytes: 16,
                       ),
                     ],
                   ),

--- a/lib/presentation/mypage/edit_profile/edit_profile_page.dart
+++ b/lib/presentation/mypage/edit_profile/edit_profile_page.dart
@@ -25,6 +25,7 @@ class EditProfilePage extends HookConsumerWidget {
     final state = ref.watch(editProfilePageNotifierProvider(user));
     final formKey = GlobalKey<FormState>();
     final notifier = ref.read(editProfilePageNotifierProvider(user).notifier);
+    const maxBytes = 16;
 
     return state.when(
       data: (value) {
@@ -70,10 +71,11 @@ class EditProfilePage extends HookConsumerWidget {
                           controller: controller,
                           keyboardType: TextInputType.text,
                           textInputAction: TextInputAction.done,
-                          validator: Validator.common,
+                          validator: (value) =>
+                              Validator.userName(value, maxBytes),
                           onFieldSubmitted: (_) {},
                           label: t.editProfilePage.textFields.name,
-                          maxBytes: 16,
+                          maxBytes: maxBytes,
                         ),
                       ),
                     ],

--- a/lib/presentation/mypage/edit_profile/edit_profile_page.dart
+++ b/lib/presentation/mypage/edit_profile/edit_profile_page.dart
@@ -23,6 +23,7 @@ class EditProfilePage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final controller = useTextEditingController(text: user.name);
     final state = ref.watch(editProfilePageNotifierProvider(user));
+    final formKey = GlobalKey<FormState>();
     final notifier = ref.read(editProfilePageNotifierProvider(user).notifier);
 
     return state.when(
@@ -63,14 +64,17 @@ class EditProfilePage extends HookConsumerWidget {
                         ),
                       ),
                       const Gap(32),
-                      SimpleTextField(
-                        controller: controller,
-                        keyboardType: TextInputType.text,
-                        textInputAction: TextInputAction.done,
-                        validator: Validator.common,
-                        onFieldSubmitted: (_) {},
-                        label: t.editProfilePage.textFields.name,
-                        maxBytes: 16,
+                      Form(
+                        key: formKey,
+                        child: SimpleTextField(
+                          controller: controller,
+                          keyboardType: TextInputType.text,
+                          textInputAction: TextInputAction.done,
+                          validator: Validator.common,
+                          onFieldSubmitted: (_) {},
+                          label: t.editProfilePage.textFields.name,
+                          maxBytes: 16,
+                        ),
                       ),
                     ],
                   ),
@@ -79,10 +83,12 @@ class EditProfilePage extends HookConsumerWidget {
                     label: t.editProfilePage.buttons.submit,
                     color: AppColor.yellow600Primary,
                     onPressed: () async {
-                      await notifier.editProfile(
-                        name: controller.text,
-                        onSuccess: () => context.pop(),
-                      );
+                      if (formKey.currentState!.validate()) {
+                        await notifier.editProfile(
+                          name: controller.text,
+                          onSuccess: () => context.pop(),
+                        );
+                      }
                     },
                   ),
                 ],

--- a/lib/presentation/register_profile/register_profile_page.dart
+++ b/lib/presentation/register_profile/register_profile_page.dart
@@ -104,6 +104,7 @@ class RegisterProfilePage extends HookConsumerWidget {
                   keyboardType: TextInputType.name,
                   textInputAction: TextInputAction.next,
                   label: i18nRegisterProfilePage.textFields,
+                  maxBytes: 16,
                 ),
                 const Gap(24),
                 WideButton(

--- a/lib/presentation/register_profile/register_profile_page.dart
+++ b/lib/presentation/register_profile/register_profile_page.dart
@@ -28,6 +28,7 @@ class RegisterProfilePage extends HookConsumerWidget {
     final formKey = useFormStateKey();
     final state = ref.watch(registerProfilePageNotifierProvider);
     final notifier = ref.read(registerProfilePageNotifierProvider.notifier);
+    const maxBytes = 16;
 
     Future<void> registerProfile() async {
       if (state.pickedFile == null && nameController.text.isEmpty) {
@@ -36,7 +37,8 @@ class RegisterProfilePage extends HookConsumerWidget {
             );
         return;
       }
-      if (state.pickedFile != null || formKey.currentState!.validate()) {
+
+      if (formKey.currentState?.validate() ?? false) {
         await notifier.registerInformation(
           name: nameController.text,
           onSuccess: () => context.go(
@@ -100,7 +102,7 @@ class RegisterProfilePage extends HookConsumerWidget {
                 SimpleTextField(
                   controller: nameController,
                   onFieldSubmitted: (_) async => registerProfile(),
-                  validator: Validator.common,
+                  validator: (value) => Validator.userName(value, maxBytes),
                   keyboardType: TextInputType.name,
                   textInputAction: TextInputAction.next,
                   label: i18nRegisterProfilePage.textFields,

--- a/lib/utils/validator.dart
+++ b/lib/utils/validator.dart
@@ -69,7 +69,10 @@ class Validator {
 
   /// ユーザーネーム入力時のバリデーション
   static String? userName(String? value, int? maxBytes) {
-    if (maxBytes != null && value != null) {
+    if (value == null || value.isEmpty) {
+      return 'ユーザーネームを入力してください';
+    }
+    if (maxBytes != null) {
       final byteCount = value.runes.fold(0, (sum, char) {
         return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
       });

--- a/lib/utils/validator.dart
+++ b/lib/utils/validator.dart
@@ -70,14 +70,14 @@ class Validator {
   /// ユーザーネーム入力時のバリデーション
   static String? userName(String? value, int? maxBytes) {
     if (value == null || value.isEmpty) {
-      return 'ユーザーネームを入力してください';
+      return _i18nValidation.usernameRequired;
     }
     if (maxBytes != null) {
       final byteCount = value.runes.fold(0, (sum, char) {
         return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
       });
       if (byteCount > maxBytes) {
-        return '入力は最大8字までです';
+        return _i18nValidation.usernameMaxLength;
       }
     }
     return null;

--- a/lib/utils/validator.dart
+++ b/lib/utils/validator.dart
@@ -66,4 +66,17 @@ class Validator {
     }
     return null;
   }
+
+  /// ユーザーネーム入力時のバリデーション
+  static String? userName(String? value, int? maxBytes) {
+    if (maxBytes != null && value != null) {
+      final byteCount = value.runes.fold(0, (sum, char) {
+        return sum + (char > 255 ? 2 : 1); // 全角:2バイト, 半角:1バイト
+      });
+      if (byteCount > maxBytes) {
+        return '入力は最大8字までです';
+      }
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
## 対応したこと
- アカウントステータスに表示制限を追加
　- maxLinesを1, overflow: TextOverflow.ellipsis,softWrap: false,
　- Expandedを追加し横幅の最大分を取るように(最大を超した場合は省略されます)
- アカウント作成時、編集時のSimpleTextFieldにByte数制限を追加、最大16Byte
　- Validatorにusernameバリデーションを追加
　- Validatorを適応
<!-- 対応したことを箇条書きでわかりやすく -->

## 関連資料
[ChatGPT](https://chatgpt.com)
<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->

## 残タスク

- [ ] 省略記号をリッチにする

<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

## 画面キャプチャ
左のEnglishで全体的な動きを収録してあります。
右の日本語はByte(わかりにくいので文字数換算)の制限が日本語だと8字までにと翻訳されていることを示す画像です
アルファベット: 16文字 日本語,簡体字,繁体字: 8文字
| English | 日本語 |
|---------|--------|
| <video src="https://github.com/user-attachments/assets/2be4874b-afd2-4755-8383-819e9379baa5" controls></video> | ![Simulator Screenshot](https://github.com/user-attachments/assets/5820f721-1766-4123-b016-dbd46b698f00) |


<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
