### PR TITLE
Fix/slang

### DIFF
--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 5
 /// Strings: 1375 (275 per locale)
 ///
-/// Built on 2025-01-27 at 18:08 UTC
+/// Built on 2025-01-28 at 14:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -33,7 +33,7 @@
             "signOutFailure": "An error occurred while signing out.",
             "successfulLinkage": "Account linked successfully.",
             "linkageFailure": "Failed to link account.",
-            "providerAlreadyLinked": "This account is already linked.",
+            "providerAlreadyLinked": "This account has already been linked.",
             "accountDeactivation": "Account linkage has been removed.",
             "invalidCredential": "Please try logging in again.",
             "linkageCancelled": "Account linking was cancelled.",
@@ -152,9 +152,9 @@
         "phoneNumberInputPage": {
             "title": "Enter Phone Number",
             "discription": {
-                "receive": "To receive the SMS code",
-                "internationalFormat": "in international phone number format",
-                "input": "please enter your phone number"
+                "receive": "Please enter your phone number",
+                "internationalFormat": "in international format",
+                "input": "to receive the SMS code"
             },
             "phoneNumber": "Phone Number",
             "sendSmsCode": "Send SMS Code",
@@ -262,7 +262,7 @@
         }
     },
     "buddyChatPage": {
-        "title": "Buddy's Suggestions",
+        "title": "Buddy Suggestions",
         "possibleChatCount": "You can send ${possibleChatCount} more messages",
         "textFields": {
             "message": "Enter message"
@@ -317,7 +317,7 @@
             "Bus"
         ],
         "categoryOptions": [
-            "Family-friendly",
+            "Family-Friendly",
             "Adult",
             "Entertainment",
             "Activity",

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -200,7 +200,7 @@ class TranslationsBuddyChatPageEn {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	String get title => 'Buddy\'s Suggestions';
+	String get title => 'Buddy Suggestions';
 	String possibleChatCount({required Object possibleChatCount}) => 'You can send ${possibleChatCount} more messages';
 	late final TranslationsBuddyChatPageTextFieldsEn textFields = TranslationsBuddyChatPageTextFieldsEn._(_root);
 	late final TranslationsBuddyChatPageButtonsEn buttons = TranslationsBuddyChatPageButtonsEn._(_root);
@@ -244,7 +244,7 @@ class TranslationsCreatePlanPageEn {
 		'Bus',
 	];
 	List<String> get categoryOptions => [
-		'Family-friendly',
+		'Family-Friendly',
 		'Adult',
 		'Entertainment',
 		'Activity',
@@ -415,7 +415,7 @@ class TranslationsAccountPageSnackBarEn {
 	String get signOutFailure => 'An error occurred while signing out.';
 	String get successfulLinkage => 'Account linked successfully.';
 	String get linkageFailure => 'Failed to link account.';
-	String get providerAlreadyLinked => 'This account is already linked.';
+	String get providerAlreadyLinked => 'This account has already been linked.';
 	String get accountDeactivation => 'Account linkage has been removed.';
 	String get invalidCredential => 'Please try logging in again.';
 	String get linkageCancelled => 'Account linking was cancelled.';
@@ -1062,9 +1062,9 @@ class TranslationsAuthenticationPhoneNumberInputPageDiscriptionEn {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	String get receive => 'To receive the SMS code';
-	String get internationalFormat => 'in international phone number format';
-	String get input => 'please enter your phone number';
+	String get receive => 'Please enter your phone number';
+	String get internationalFormat => 'in international format';
+	String get input => 'to receive the SMS code';
 }
 
 // Path: authentication.phoneNumberInputPage.scaffoldMessenger
@@ -1367,7 +1367,7 @@ extension on Translations {
 			case 'accountPage.snackBar.signOutFailure': return 'An error occurred while signing out.';
 			case 'accountPage.snackBar.successfulLinkage': return 'Account linked successfully.';
 			case 'accountPage.snackBar.linkageFailure': return 'Failed to link account.';
-			case 'accountPage.snackBar.providerAlreadyLinked': return 'This account is already linked.';
+			case 'accountPage.snackBar.providerAlreadyLinked': return 'This account has already been linked.';
 			case 'accountPage.snackBar.accountDeactivation': return 'Account linkage has been removed.';
 			case 'accountPage.snackBar.invalidCredential': return 'Please try logging in again.';
 			case 'accountPage.snackBar.linkageCancelled': return 'Account linking was cancelled.';
@@ -1435,9 +1435,9 @@ extension on Translations {
 			case 'authentication.completeSendEmailPage.buttons.resendEmail': return 'Resend Confirmation Email';
 			case 'authentication.completeSendEmailPage.buttons.changeEmail': return 'Change Email Address';
 			case 'authentication.phoneNumberInputPage.title': return 'Enter Phone Number';
-			case 'authentication.phoneNumberInputPage.discription.receive': return 'To receive the SMS code';
-			case 'authentication.phoneNumberInputPage.discription.internationalFormat': return 'in international phone number format';
-			case 'authentication.phoneNumberInputPage.discription.input': return 'please enter your phone number';
+			case 'authentication.phoneNumberInputPage.discription.receive': return 'Please enter your phone number';
+			case 'authentication.phoneNumberInputPage.discription.internationalFormat': return 'in international format';
+			case 'authentication.phoneNumberInputPage.discription.input': return 'to receive the SMS code';
 			case 'authentication.phoneNumberInputPage.phoneNumber': return 'Phone Number';
 			case 'authentication.phoneNumberInputPage.sendSmsCode': return 'Send SMS Code';
 			case 'authentication.phoneNumberInputPage.scaffoldMessenger.empty': return 'Please enter your phone number';
@@ -1506,7 +1506,7 @@ extension on Translations {
 			case 'myPlanPage.error.failedGetId': return 'Failed to retrieve plan ID.';
 			case 'myPlanPage.error.failedGetPlanData': return 'An error occurred while retrieving plan data.';
 			case 'myPlanPage.error.failedUnBookmark': return 'Failed to remove bookmark.';
-			case 'buddyChatPage.title': return 'Buddy\'s Suggestions';
+			case 'buddyChatPage.title': return 'Buddy Suggestions';
 			case 'buddyChatPage.possibleChatCount': return ({required Object possibleChatCount}) => 'You can send ${possibleChatCount} more messages';
 			case 'buddyChatPage.textFields.message': return 'Enter message';
 			case 'buddyChatPage.buttons.send': return 'Done';
@@ -1536,7 +1536,7 @@ extension on Translations {
 			case 'createPlanPage.transportOptions.1': return 'Walking';
 			case 'createPlanPage.transportOptions.2': return 'Car';
 			case 'createPlanPage.transportOptions.3': return 'Bus';
-			case 'createPlanPage.categoryOptions.0': return 'Family-friendly';
+			case 'createPlanPage.categoryOptions.0': return 'Family-Friendly';
 			case 'createPlanPage.categoryOptions.1': return 'Adult';
 			case 'createPlanPage.categoryOptions.2': return 'Entertainment';
 			case 'createPlanPage.categoryOptions.3': return 'Activity';

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -89,7 +89,7 @@ class _TranslationsAccountPageKo implements TranslationsAccountPageEn {
 	final TranslationsKo _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '계정';
+	@override String get title => '계정 관리';
 	@override late final _TranslationsAccountPageItemsKo items = _TranslationsAccountPageItemsKo._(_root);
 	@override late final _TranslationsAccountPageSnackBarKo snackBar = _TranslationsAccountPageSnackBarKo._(_root);
 	@override late final _TranslationsAccountPageDiaLogKo diaLog = _TranslationsAccountPageDiaLogKo._(_root);
@@ -299,7 +299,7 @@ class _TranslationsBillDetailsPageKo implements TranslationsBillDetailsPageEn {
 
 	// Translations
 	@override late final _TranslationsBillDetailsPageTitleKo title = _TranslationsBillDetailsPageTitleKo._(_root);
-	@override String get description => '프리미엄 플랜에 가입하시면 더욱 편리하게 시부야 관광을 즐기실 수 있습니다.';
+	@override String get description => '프리미엄 플랜으로 더욱 편리한 시부야 여행을 계획해 보세요.';
 	@override late final _TranslationsBillDetailsPagePricingPlanKo pricingPlan = _TranslationsBillDetailsPagePricingPlanKo._(_root);
 	@override late final _TranslationsBillDetailsPageFeaturesKo features = _TranslationsBillDetailsPageFeaturesKo._(_root);
 	@override late final _TranslationsBillDetailsPagePricingOptionsKo pricingOptions = _TranslationsBillDetailsPagePricingOptionsKo._(_root);
@@ -351,7 +351,7 @@ class _TranslationsNavigationBarItemsKo implements TranslationsNavigationBarItem
 	// Translations
 	@override String get home => '홈';
 	@override String get myPlan => '내 플랜';
-	@override String get myPage => '내 페이지';
+	@override String get myPage => '마이페이지';
 }
 
 // Path: homePage.popularPlans
@@ -372,7 +372,7 @@ class _TranslationsHomePagePopularTopicsKo implements TranslationsHomePagePopula
 
 	// Translations
 	@override String get title => '인기 주제';
-	@override String numberOfTopics({required Object number}) => '${number}개~';
+	@override String numberOfTopics({required Object number}) => '${number}개';
 }
 
 // Path: homePage.recentPlans
@@ -393,8 +393,8 @@ class _TranslationsAccountPageItemsKo implements TranslationsAccountPageItemsEn 
 
 	// Translations
 	@override String get signOut => '로그아웃';
-	@override String get linkedWithGoogle => 'Google 연동';
-	@override String get linkedWithApple => 'Apple 연동';
+	@override String get linkedWithGoogle => 'Google 계정 연동';
+	@override String get linkedWithApple => 'Apple 계정 연동';
 	@override String get alreadyLinkedGoogle => 'Google 연동 완료';
 	@override String get alreadyLinkedApple => 'Apple 연동 완료';
 	@override String get deleteAccount => '계정 삭제';
@@ -408,18 +408,18 @@ class _TranslationsAccountPageSnackBarKo implements TranslationsAccountPageSnack
 
 	// Translations
 	@override String get signOut => '로그아웃되었습니다.';
-	@override String get signOutFailure => '로그아웃 중 오류가 발생했습니다.';
-	@override String get successfulLinkage => '계정 연동에 성공했습니다.';
+	@override String get signOutFailure => '로그아웃 처리 중 오류가 발생했습니다.';
+	@override String get successfulLinkage => '계정 연동이 완료되었습니다.';
 	@override String get linkageFailure => '계정 연동에 실패했습니다.';
 	@override String get providerAlreadyLinked => '이미 연동된 계정입니다.';
 	@override String get accountDeactivation => '계정 연동이 해제되었습니다.';
-	@override String get invalidCredential => '다시 로그인 해주세요.';
+	@override String get invalidCredential => '다시 로그인해 주세요.';
 	@override String get linkageCancelled => '계정 연동이 취소되었습니다.';
-	@override String get unlinkageFailure => '계정 연동 해제에 실패했습니다.';
-	@override String get operationNotAllowed => '제공자가 비활성화되었습니다. 개발자에게 문의하세요.';
+	@override String get unlinkageFailure => '계정 연동 해제를 실패했습니다.';
+	@override String get operationNotAllowed => '해당 서비스가 비활성화되었습니다. 개발자에게 문의해 주세요.';
 	@override String get unknownError => '알 수 없는 오류가 발생했습니다.';
 	@override String get deleteAccount => '계정이 삭제되었습니다.';
-	@override String get deleteAccountFailure => '계정 삭제에 실패했습니다.';
+	@override String get deleteAccountFailure => '계정 삭제를 실패했습니다.';
 }
 
 // Path: accountPage.diaLog
@@ -430,14 +430,14 @@ class _TranslationsAccountPageDiaLogKo implements TranslationsAccountPageDiaLogE
 
 	// Translations
 	@override String get yes => '예';
-	@override String get no => '아니요';
+	@override String get no => '아니오';
 	@override String get title => '계정 연동 해제 확인';
-	@override String get googleText => '현재 계정과 Google 계정의 연동을 해제하시겠습니까?';
-	@override String get appleText => '현재 계정과 Apple 계정의 연동을 해제하시겠습니까?';
-	@override String get signOut => '로그아웃하시겠습니까?';
-	@override String get signOutText => '앱 기능을 이용하려면 다시 로그인해야 합니다.';
-	@override String get deleteAccount => '계정을 삭제하시겠습니까?';
-	@override String get deleteAccountText => '계정을 삭제하면 모든 데이터가 삭제됩니다.';
+	@override String get googleText => 'Google 계정 연동을 해제하시겠습니까?';
+	@override String get appleText => 'Apple 계정 연동을 해제하시겠습니까?';
+	@override String get signOut => '로그아웃 하시겠습니까?';
+	@override String get signOutText => '다시 로그인해야 서비스를 이용하실 수 있습니다.';
+	@override String get deleteAccount => '정말 계정을 삭제하시겠습니까?';
+	@override String get deleteAccountText => '삭제 시 모든 데이터가 영구적으로 삭제됩니다.';
 }
 
 // Path: authentication.signInPage
@@ -804,7 +804,7 @@ class _TranslationsBillDetailsPageTitleKo implements TranslationsBillDetailsPage
 	// Translations
 	@override String get defaultTitle => '프리미엄 플랜';
 	@override String get createPlan => '무제한 플랜 생성을 활성화하시겠습니까?';
-	@override String get chat => '무제한 채팅을 즐기고 싶으신가요?';
+	@override String get chat => '무제한 채팅을 사용해 보시겠습니까?';
 }
 
 // Path: billDetailsPage.pricingPlan
@@ -814,7 +814,7 @@ class _TranslationsBillDetailsPagePricingPlanKo implements TranslationsBillDetai
 	final TranslationsKo _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '요금 플랜';
+	@override String get title => '요금제';
 	@override late final _TranslationsBillDetailsPagePricingPlanColumnsKo columns = _TranslationsBillDetailsPagePricingPlanColumnsKo._(_root);
 	@override late final _TranslationsBillDetailsPagePricingPlanDetailsKo details = _TranslationsBillDetailsPagePricingPlanDetailsKo._(_root);
 }
@@ -918,10 +918,10 @@ class _TranslationsAuthenticationSignInPageButtonsKo implements TranslationsAuth
 	// Translations
 	@override String get signIn => '로그인';
 	@override String get signUp => '회원가입';
-	@override String get resetPassword => '비밀번호를 잊으셨나요?';
+	@override String get resetPassword => '비밀번호 찾기';
 	@override String get appleSignIn => 'Apple로 로그인';
 	@override String get googleSignIn => 'Google로 로그인';
-	@override String get signInAfter => '나중에 등록';
+	@override String get signInAfter => '나중에 하기';
 }
 
 // Path: authentication.resetPasswordPage.textFields
@@ -1306,13 +1306,13 @@ class _TranslationsBillDetailsPagePricingPlanDetailsPremiumPriceKo implements Tr
 	final TranslationsKo _root; // ignore: unused_field
 
 	// Translations
-	@override String get days => '일수별 구매';
+	@override String get days => '일별 구매';
 	@override String daily({required Object price}) => '・1일 ${price}';
 	@override String threeDays({required Object price}) => '・3일 ${price}';
 	@override String fiveDays({required Object price}) => '・5일 ${price}';
 	@override String sevenDays({required Object price}) => '・7일 ${price}';
 	@override String get or => '또는';
-	@override String get lifetime => '영구 이용';
+	@override String get lifetime => '평생 이용권';
 	@override String lifetimePrice({required Object price}) => '${price}';
 }
 
@@ -1347,50 +1347,50 @@ extension on TranslationsKo {
 		switch (path) {
 			case 'navigationBar.items.home': return '홈';
 			case 'navigationBar.items.myPlan': return '내 플랜';
-			case 'navigationBar.items.myPage': return '내 페이지';
+			case 'navigationBar.items.myPage': return '마이페이지';
 			case 'homePage.popularPlans.title': return '인기 플랜';
 			case 'homePage.popularTopics.title': return '인기 주제';
-			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number}개~';
+			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number}개';
 			case 'homePage.recentPlans.title': return '최근 생성된 플랜';
-			case 'accountPage.title': return '계정';
+			case 'accountPage.title': return '계정 관리';
 			case 'accountPage.items.signOut': return '로그아웃';
-			case 'accountPage.items.linkedWithGoogle': return 'Google 연동';
-			case 'accountPage.items.linkedWithApple': return 'Apple 연동';
+			case 'accountPage.items.linkedWithGoogle': return 'Google 계정 연동';
+			case 'accountPage.items.linkedWithApple': return 'Apple 계정 연동';
 			case 'accountPage.items.alreadyLinkedGoogle': return 'Google 연동 완료';
 			case 'accountPage.items.alreadyLinkedApple': return 'Apple 연동 완료';
 			case 'accountPage.items.deleteAccount': return '계정 삭제';
 			case 'accountPage.snackBar.signOut': return '로그아웃되었습니다.';
-			case 'accountPage.snackBar.signOutFailure': return '로그아웃 중 오류가 발생했습니다.';
-			case 'accountPage.snackBar.successfulLinkage': return '계정 연동에 성공했습니다.';
+			case 'accountPage.snackBar.signOutFailure': return '로그아웃 처리 중 오류가 발생했습니다.';
+			case 'accountPage.snackBar.successfulLinkage': return '계정 연동이 완료되었습니다.';
 			case 'accountPage.snackBar.linkageFailure': return '계정 연동에 실패했습니다.';
 			case 'accountPage.snackBar.providerAlreadyLinked': return '이미 연동된 계정입니다.';
 			case 'accountPage.snackBar.accountDeactivation': return '계정 연동이 해제되었습니다.';
-			case 'accountPage.snackBar.invalidCredential': return '다시 로그인 해주세요.';
+			case 'accountPage.snackBar.invalidCredential': return '다시 로그인해 주세요.';
 			case 'accountPage.snackBar.linkageCancelled': return '계정 연동이 취소되었습니다.';
-			case 'accountPage.snackBar.unlinkageFailure': return '계정 연동 해제에 실패했습니다.';
-			case 'accountPage.snackBar.operationNotAllowed': return '제공자가 비활성화되었습니다. 개발자에게 문의하세요.';
+			case 'accountPage.snackBar.unlinkageFailure': return '계정 연동 해제를 실패했습니다.';
+			case 'accountPage.snackBar.operationNotAllowed': return '해당 서비스가 비활성화되었습니다. 개발자에게 문의해 주세요.';
 			case 'accountPage.snackBar.unknownError': return '알 수 없는 오류가 발생했습니다.';
 			case 'accountPage.snackBar.deleteAccount': return '계정이 삭제되었습니다.';
-			case 'accountPage.snackBar.deleteAccountFailure': return '계정 삭제에 실패했습니다.';
+			case 'accountPage.snackBar.deleteAccountFailure': return '계정 삭제를 실패했습니다.';
 			case 'accountPage.diaLog.yes': return '예';
-			case 'accountPage.diaLog.no': return '아니요';
+			case 'accountPage.diaLog.no': return '아니오';
 			case 'accountPage.diaLog.title': return '계정 연동 해제 확인';
-			case 'accountPage.diaLog.googleText': return '현재 계정과 Google 계정의 연동을 해제하시겠습니까?';
-			case 'accountPage.diaLog.appleText': return '현재 계정과 Apple 계정의 연동을 해제하시겠습니까?';
-			case 'accountPage.diaLog.signOut': return '로그아웃하시겠습니까?';
-			case 'accountPage.diaLog.signOutText': return '앱 기능을 이용하려면 다시 로그인해야 합니다.';
-			case 'accountPage.diaLog.deleteAccount': return '계정을 삭제하시겠습니까?';
-			case 'accountPage.diaLog.deleteAccountText': return '계정을 삭제하면 모든 데이터가 삭제됩니다.';
+			case 'accountPage.diaLog.googleText': return 'Google 계정 연동을 해제하시겠습니까?';
+			case 'accountPage.diaLog.appleText': return 'Apple 계정 연동을 해제하시겠습니까?';
+			case 'accountPage.diaLog.signOut': return '로그아웃 하시겠습니까?';
+			case 'accountPage.diaLog.signOutText': return '다시 로그인해야 서비스를 이용하실 수 있습니다.';
+			case 'accountPage.diaLog.deleteAccount': return '정말 계정을 삭제하시겠습니까?';
+			case 'accountPage.diaLog.deleteAccountText': return '삭제 시 모든 데이터가 영구적으로 삭제됩니다.';
 			case 'authentication.signInPage.title': return '로그인';
 			case 'authentication.signInPage.optionText': return ' 또는 ';
 			case 'authentication.signInPage.textFields.email': return '이메일 주소';
 			case 'authentication.signInPage.textFields.password': return '비밀번호';
 			case 'authentication.signInPage.buttons.signIn': return '로그인';
 			case 'authentication.signInPage.buttons.signUp': return '회원가입';
-			case 'authentication.signInPage.buttons.resetPassword': return '비밀번호를 잊으셨나요?';
+			case 'authentication.signInPage.buttons.resetPassword': return '비밀번호 찾기';
 			case 'authentication.signInPage.buttons.appleSignIn': return 'Apple로 로그인';
 			case 'authentication.signInPage.buttons.googleSignIn': return 'Google로 로그인';
-			case 'authentication.signInPage.buttons.signInAfter': return '나중에 등록';
+			case 'authentication.signInPage.buttons.signInAfter': return '나중에 하기';
 			case 'authentication.resetPasswordPage.title': return '비밀번호 재설정';
 			case 'authentication.resetPasswordPage.description': return '입력한 이메일 주소로 비밀번호 재설정 이메일을 발송합니다.';
 			case 'authentication.resetPasswordPage.textFields.email': return '이메일 주소';
@@ -1560,19 +1560,19 @@ extension on TranslationsKo {
 			case 'prompt.planProposalMessage': return '이런 플랜은 어떠신가요?';
 			case 'billDetailsPage.title.defaultTitle': return '프리미엄 플랜';
 			case 'billDetailsPage.title.createPlan': return '무제한 플랜 생성을 활성화하시겠습니까?';
-			case 'billDetailsPage.title.chat': return '무제한 채팅을 즐기고 싶으신가요?';
-			case 'billDetailsPage.description': return '프리미엄 플랜에 가입하시면 더욱 편리하게 시부야 관광을 즐기실 수 있습니다.';
-			case 'billDetailsPage.pricingPlan.title': return '요금 플랜';
+			case 'billDetailsPage.title.chat': return '무제한 채팅을 사용해 보시겠습니까?';
+			case 'billDetailsPage.description': return '프리미엄 플랜으로 더욱 편리한 시부야 여행을 계획해 보세요.';
+			case 'billDetailsPage.pricingPlan.title': return '요금제';
 			case 'billDetailsPage.pricingPlan.columns.standard': return '스탠다드';
 			case 'billDetailsPage.pricingPlan.columns.premium': return '프리미엄';
 			case 'billDetailsPage.pricingPlan.details.free': return '무료 🎉';
-			case 'billDetailsPage.pricingPlan.details.premiumPrice.days': return '일수별 구매';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.days': return '일별 구매';
 			case 'billDetailsPage.pricingPlan.details.premiumPrice.daily': return ({required Object price}) => '・1일 ${price}';
 			case 'billDetailsPage.pricingPlan.details.premiumPrice.threeDays': return ({required Object price}) => '・3일 ${price}';
 			case 'billDetailsPage.pricingPlan.details.premiumPrice.fiveDays': return ({required Object price}) => '・5일 ${price}';
 			case 'billDetailsPage.pricingPlan.details.premiumPrice.sevenDays': return ({required Object price}) => '・7일 ${price}';
 			case 'billDetailsPage.pricingPlan.details.premiumPrice.or': return '또는';
-			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime': return '영구 이용';
+			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetime': return '평생 이용권';
 			case 'billDetailsPage.pricingPlan.details.premiumPrice.lifetimePrice': return ({required Object price}) => '${price}';
 			case 'billDetailsPage.features.title': return '등급별 기능';
 			case 'billDetailsPage.features.rows.planCreationLimit': return '플랜 생성 가능 횟수';

--- a/lib/i18n/strings_ko.i18n.json
+++ b/lib/i18n/strings_ko.i18n.json
@@ -3,7 +3,7 @@
         "items": {
             "home": "홈",
             "myPlan": "내 플랜",
-            "myPage": "내 페이지"
+            "myPage": "마이페이지"
         }
     },
     "homePage": {
@@ -12,47 +12,47 @@
         },
         "popularTopics": {
             "title": "인기 주제",
-            "numberOfTopics": "${number}개~"
+            "numberOfTopics": "${number}개"
         },
         "recentPlans": {
             "title": "최근 생성된 플랜"
         }
     },
     "accountPage": {
-        "title": "계정",
+        "title": "계정 관리",
         "items": {
             "signOut": "로그아웃",
-            "linkedWithGoogle": "Google 연동",
-            "linkedWithApple": "Apple 연동",
+            "linkedWithGoogle": "Google 계정 연동",
+            "linkedWithApple": "Apple 계정 연동",
             "alreadyLinkedGoogle": "Google 연동 완료",
             "alreadyLinkedApple": "Apple 연동 완료",
             "deleteAccount": "계정 삭제"
         },
         "snackBar": {
             "signOut": "로그아웃되었습니다.",
-            "signOutFailure": "로그아웃 중 오류가 발생했습니다.",
-            "successfulLinkage": "계정 연동에 성공했습니다.",
+            "signOutFailure": "로그아웃 처리 중 오류가 발생했습니다.",
+            "successfulLinkage": "계정 연동이 완료되었습니다.",
             "linkageFailure": "계정 연동에 실패했습니다.",
             "providerAlreadyLinked": "이미 연동된 계정입니다.",
             "accountDeactivation": "계정 연동이 해제되었습니다.",
-            "invalidCredential": "다시 로그인 해주세요.",
+            "invalidCredential": "다시 로그인해 주세요.",
             "linkageCancelled": "계정 연동이 취소되었습니다.",
-            "unlinkageFailure": "계정 연동 해제에 실패했습니다.",
-            "operationNotAllowed": "제공자가 비활성화되었습니다. 개발자에게 문의하세요.",
+            "unlinkageFailure": "계정 연동 해제를 실패했습니다.",
+            "operationNotAllowed": "해당 서비스가 비활성화되었습니다. 개발자에게 문의해 주세요.",
             "unknownError": "알 수 없는 오류가 발생했습니다.",
             "deleteAccount": "계정이 삭제되었습니다.",
-            "deleteAccountFailure": "계정 삭제에 실패했습니다."
+            "deleteAccountFailure": "계정 삭제를 실패했습니다."
         },
         "diaLog": {
             "yes": "예",
-            "no": "아니요",
+            "no": "아니오",
             "title": "계정 연동 해제 확인",
-            "googleText": "현재 계정과 Google 계정의 연동을 해제하시겠습니까?",
-            "appleText": "현재 계정과 Apple 계정의 연동을 해제하시겠습니까?",
-            "signOut": "로그아웃하시겠습니까?",
-            "signOutText": "앱 기능을 이용하려면 다시 로그인해야 합니다.",
-            "deleteAccount": "계정을 삭제하시겠습니까?",
-            "deleteAccountText": "계정을 삭제하면 모든 데이터가 삭제됩니다."
+            "googleText": "Google 계정 연동을 해제하시겠습니까?",
+            "appleText": "Apple 계정 연동을 해제하시겠습니까?",
+            "signOut": "로그아웃 하시겠습니까?",
+            "signOutText": "다시 로그인해야 서비스를 이용하실 수 있습니다.",
+            "deleteAccount": "정말 계정을 삭제하시겠습니까?",
+            "deleteAccountText": "삭제 시 모든 데이터가 영구적으로 삭제됩니다."
         }
     },
     "authentication": {
@@ -66,10 +66,10 @@
             "buttons": {
                 "signIn": "로그인",
                 "signUp": "회원가입",
-                "resetPassword": "비밀번호를 잊으셨나요?",
+                "resetPassword": "비밀번호 찾기",
                 "appleSignIn": "Apple로 로그인",
                 "googleSignIn": "Google로 로그인",
-                "signInAfter": "나중에 등록"
+                "signInAfter": "나중에 하기"
             }
         },
         "resetPasswordPage": {
@@ -374,11 +374,11 @@
         "title": {
             "defaultTitle": "프리미엄 플랜",
             "createPlan": "무제한 플랜 생성을 활성화하시겠습니까?",
-            "chat": "무제한 채팅을 즐기고 싶으신가요?"
+            "chat": "무제한 채팅을 사용해 보시겠습니까?"
         },
-        "description": "프리미엄 플랜에 가입하시면 더욱 편리하게 시부야 관광을 즐기실 수 있습니다.",
+        "description": "프리미엄 플랜으로 더욱 편리한 시부야 여행을 계획해 보세요.",
         "pricingPlan": {
-            "title": "요금 플랜",
+            "title": "요금제",
             "columns": {
                 "standard": "스탠다드",
                 "premium": "프리미엄"
@@ -386,13 +386,13 @@
             "details": {
                 "free": "무료 🎉",
                 "premiumPrice": {
-                    "days": "일수별 구매",
+                    "days": "일별 구매",
                     "daily": "・1일 ${price}",
                     "threeDays": "・3일 ${price}",
                     "fiveDays": "・5일 ${price}",
                     "sevenDays": "・7일 ${price}",
                     "or": "또는",
-                    "lifetime": "영구 이용",
+                    "lifetime": "평생 이용권",
                     "lifetimePrice": "${price}"
                 }
             }

--- a/lib/i18n/strings_zh-Hans.i18n.json
+++ b/lib/i18n/strings_zh-Hans.i18n.json
@@ -3,7 +3,7 @@
         "items": {
             "home": "首页",
             "myPlan": "我的计划",
-            "myPage": "我的页面"
+            "myPage": "个人中心"
         }
     },
     "homePage": {
@@ -22,8 +22,8 @@
         "title": "账户",
         "items": {
             "signOut": "退出登录",
-            "linkedWithGoogle": "与Google连接",
-            "linkedWithApple": "与Apple连接",
+            "linkedWithGoogle": "关联Google账号",
+            "linkedWithApple": "关联Apple账号",
             "alreadyLinkedGoogle": "已与Google连接",
             "alreadyLinkedApple": "已与Apple连接",
             "deleteAccount": "删除账户"
@@ -74,7 +74,7 @@
         },
         "firebaseAuth": {
             "error": {
-                "networkRequestFailed": "请在良好的网络环境中重试",
+                "networkRequestFailed": "请检查网络连接后重试",
                 "weakPassword": "密码太短。请输入6个字符或更多",
                 "invalidEmail": "电子邮件地址格式不正确",
                 "userNotFound": "找不到帐户",
@@ -87,7 +87,7 @@
             "title": "重置密码",
             "description": "将向输入的电子邮件地址发送密码重置邮件",
             "textFields": {
-                "email": "电子邮件地址"
+                "email": "邮箱"
             },
             "buttons": {
                 "submit": "发送"
@@ -153,7 +153,7 @@
             "title": "输入电话号码",
             "discription": {
                 "receive": "以接收 SMS 验证码",
-                "internationalFormat": "使用国际电话号码格式",
+                "internationalFormat": "国际电话格式",
                 "input": "请输入您的电话号码"
             },
             "phoneNumber": "电话号码",
@@ -244,7 +244,7 @@
         "title": "我的计划",
         "tabs": {
             "createdPlans": "已创建计划",
-            "bookmark": "书签"
+            "bookmark": "收藏"
         },
         "bookmarkItems": {
             "nondata": "暂无收藏计划。",
@@ -424,7 +424,7 @@
             "oneDay": {
                 "duration": "1日",
                 "discount": "",
-                "price": "300日元"
+                "price": "300円"
             },
             "threeDays": {
                 "duration": "3日",

--- a/lib/i18n/strings_zh-Hant.i18n.json
+++ b/lib/i18n/strings_zh-Hant.i18n.json
@@ -3,7 +3,7 @@
         "items": {
             "home": "首頁",
             "myPlan": "我的計劃",
-            "myPage": "我的頁面"
+            "myPage": "個人中心"
         }
     },
     "homePage": {
@@ -22,8 +22,8 @@
         "title": "帳戶",
         "items": {
             "signOut": "登出",
-            "linkedWithGoogle": "與Google連結",
-            "linkedWithApple": "與Apple連結",
+            "linkedWithGoogle": "連結Google帳號",
+            "linkedWithApple": "連結Google帳號",
             "alreadyLinkedGoogle": "已與Google連結",
             "alreadyLinkedApple": "已與Apple連結",
             "deleteAccount": "刪除帳戶"
@@ -60,7 +60,7 @@
             "title": "登入",
             "optionText": " 或 ",
             "textFields": {
-                "email": "電子郵件地址",
+                "email": "電郵",
                 "password": "密碼"
             },
             "buttons": {
@@ -74,7 +74,7 @@
         },
         "firebaseAuth": {
             "error": {
-                "networkRequestFailed": "請在良好的網絡環境中重試",
+                "networkRequestFailed": "請檢查網路連線後重試",
                 "weakPassword": "密碼太短。請輸入6個字符或更多",
                 "invalidEmail": "電子郵件地址格式不正確",
                 "userNotFound": "找不到帳戶",
@@ -153,7 +153,7 @@
             "title": "輸入電話號碼",
             "discription": {
                 "receive": "以接收 SMS 驗證碼",
-                "internationalFormat": "使用國際電話號碼格式",
+                "internationalFormat": "國際電話格式",
                 "input": "請輸入您的電話號碼"
             },
             "phoneNumber": "電話號碼",
@@ -243,7 +243,7 @@
         "title": "我的方案",
         "tabs": {
             "createdPlans": "已建立方案",
-            "bookmark": "書籤"
+            "bookmark": "收藏"
         },
         "bookmarkItems": {
             "nondata": "暫無收藏方案。",

--- a/lib/i18n/strings_zh_Hans.g.dart
+++ b/lib/i18n/strings_zh_Hans.g.dart
@@ -351,7 +351,7 @@ class _TranslationsNavigationBarItemsZhHans implements TranslationsNavigationBar
 	// Translations
 	@override String get home => '首页';
 	@override String get myPlan => '我的计划';
-	@override String get myPage => '我的页面';
+	@override String get myPage => '个人中心';
 }
 
 // Path: homePage.popularPlans
@@ -393,8 +393,8 @@ class _TranslationsAccountPageItemsZhHans implements TranslationsAccountPageItem
 
 	// Translations
 	@override String get signOut => '退出登录';
-	@override String get linkedWithGoogle => '与Google连接';
-	@override String get linkedWithApple => '与Apple连接';
+	@override String get linkedWithGoogle => '关联Google账号';
+	@override String get linkedWithApple => '关联Apple账号';
 	@override String get alreadyLinkedGoogle => '已与Google连接';
 	@override String get alreadyLinkedApple => '已与Apple连接';
 	@override String get deleteAccount => '删除账户';
@@ -605,7 +605,7 @@ class _TranslationsMyPlanPageTabsZhHans implements TranslationsMyPlanPageTabsEn 
 
 	// Translations
 	@override String get createdPlans => '已创建计划';
-	@override String get bookmark => '书签';
+	@override String get bookmark => '收藏';
 }
 
 // Path: myPlanPage.bookmarkItems
@@ -931,7 +931,7 @@ class _TranslationsAuthenticationFirebaseAuthErrorZhHans implements Translations
 	final TranslationsZhHans _root; // ignore: unused_field
 
 	// Translations
-	@override String get networkRequestFailed => '请在良好的网络环境中重试';
+	@override String get networkRequestFailed => '请检查网络连接后重试';
 	@override String get weakPassword => '密码太短。请输入6个字符或更多';
 	@override String get invalidEmail => '电子邮件地址格式不正确';
 	@override String get userNotFound => '找不到帐户';
@@ -947,7 +947,7 @@ class _TranslationsAuthenticationResetPasswordPageTextFieldsZhHans implements Tr
 	final TranslationsZhHans _root; // ignore: unused_field
 
 	// Translations
-	@override String get email => '电子邮件地址';
+	@override String get email => '邮箱';
 }
 
 // Path: authentication.resetPasswordPage.buttons
@@ -1059,7 +1059,7 @@ class _TranslationsAuthenticationPhoneNumberInputPageDiscriptionZhHans implement
 
 	// Translations
 	@override String get receive => '以接收 SMS 验证码';
-	@override String get internationalFormat => '使用国际电话号码格式';
+	@override String get internationalFormat => '国际电话格式';
 	@override String get input => '请输入您的电话号码';
 }
 
@@ -1205,7 +1205,7 @@ class _TranslationsBillDetailsPagePricingOptionsOneDayZhHans implements Translat
 	// Translations
 	@override String get duration => '1日';
 	@override String get discount => '';
-	@override String get price => '300日元';
+	@override String get price => '300円';
 }
 
 // Path: billDetailsPage.pricingOptions.threeDays
@@ -1347,15 +1347,15 @@ extension on TranslationsZhHans {
 		switch (path) {
 			case 'navigationBar.items.home': return '首页';
 			case 'navigationBar.items.myPlan': return '我的计划';
-			case 'navigationBar.items.myPage': return '我的页面';
+			case 'navigationBar.items.myPage': return '个人中心';
 			case 'homePage.popularPlans.title': return '热门计划';
 			case 'homePage.popularTopics.title': return '热门话题';
 			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number}件~';
 			case 'homePage.recentPlans.title': return '最近创建的计划';
 			case 'accountPage.title': return '账户';
 			case 'accountPage.items.signOut': return '退出登录';
-			case 'accountPage.items.linkedWithGoogle': return '与Google连接';
-			case 'accountPage.items.linkedWithApple': return '与Apple连接';
+			case 'accountPage.items.linkedWithGoogle': return '关联Google账号';
+			case 'accountPage.items.linkedWithApple': return '关联Apple账号';
 			case 'accountPage.items.alreadyLinkedGoogle': return '已与Google连接';
 			case 'accountPage.items.alreadyLinkedApple': return '已与Apple连接';
 			case 'accountPage.items.deleteAccount': return '删除账户';
@@ -1391,7 +1391,7 @@ extension on TranslationsZhHans {
 			case 'authentication.signInPage.buttons.appleSignIn': return '使用Apple登录';
 			case 'authentication.signInPage.buttons.googleSignIn': return '使用Google登录';
 			case 'authentication.signInPage.buttons.signInAfter': return '稍后注册';
-			case 'authentication.firebaseAuth.error.networkRequestFailed': return '请在良好的网络环境中重试';
+			case 'authentication.firebaseAuth.error.networkRequestFailed': return '请检查网络连接后重试';
 			case 'authentication.firebaseAuth.error.weakPassword': return '密码太短。请输入6个字符或更多';
 			case 'authentication.firebaseAuth.error.invalidEmail': return '电子邮件地址格式不正确';
 			case 'authentication.firebaseAuth.error.userNotFound': return '找不到帐户';
@@ -1400,7 +1400,7 @@ extension on TranslationsZhHans {
 			case 'authentication.firebaseAuth.error.unexpected': return '发生错误。请在良好的网络环境中重试';
 			case 'authentication.resetPasswordPage.title': return '重置密码';
 			case 'authentication.resetPasswordPage.description': return '将向输入的电子邮件地址发送密码重置邮件';
-			case 'authentication.resetPasswordPage.textFields.email': return '电子邮件地址';
+			case 'authentication.resetPasswordPage.textFields.email': return '邮箱';
 			case 'authentication.resetPasswordPage.buttons.submit': return '发送';
 			case 'authentication.signUpPage.title.defaultText': return '新用户注册';
 			case 'authentication.signUpPage.title.modifyEmail': return '更改邮箱地址';
@@ -1432,7 +1432,7 @@ extension on TranslationsZhHans {
 			case 'authentication.completeSendEmailPage.buttons.changeEmail': return '更改电子邮件地址';
 			case 'authentication.phoneNumberInputPage.title': return '输入电话号码';
 			case 'authentication.phoneNumberInputPage.discription.receive': return '以接收 SMS 验证码';
-			case 'authentication.phoneNumberInputPage.discription.internationalFormat': return '使用国际电话号码格式';
+			case 'authentication.phoneNumberInputPage.discription.internationalFormat': return '国际电话格式';
 			case 'authentication.phoneNumberInputPage.discription.input': return '请输入您的电话号码';
 			case 'authentication.phoneNumberInputPage.phoneNumber': return '电话号码';
 			case 'authentication.phoneNumberInputPage.sendSmsCode': return '发送 SMS 验证码';
@@ -1493,7 +1493,7 @@ extension on TranslationsZhHans {
 			case 'changeThemePage.items.dark': return '暗处';
 			case 'myPlanPage.title': return '我的计划';
 			case 'myPlanPage.tabs.createdPlans': return '已创建计划';
-			case 'myPlanPage.tabs.bookmark': return '书签';
+			case 'myPlanPage.tabs.bookmark': return '收藏';
 			case 'myPlanPage.bookmarkItems.nondata': return '暂无收藏计划。';
 			case 'myPlanPage.bookmarkItems.reloading': return '重新加载';
 			case 'myPlanPage.createdPlansItems.nondata': return '开始创建计划吧！';
@@ -1588,7 +1588,7 @@ extension on TranslationsZhHans {
 			case 'billDetailsPage.features.columns.premium.chatLimit': return '无限制';
 			case 'billDetailsPage.pricingOptions.oneDay.duration': return '1日';
 			case 'billDetailsPage.pricingOptions.oneDay.discount': return '';
-			case 'billDetailsPage.pricingOptions.oneDay.price': return '300日元';
+			case 'billDetailsPage.pricingOptions.oneDay.price': return '300円';
 			case 'billDetailsPage.pricingOptions.threeDays.duration': return '3日';
 			case 'billDetailsPage.pricingOptions.threeDays.discount': return '-5%';
 			case 'billDetailsPage.pricingOptions.threeDays.price': return '890日元';

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -351,7 +351,7 @@ class _TranslationsNavigationBarItemsZhHant implements TranslationsNavigationBar
 	// Translations
 	@override String get home => '首頁';
 	@override String get myPlan => '我的計劃';
-	@override String get myPage => '我的頁面';
+	@override String get myPage => '個人中心';
 }
 
 // Path: homePage.popularPlans
@@ -393,8 +393,8 @@ class _TranslationsAccountPageItemsZhHant implements TranslationsAccountPageItem
 
 	// Translations
 	@override String get signOut => '登出';
-	@override String get linkedWithGoogle => '與Google連結';
-	@override String get linkedWithApple => '與Apple連結';
+	@override String get linkedWithGoogle => '連結Google帳號';
+	@override String get linkedWithApple => '連結Google帳號';
 	@override String get alreadyLinkedGoogle => '已與Google連結';
 	@override String get alreadyLinkedApple => '已與Apple連結';
 	@override String get deleteAccount => '刪除帳戶';
@@ -605,7 +605,7 @@ class _TranslationsMyPlanPageTabsZhHant implements TranslationsMyPlanPageTabsEn 
 
 	// Translations
 	@override String get createdPlans => '已建立方案';
-	@override String get bookmark => '書籤';
+	@override String get bookmark => '收藏';
 }
 
 // Path: myPlanPage.bookmarkItems
@@ -905,7 +905,7 @@ class _TranslationsAuthenticationSignInPageTextFieldsZhHant implements Translati
 	final TranslationsZhHant _root; // ignore: unused_field
 
 	// Translations
-	@override String get email => '電子郵件地址';
+	@override String get email => '電郵';
 	@override String get password => '密碼';
 }
 
@@ -931,7 +931,7 @@ class _TranslationsAuthenticationFirebaseAuthErrorZhHant implements Translations
 	final TranslationsZhHant _root; // ignore: unused_field
 
 	// Translations
-	@override String get networkRequestFailed => '請在良好的網絡環境中重試';
+	@override String get networkRequestFailed => '請檢查網路連線後重試';
 	@override String get weakPassword => '密碼太短。請輸入6個字符或更多';
 	@override String get invalidEmail => '電子郵件地址格式不正確';
 	@override String get userNotFound => '找不到帳戶';
@@ -1059,7 +1059,7 @@ class _TranslationsAuthenticationPhoneNumberInputPageDiscriptionZhHant implement
 
 	// Translations
 	@override String get receive => '以接收 SMS 驗證碼';
-	@override String get internationalFormat => '使用國際電話號碼格式';
+	@override String get internationalFormat => '國際電話格式';
 	@override String get input => '請輸入您的電話號碼';
 }
 
@@ -1347,15 +1347,15 @@ extension on TranslationsZhHant {
 		switch (path) {
 			case 'navigationBar.items.home': return '首頁';
 			case 'navigationBar.items.myPlan': return '我的計劃';
-			case 'navigationBar.items.myPage': return '我的頁面';
+			case 'navigationBar.items.myPage': return '個人中心';
 			case 'homePage.popularPlans.title': return '熱門計畫';
 			case 'homePage.popularTopics.title': return '熱門話題';
 			case 'homePage.popularTopics.numberOfTopics': return ({required Object number}) => '${number}件~';
 			case 'homePage.recentPlans.title': return '最近創建的計畫';
 			case 'accountPage.title': return '帳戶';
 			case 'accountPage.items.signOut': return '登出';
-			case 'accountPage.items.linkedWithGoogle': return '與Google連結';
-			case 'accountPage.items.linkedWithApple': return '與Apple連結';
+			case 'accountPage.items.linkedWithGoogle': return '連結Google帳號';
+			case 'accountPage.items.linkedWithApple': return '連結Google帳號';
 			case 'accountPage.items.alreadyLinkedGoogle': return '已與Google連結';
 			case 'accountPage.items.alreadyLinkedApple': return '已與Apple連結';
 			case 'accountPage.items.deleteAccount': return '刪除帳戶';
@@ -1383,7 +1383,7 @@ extension on TranslationsZhHant {
 			case 'accountPage.diaLog.deleteAccountText': return '刪除帳戶後，所有數據將被刪除。';
 			case 'authentication.signInPage.title': return '登入';
 			case 'authentication.signInPage.optionText': return ' 或 ';
-			case 'authentication.signInPage.textFields.email': return '電子郵件地址';
+			case 'authentication.signInPage.textFields.email': return '電郵';
 			case 'authentication.signInPage.textFields.password': return '密碼';
 			case 'authentication.signInPage.buttons.signIn': return '登入';
 			case 'authentication.signInPage.buttons.signUp': return '註冊';
@@ -1391,7 +1391,7 @@ extension on TranslationsZhHant {
 			case 'authentication.signInPage.buttons.appleSignIn': return '使用Apple登入';
 			case 'authentication.signInPage.buttons.googleSignIn': return '使用Google登入';
 			case 'authentication.signInPage.buttons.signInAfter': return '稍後註冊';
-			case 'authentication.firebaseAuth.error.networkRequestFailed': return '請在良好的網絡環境中重試';
+			case 'authentication.firebaseAuth.error.networkRequestFailed': return '請檢查網路連線後重試';
 			case 'authentication.firebaseAuth.error.weakPassword': return '密碼太短。請輸入6個字符或更多';
 			case 'authentication.firebaseAuth.error.invalidEmail': return '電子郵件地址格式不正確';
 			case 'authentication.firebaseAuth.error.userNotFound': return '找不到帳戶';
@@ -1432,7 +1432,7 @@ extension on TranslationsZhHant {
 			case 'authentication.completeSendEmailPage.buttons.changeEmail': return '更改電子郵件地址';
 			case 'authentication.phoneNumberInputPage.title': return '輸入電話號碼';
 			case 'authentication.phoneNumberInputPage.discription.receive': return '以接收 SMS 驗證碼';
-			case 'authentication.phoneNumberInputPage.discription.internationalFormat': return '使用國際電話號碼格式';
+			case 'authentication.phoneNumberInputPage.discription.internationalFormat': return '國際電話格式';
 			case 'authentication.phoneNumberInputPage.discription.input': return '請輸入您的電話號碼';
 			case 'authentication.phoneNumberInputPage.phoneNumber': return '電話號碼';
 			case 'authentication.phoneNumberInputPage.sendSmsCode': return '發送 SMS 驗證碼';
@@ -1493,7 +1493,7 @@ extension on TranslationsZhHant {
 			case 'changeThemePage.items.dark': return '黑暗';
 			case 'myPlanPage.title': return '我的方案';
 			case 'myPlanPage.tabs.createdPlans': return '已建立方案';
-			case 'myPlanPage.tabs.bookmark': return '書籤';
+			case 'myPlanPage.tabs.bookmark': return '收藏';
 			case 'myPlanPage.bookmarkItems.nondata': return '暫無收藏方案。';
 			case 'myPlanPage.bookmarkItems.reloading': return '重新載入';
 			case 'myPlanPage.createdPlansItems.nondata': return '開始建立方案吧！';


### PR DESCRIPTION
## 対応したこと

英語
韓国語
中国語（両方）
の翻訳を修正。
### 韓国語
-  直訳をより自然な韓国語表現に変換（例：「내 페이지 」の代わりに 「마이 페이지」）。
- 一貫性： すべてのセクションで用語を統一（例：アカウントリンクに「연동」を統一）
- 形式： 韓国語のUI慣例に合うように形式レベルを調整
- 技術用語： 標準的な韓国語の技術用語を使用（例：「스µ바」 → 「알림」 を元の文脈に適した 「snackBar」 に変更）
- 通貨フォーマット： 円記号(¥)をウォン記号(ȉ)に変更。
- スペーシング： 韓国語の文章に適切なスペースを追加
- 付書式： 韓国語の日付書式を維持 (yyyy년 MM월 dd일)
- エラーメッセージ エラーメッセージをより使いやすく、実用的なものに変更。
- ボタンラベル： CTAをより自然で会話的なものに
- 句読点： 韓国語のタイポグラフィ・ルールに従って句読点を調整
### 英語
- phoneNumberInputPage.discription の文を自然な英語の語順に変更
- accountPage.snackBar.providerAlreadyLinkedを完了形に変更
- buddyChatPage.titleの文を変更
- createPlanPage.categoryOptionsを複合形容詞としてハイフンを入れ、タイトルケースにして、他のオプションとのスタイルの一貫性の確保
### 中国語
- 「我的页面」→「个人中心/個人中心」（ユーザーに馴染み深い表現）
- 「书签/書籤」→「收藏」（機能をより正確に表現）
- 「连接/連接」→「关联/連結」（アカウント連携の文脈でより適切）
- 「电子邮件地址/電子郵件地址」→「邮箱/電郵」（簡潔な表現）
- 通貨表記「円」→「日元/日圓」
- 「巴士」→「公車」（台湾繁体字の場合）
- 抽象的な表現→具体的な行動指示（「ネットワーク環境を確認」→「ネットワーク接続を確認」）
- 「国际电话号码格式」→「国际电话格式」（冗長さの排除）
- 「解除连接」→「解除連結」（操作の意図を明確化）
- 「方案」→「方案」（繁体字で一貫性を持たせる）
- 「计划」→「计划」（簡体字で一貫性を持たせる）