### PR TITLE
マイプランページのタグがオーバーフローする不具合

### DIFF
--- a/lib/presentation/components/row_category_tags.dart
+++ b/lib/presentation/components/row_category_tags.dart
@@ -104,6 +104,6 @@ class RowCategoryTags extends StatelessWidget {
       ),
       textDirection: TextDirection.ltr,
     )..layout();
-    return textPainter.width + 16;
+    return textPainter.width + 18;
   }
 }


### PR DESCRIPTION
## 対応したこと

マイプランページのタグがオーバーフローする不具合
予想された不具合
・修正したコードのタグの幅計算に...の部分が含まれていないことによって起こった可能性

## 関連資料

🍐

## 残タスク

🍐

## 画面キャプチャ

### 修正前(5inch)
<img src="https://github.com/user-attachments/assets/c42442de-fa1c-42ea-87ea-8c4ef488c8ce" width="50%">

### 修正後(5inch)
<img src="https://github.com/user-attachments/assets/9f6cf0c8-4343-45d4-8030-1960ce1ff8ff" width="50%">

### 修正後(4inch)
<img src="https://github.com/user-attachments/assets/b62d6d14-4882-4c9e-8cc8-a8af856e71bd" width="50%">

### 修正後(iphone se)
<img src="https://github.com/user-attachments/assets/08789ff8-2dc4-4446-804e-f12af2c456ee" width="50%">

### 修正後(iphone pro max)
<img src="https://github.com/user-attachments/assets/d2ab31ea-2b88-4c34-87bf-a460d6af608a" width="50%">
