### PR TITLE
planCardの表示を修正。

### DIFF
--- a/lib/presentation/components/ranking_label.dart
+++ b/lib/presentation/components/ranking_label.dart
@@ -28,8 +28,9 @@ class RankingLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final size = context.deviceWidth * 0.1;
-
+    final devicesize = context.deviceWidth;
+    final size = devicesize * 0.1;
+    debugPrint(devicesize.toString());
     return Offstage(
       offstage: ranking == null,
       child: Container(
@@ -42,7 +43,10 @@ class RankingLabel extends StatelessWidget {
           ),
           color: rankingColor(ranking),
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 7.5),
+        padding: EdgeInsets.symmetric(
+          horizontal: ranking! < 10 ? devicesize * 0.03 : devicesize * 0.01,
+          vertical: devicesize * 0.01,
+        ),
         width: size,
         height: size,
         child: Text(

--- a/lib/presentation/components/ranking_label.dart
+++ b/lib/presentation/components/ranking_label.dart
@@ -30,7 +30,6 @@ class RankingLabel extends StatelessWidget {
   Widget build(BuildContext context) {
     final devicesize = context.deviceWidth;
     final size = devicesize * 0.1;
-    debugPrint(devicesize.toString());
     return Offstage(
       offstage: ranking == null,
       child: Container(


### PR DESCRIPTION
## 対応したこと
planCardのRankinglabelのpaddingを数値で固定していたものを端末の大きさごとに変わるように修正

## 画面キャプチャ（修正前）
<img width="184" alt="label" src="https://github.com/user-attachments/assets/959b8e89-eca5-48da-bb6b-1177ba00fddd" />

## 画面キャプチャ（修正後）

### 小さい端末
<img width="50%" alt="スクリーンショット 2025-01-23 15 13 26" src="https://github.com/user-attachments/assets/3f97defb-779d-47eb-8cad-28570d1e05bb" />

### 大きい端末
<img width="50%" alt="スクリーンショット 2025-01-23 15 13 26" src="https://github.com/user-attachments/assets/1db100b6-c367-482b-b60a-42cee8d86f71" />
<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
