### PR TITLE
画像検索コスト削減のための最適化

### DIFF
--- a/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
+++ b/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
@@ -220,20 +220,29 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
     } on Exception catch (e) {
       debugPrint('Error in buddyChatPageNotifier by _getAllFilledMessage: $e');
     }
-    return chatMessage.copyWith(
-      plan: chatMessage.plan?.copyWith(
-        thumbnailUrl: photoUrls[0],
-        topics: planPrompt.topics,
-      ),
-      places: chatMessage.places?.asMap().entries.map(
-        (entry) {
-          final place = entry.value;
-          return place.copyWith(
-            thumbnailUrl: photoUrls[entry.key],
-          );
-        },
-      ).toList(),
-    );
+    if (forFirstBuild) {
+      return chatMessage.copyWith(
+        plan: chatMessage.plan?.copyWith(
+          thumbnailUrl: photoUrls[0],
+          topics: planPrompt.topics,
+        ),
+        places: chatMessage.places?.asMap().entries.map(
+          (entry) {
+            final place = entry.value;
+            return place.copyWith(
+              thumbnailUrl: photoUrls[entry.key],
+            );
+          },
+        ).toList(),
+      );
+    } else {
+      // 最初のメッセージ以外の場合
+      return _setChatmessageFields(
+        chatMessage,
+        photoUrls,
+        placeDetailStrings,
+      );
+    }
   }
 
   List<String>? getPlaceNamesWithoutAlreadySearched(ChatMessage chatMessage) {
@@ -247,6 +256,61 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
         ?.where((place) => !alreadySearchedPlaceNames!.contains(place.name))
         .map((place) => place.name)
         .toList();
+  }
+
+  ChatMessage _setChatmessageFields(
+    ChatMessage chatMessage,
+    List<String> photoUrls,
+    List<String> placeDetailStrings,
+  ) {
+    final lastMessage = state.requireValue.messages.lastWhere(
+      (message) => message.plan != null && message.places != null,
+    );
+    // すでに表示されている場所の数 + 新しく検索した文字列の合計が、これから表示する場所の数と一致する場合
+    // 新しく検索した文字列を元に取得した写真のURLを、新しく検索した場所の写真のURLとして上書き追加
+    if (lastMessage.places!.length + placeDetailStrings.length ==
+        chatMessage.places!.length) {
+      return chatMessage.copyWith(
+        plan: chatMessage.plan?.copyWith(
+          thumbnailUrl: lastMessage.plan!.thumbnailUrl,
+        ),
+        places: [
+          ...lastMessage.places!,
+          ...chatMessage.places!
+              .where(
+            (place) =>
+                !lastMessage.places!.map((e) => e.name).contains(place.name),
+          )
+              .map(
+            (place) {
+              return place.copyWith(
+                thumbnailUrl: photoUrls[chatMessage.places!.indexOf(place) -
+                    lastMessage.places!.length],
+              );
+            },
+          ),
+        ],
+      );
+    } else {
+      // 一つ目の場所から全てが新しく検索されている場合
+      // 新しく検索した文字列を元に取得した写真のURLを、新しく検索した場所の写真のURLとして上書き追加
+
+      return chatMessage.copyWith(
+        plan: chatMessage.plan?.copyWith(
+          thumbnailUrl: photoUrls[0],
+        ),
+        places: [
+          ...chatMessage.places!.asMap().entries.map(
+            (entry) {
+              final place = entry.value;
+              return place.copyWith(
+                thumbnailUrl: photoUrls[entry.key],
+              );
+            },
+          ),
+        ],
+      );
+    }
   }
 
   void changeStandardConfigToPremium() {

--- a/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
+++ b/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
@@ -74,7 +74,10 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
     try {
       final res = await geminiDataSource.sendMessage(message: message);
 
-      final buddyMessage = await _getAllFilledMessage(res);
+      final buddyMessage = await _getAllFilledMessage(
+        res,
+        forFirstBuild: false,
+      );
 
       state = AsyncValue.data(
         state.requireValue.copyWith(
@@ -169,7 +172,7 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
 
     final res = await geminiDataSource.sendPlanDetail(planPrompt: planPrompt);
 
-    final buddyMessage = await _getAllFilledMessage(res);
+    final buddyMessage = await _getAllFilledMessage(res, forFirstBuild: true);
 
     final message = ChatMessage(
       id: buddyMessage.id,
@@ -187,14 +190,21 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
     );
   }
 
-  Future<ChatMessage> _getAllFilledMessage(ChatMessage chatMessage) async {
+  Future<ChatMessage> _getAllFilledMessage(
+    ChatMessage chatMessage, {
+    required bool forFirstBuild,
+  }) async {
     var placeIds = <String>[];
     var photoUrls = <String>[];
 
     /// 検索したい写真の名前をリスト化
     final placeDetailStrings = <String>[
-      chatMessage.plan?.title ?? '',
-      ...chatMessage.places?.map((place) => place.name) ?? [],
+      if (forFirstBuild) ...[
+        ...chatMessage.places?.map((place) => place.name) ?? [],
+      ] else ...[
+        /// すでに表示されている場所の名前をのぞいた、検索したい写真の名前をリスト化
+        ...getPlaceNamesWithoutAlreadySearched(chatMessage) ?? [],
+      ],
     ];
 
     try {
@@ -219,11 +229,24 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
         (entry) {
           final place = entry.value;
           return place.copyWith(
-            thumbnailUrl: photoUrls[entry.key + 1],
+            thumbnailUrl: photoUrls[entry.key],
           );
         },
       ).toList(),
     );
+  }
+
+  List<String>? getPlaceNamesWithoutAlreadySearched(ChatMessage chatMessage) {
+    final alreadySearchedPlaceNames = state.requireValue.messages
+        .lastWhere((message) => message.places != null)
+        .places
+        ?.map((place) => place.name)
+        .toList();
+
+    return chatMessage.places
+        ?.where((place) => !alreadySearchedPlaceNames!.contains(place.name))
+        .map((place) => place.name)
+        .toList();
   }
 
   void changeStandardConfigToPremium() {


### PR DESCRIPTION
## 対応したこと

<!-- 対応したことを箇条書きでわかりやすく -->

- 以前まで、タイトルの画像と場所の総数分(例: 3箇所)の合計4つの画像を検索させていたが、タイトルの画像を一つ目の場所の画像にする
- Buddyにチャットを送るたびにすでに表示されていたプランに含まれる場所を再検索してしまっていたが、検索済みの場所の画像は無駄に検索させないように条件を分岐

## 関連資料

<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->
特になし

## 残タスク

<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

- [x] 動作確認


## 画面キャプチャ

<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
<img width="457" alt="スクリーンショット 2025-01-30 21 30 42" src="https://github.com/user-attachments/assets/28bb570e-98a0-4033-b304-ba700cd8c0d0" />
