### PR TITLE
プラン作成画面で長文を打つとテキストフィールドがオーバーフローする不具合の修正

### DIFF
--- a/lib/presentation/buddy_chat/buddy_chat_page.dart
+++ b/lib/presentation/buddy_chat/buddy_chat_page.dart
@@ -189,27 +189,30 @@ class BuddyChatPage extends HookConsumerWidget {
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           Expanded(
             child: IntrinsicHeight(
-              child: TextFormField(
-                expands: true,
-                maxLines: null,
-                cursorColor: AppColor.black,
-                keyboardType: TextInputType.multiline,
-                validator: Validator.common,
-                maxLength: 256,
-                controller: textController,
-                onFieldSubmitted: (_) async => sendMessage(),
-                decoration: InputDecoration(
-                  counter: const SizedBox.shrink(),
-                  filled: true,
-                  fillColor: AppColor.grey200,
-                  border: const OutlineInputBorder(
-                    borderSide: BorderSide.none,
-                    borderRadius: BorderRadius.all(Radius.circular(12)),
+              child: SingleChildScrollView(
+                child: TextFormField(
+                  minLines: 1,
+                  maxLines: 6,
+                  cursorColor: AppColor.black,
+                  keyboardType: TextInputType.multiline,
+                  validator: Validator.common,
+                  maxLength: 256,
+                  controller: textController,
+                  onFieldSubmitted: (_) async => sendMessage(),
+                  decoration: InputDecoration(
+                    counter: const SizedBox.shrink(),
+                    filled: true,
+                    fillColor: AppColor.grey200,
+                    border: const OutlineInputBorder(
+                      borderSide: BorderSide.none,
+                      borderRadius: BorderRadius.all(Radius.circular(12)),
+                    ),
+                    hintText: localizedHintText,
                   ),
-                  hintText: localizedHintText,
                 ),
               ),
             ),


### PR DESCRIPTION
## 対応したこと

プラン作成画面で長文を打つとテキストフィールドがオーバーフローする不具合の修正

## 関連資料

🍐

## 残タスク

🍐

## 画面キャプチャ

<img src = "https://github.com/user-attachments/assets/c5e974d5-6e2e-490b-ae16-567e2139a736" width = "50%">
