### PR TITLE
メール認証ページに遷移時、自動でメールを一度送信するよう修正

### DIFF
--- a/lib/gen/assets.gen.dart
+++ b/lib/gen/assets.gen.dart
@@ -32,10 +32,6 @@ class $AssetsImagesGen {
   /// File path: assets/images/anime.png
   AssetGenImage get anime => const AssetGenImage('assets/images/anime.png');
 
-  /// File path: assets/images/app_icon.png
-  AssetGenImage get appIcon =>
-      const AssetGenImage('assets/images/app_icon.png');
-
   /// File path: assets/images/billing_header.png
   AssetGenImage get billingHeader =>
       const AssetGenImage('assets/images/billing_header.png');
@@ -61,7 +57,6 @@ class $AssetsImagesGen {
   List<AssetGenImage> get values => [
         activity,
         anime,
-        appIcon,
         billingHeader,
         error,
         gourmet,

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 5
 /// Strings: 1375 (275 per locale)
 ///
-/// Built on 2025-01-31 at 04:20 UTC
+/// Built on 2025-01-31 at 14:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 5
 /// Strings: 1375 (275 per locale)
 ///
-/// Built on 2025-01-28 at 17:04 UTC
+/// Built on 2025-01-31 at 04:20 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -109,7 +109,7 @@
         },
         "emailVerificationPage": {
             "title": "Email Address Verification",
-            "descriptionForDestination": "A verification email will be sent to the entered ${email}.",
+            "descriptionForDestination": "A verification email has been sent to the entered ${email}",
             "descriptionForCoolDown": "You can resend the verification email once every 60 seconds.",
             "buttons": {
                 "sendEmail": "Send Verification Email",

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -500,7 +500,7 @@ class TranslationsAuthenticationEmailVerificationPageEn {
 
 	// Translations
 	String get title => 'Email Address Verification';
-	String descriptionForDestination({required Object email}) => 'A verification email will be sent to the entered ${email}.';
+	String descriptionForDestination({required Object email}) => 'A verification email has been sent to the entered ${email}';
 	String get descriptionForCoolDown => 'You can resend the verification email once every 60 seconds.';
 	late final TranslationsAuthenticationEmailVerificationPageButtonsEn buttons = TranslationsAuthenticationEmailVerificationPageButtonsEn._(_root);
 	late final TranslationsAuthenticationEmailVerificationPageSnackBarEn snackBar = TranslationsAuthenticationEmailVerificationPageSnackBarEn._(_root);
@@ -1413,7 +1413,7 @@ extension on Translations {
 			case 'authentication.signUpPage.button.defaultText': return 'Sign Up';
 			case 'authentication.signUpPage.button.modifyEmail': return 'Change Email Address';
 			case 'authentication.emailVerificationPage.title': return 'Email Address Verification';
-			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => 'A verification email will be sent to the entered ${email}.';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => 'A verification email has been sent to the entered ${email}';
 			case 'authentication.emailVerificationPage.descriptionForCoolDown': return 'You can resend the verification email once every 60 seconds.';
 			case 'authentication.emailVerificationPage.buttons.sendEmail': return 'Send Verification Email';
 			case 'authentication.emailVerificationPage.buttons.resendEmail': return 'Resend Verification Email';

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -486,7 +486,7 @@ class _TranslationsAuthenticationEmailVerificationPageJa implements Translations
 
 	// Translations
 	@override String get title => 'メールアドレスの確認';
-	@override String descriptionForDestination({required Object email}) => '入力された${email}に確認メールを送信します';
+	@override String descriptionForDestination({required Object email}) => '入力された${email}に確認メールを送信しました';
 	@override String get descriptionForCoolDown => '確認メールの再送信は、60秒ごとに1回可能です。';
 	@override late final _TranslationsAuthenticationEmailVerificationPageButtonsJa buttons = _TranslationsAuthenticationEmailVerificationPageButtonsJa._(_root);
 	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarJa snackBar = _TranslationsAuthenticationEmailVerificationPageSnackBarJa._(_root);
@@ -1402,7 +1402,7 @@ extension on TranslationsJa {
 			case 'authentication.signUpPage.button.defaultText': return '新規登録';
 			case 'authentication.signUpPage.button.modifyEmail': return '変更';
 			case 'authentication.emailVerificationPage.title': return 'メールアドレスの確認';
-			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '入力された${email}に確認メールを送信します';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '入力された${email}に確認メールを送信しました';
 			case 'authentication.emailVerificationPage.descriptionForCoolDown': return '確認メールの再送信は、60秒ごとに1回可能です。';
 			case 'authentication.emailVerificationPage.buttons.sendEmail': return '確認メールを送信';
 			case 'authentication.emailVerificationPage.buttons.resendEmail': return '確認メールを再送信';

--- a/lib/i18n/strings_ja.i18n.json
+++ b/lib/i18n/strings_ja.i18n.json
@@ -98,7 +98,7 @@
         },
         "emailVerificationPage": {
             "title": "メールアドレスの確認",
-            "descriptionForDestination": "入力された${email}に確認メールを送信します",
+            "descriptionForDestination": "入力された${email}に確認メールを送信しました",
             "descriptionForCoolDown": "確認メールの再送信は、60秒ごとに1回可能です。",
             "buttons": {
                 "sendEmail": "確認メールを送信",

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -486,7 +486,7 @@ class _TranslationsAuthenticationEmailVerificationPageKo implements Translations
 
 	// Translations
 	@override String get title => '이메일 주소 확인';
-	@override String descriptionForDestination({required Object email}) => '입력한 ${email}로 확인 이메일을 발송합니다.';
+	@override String descriptionForDestination({required Object email}) => '입력된 ${email}로 확인 이메일을 보냈습니다';
 	@override String get descriptionForCoolDown => '확인 이메일 재발송은 60초마다 1회 가능합니다.';
 	@override late final _TranslationsAuthenticationEmailVerificationPageButtonsKo buttons = _TranslationsAuthenticationEmailVerificationPageButtonsKo._(_root);
 	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarKo snackBar = _TranslationsAuthenticationEmailVerificationPageSnackBarKo._(_root);
@@ -1402,7 +1402,7 @@ extension on TranslationsKo {
 			case 'authentication.signUpPage.button.defaultText': return '회원가입';
 			case 'authentication.signUpPage.button.modifyEmail': return '변경';
 			case 'authentication.emailVerificationPage.title': return '이메일 주소 확인';
-			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '입력한 ${email}로 확인 이메일을 발송합니다.';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '입력된 ${email}로 확인 이메일을 보냈습니다';
 			case 'authentication.emailVerificationPage.descriptionForCoolDown': return '확인 이메일 재발송은 60초마다 1회 가능합니다.';
 			case 'authentication.emailVerificationPage.buttons.sendEmail': return '확인 이메일 발송';
 			case 'authentication.emailVerificationPage.buttons.resendEmail': return '확인 이메일 재발송';

--- a/lib/i18n/strings_ko.i18n.json
+++ b/lib/i18n/strings_ko.i18n.json
@@ -98,7 +98,7 @@
         },
         "emailVerificationPage": {
             "title": "이메일 주소 확인",
-            "descriptionForDestination": "입력한 ${email}로 확인 이메일을 발송합니다.",
+            "descriptionForDestination": "입력된 ${email}로 확인 이메일을 보냈습니다",
             "descriptionForCoolDown": "확인 이메일 재발송은 60초마다 1회 가능합니다.",
             "buttons": {
                 "sendEmail": "확인 이메일 발송",

--- a/lib/i18n/strings_zh-Hans.i18n.json
+++ b/lib/i18n/strings_zh-Hans.i18n.json
@@ -109,7 +109,7 @@
         },
         "emailVerificationPage": {
             "title": "邮箱地址验证",
-            "descriptionForDestination": "将向输入的${email}发送确认邮件。",
+            "descriptionForDestination": "已向输入的${email}发送了验证邮件",
             "descriptionForCoolDown": "确认邮件每60秒只能重新发送一次。",
             "buttons": {
                 "sendEmail": "发送确认邮件",
@@ -164,7 +164,6 @@
                 "error": "SMS 验证码发送失败。请确认电话号码后重试。",
                 "unexpectedError": "发生了意外错误：",
                 "phoneNumberVerificaiton": "电话号码验证尚未完成"
-
             }
         },
         "smsVerificationPage": {

--- a/lib/i18n/strings_zh-Hant.i18n.json
+++ b/lib/i18n/strings_zh-Hant.i18n.json
@@ -109,7 +109,7 @@
         },
         "emailVerificationPage": {
             "title": "電子郵件地址驗證",
-            "descriptionForDestination": "將向輸入的${email}發送確認郵件。",
+            "descriptionForDestination": "已向輸入的${email}發送了驗證郵件",
             "descriptionForCoolDown": "確認郵件每60秒只能重新發送一次。",
             "buttons": {
                 "sendEmail": "發送確認郵件",

--- a/lib/i18n/strings_zh_Hans.g.dart
+++ b/lib/i18n/strings_zh_Hans.g.dart
@@ -496,7 +496,7 @@ class _TranslationsAuthenticationEmailVerificationPageZhHans implements Translat
 
 	// Translations
 	@override String get title => '邮箱地址验证';
-	@override String descriptionForDestination({required Object email}) => '将向输入的${email}发送确认邮件。';
+	@override String descriptionForDestination({required Object email}) => '已向输入的${email}发送了验证邮件';
 	@override String get descriptionForCoolDown => '确认邮件每60秒只能重新发送一次。';
 	@override late final _TranslationsAuthenticationEmailVerificationPageButtonsZhHans buttons = _TranslationsAuthenticationEmailVerificationPageButtonsZhHans._(_root);
 	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans snackBar = _TranslationsAuthenticationEmailVerificationPageSnackBarZhHans._(_root);
@@ -1409,7 +1409,7 @@ extension on TranslationsZhHans {
 			case 'authentication.signUpPage.button.defaultText': return '注册';
 			case 'authentication.signUpPage.button.modifyEmail': return '更改';
 			case 'authentication.emailVerificationPage.title': return '邮箱地址验证';
-			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '将向输入的${email}发送确认邮件。';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '已向输入的${email}发送了验证邮件';
 			case 'authentication.emailVerificationPage.descriptionForCoolDown': return '确认邮件每60秒只能重新发送一次。';
 			case 'authentication.emailVerificationPage.buttons.sendEmail': return '发送确认邮件';
 			case 'authentication.emailVerificationPage.buttons.resendEmail': return '重新发送确认邮件';

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -496,7 +496,7 @@ class _TranslationsAuthenticationEmailVerificationPageZhHant implements Translat
 
 	// Translations
 	@override String get title => '電子郵件地址驗證';
-	@override String descriptionForDestination({required Object email}) => '將向輸入的${email}發送確認郵件。';
+	@override String descriptionForDestination({required Object email}) => '已向輸入的${email}發送了驗證郵件';
 	@override String get descriptionForCoolDown => '確認郵件每60秒只能重新發送一次。';
 	@override late final _TranslationsAuthenticationEmailVerificationPageButtonsZhHant buttons = _TranslationsAuthenticationEmailVerificationPageButtonsZhHant._(_root);
 	@override late final _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant snackBar = _TranslationsAuthenticationEmailVerificationPageSnackBarZhHant._(_root);
@@ -1409,7 +1409,7 @@ extension on TranslationsZhHant {
 			case 'authentication.signUpPage.button.defaultText': return '註冊';
 			case 'authentication.signUpPage.button.modifyEmail': return '更改';
 			case 'authentication.emailVerificationPage.title': return '電子郵件地址驗證';
-			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '將向輸入的${email}發送確認郵件。';
+			case 'authentication.emailVerificationPage.descriptionForDestination': return ({required Object email}) => '已向輸入的${email}發送了驗證郵件';
 			case 'authentication.emailVerificationPage.descriptionForCoolDown': return '確認郵件每60秒只能重新發送一次。';
 			case 'authentication.emailVerificationPage.buttons.sendEmail': return '發送確認郵件';
 			case 'authentication.emailVerificationPage.buttons.resendEmail': return '重新發送確認郵件';

--- a/lib/infrastructure/authentication/authentication_data_source.g.dart
+++ b/lib/infrastructure/authentication/authentication_data_source.g.dart
@@ -7,7 +7,7 @@ part of 'authentication_data_source.dart';
 // **************************************************************************
 
 String _$authenticationDataSourceHash() =>
-    r'2183be09a5cb7f83f27da1eb880675b909bbd315';
+    r'e0e9109ca4dcbf47438b3772d5250ba07b1cff62';
 
 /// See also [AuthenticationDataSource].
 @ProviderFor(AuthenticationDataSource)

--- a/lib/presentation/email_verification/email_verification_page.dart
+++ b/lib/presentation/email_verification/email_verification_page.dart
@@ -26,6 +26,33 @@ class EmailVerificationPage extends ConsumerWidget {
     final state = ref.watch(emailVerificationPageNotifierProvider);
     final notifier = ref.read(emailVerificationPageNotifierProvider.notifier);
 
+    Widget getSubmitLabel() {
+      final style = AppTextStyle.textStyle.copyWith(
+        fontSize: 14,
+        color: AppColor.black,
+        fontWeight: FontWeight.w700,
+      );
+      return switch (state.emailVerificationButtonState) {
+        EmailVerificationButtonState.initialize =>
+          LoadingAnimationWidget.waveDots(
+            color: AppColor.black,
+            size: 20,
+          ),
+        EmailVerificationButtonState.coolDown => Text(
+            '${state.resendEmailVerificationCountdown}s',
+            style: style,
+          ),
+        EmailVerificationButtonState.resend => Text(
+            i18nEmailVerificationPage.buttons.resendEmail,
+            style: style,
+          ),
+        EmailVerificationButtonState.verified => Text(
+            i18nEmailVerificationPage.buttons.toNext,
+            style: style,
+          ),
+      };
+    }
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: AppColor.white,
@@ -79,28 +106,34 @@ class EmailVerificationPage extends ConsumerWidget {
                     ),
             ),
             const Gap(64),
-            WideButton(
-              label: switch (state.emailVerificationButtonState) {
-                EmailVerificationButtonState.initialize =>
-                  i18nEmailVerificationPage.buttons.sendEmail,
-                EmailVerificationButtonState.coolDown =>
-                  '${state.resendEmailVerificationCountdown}s',
-                EmailVerificationButtonState.resend =>
-                  i18nEmailVerificationPage.buttons.resendEmail,
-                EmailVerificationButtonState.verified =>
-                  i18nEmailVerificationPage.buttons.toNext,
-              },
-              color: state.emailVerificationButtonState ==
-                      EmailVerificationButtonState.coolDown
-                  ? AppColor.grey600
-                  : AppColor.yellow600Primary,
-              onPressed: () async {
-                if (state.isEmailVerified) {
-                  const PhoneNumberInputPageRouteData().go(context);
-                } else {
-                  await notifier.sendEmailVerification();
-                }
-              },
+            SizedBox(
+              width: double.infinity,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: state.emailVerificationButtonState ==
+                          EmailVerificationButtonState.coolDown
+                      ? AppColor.grey600
+                      : AppColor.yellow600Primary,
+                  borderRadius: BorderRadius.circular(32),
+                ),
+                child: FilledButton.icon(
+                  style: FilledButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(32),
+                    ),
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    backgroundColor: Colors.transparent,
+                  ),
+                  onPressed: () async {
+                    if (state.isEmailVerified) {
+                      const PhoneNumberInputPageRouteData().go(context);
+                    } else {
+                      await notifier.sendEmailVerification();
+                    }
+                  },
+                  label: getSubmitLabel(),
+                ),
+              ),
             ),
             const Gap(16),
             if (!state.isEmailVerified)

--- a/lib/presentation/email_verification/email_verification_page_notifier.dart
+++ b/lib/presentation/email_verification/email_verification_page_notifier.dart
@@ -43,9 +43,7 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
 
   Future<void> sendEmailVerification() async {
     if (state.emailVerificationButtonState ==
-            EmailVerificationButtonState.coolDown ||
-        state.emailVerificationButtonState ==
-            EmailVerificationButtonState.initialize) {
+        EmailVerificationButtonState.coolDown) {
       return;
     }
 

--- a/lib/presentation/email_verification/email_verification_page_notifier.dart
+++ b/lib/presentation/email_verification/email_verification_page_notifier.dart
@@ -5,7 +5,6 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../i18n/strings.g.dart';
 import '../../infrastructure/authentication/authentication_data_source.dart';
 import '../../utils/providers/scaffold_messenger/scaffold_messenger.dart';
-import '../../utils/routes/app_router.dart';
 import 'email_verification_state.dart';
 
 part 'email_verification_page_notifier.g.dart';
@@ -16,6 +15,8 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
       ref.read(authenticationDataSourceProvider.notifier);
   ScaffoldMessenger get scaffoldMessenger =>
       ref.read(scaffoldMessengerProvider.notifier);
+  TranslationsAuthenticationEmailVerificationPageSnackBarEn get i18n =>
+      t.authentication.emailVerificationPage.snackBar;
 
   @override
   EmailVerificationState build() {
@@ -47,10 +48,7 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
             EmailVerificationButtonState.initialize) {
       return;
     }
-    final i18n = Translations.of(rootNavigatorKey.currentContext!)
-        .authentication
-        .emailVerificationPage
-        .snackBar;
+
     try {
       await authenticationDataSource.sendEmailVerification();
       state = state.copyWith(

--- a/lib/presentation/email_verification/email_verification_page_notifier.dart
+++ b/lib/presentation/email_verification/email_verification_page_notifier.dart
@@ -42,7 +42,9 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
 
   Future<void> sendEmailVerification() async {
     if (state.emailVerificationButtonState ==
-        EmailVerificationButtonState.coolDown) {
+            EmailVerificationButtonState.coolDown ||
+        state.emailVerificationButtonState ==
+            EmailVerificationButtonState.initialize) {
       return;
     }
     final i18n = Translations.of(rootNavigatorKey.currentContext!)

--- a/lib/presentation/email_verification/email_verification_page_notifier.dart
+++ b/lib/presentation/email_verification/email_verification_page_notifier.dart
@@ -29,6 +29,10 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
           isEmailVerified: true,
           emailVerificationButtonState: EmailVerificationButtonState.verified,
         );
+      } else {
+        if (checkVerifyTimer.tick == 1) {
+          await sendEmailVerification();
+        }
       }
     });
     ref.onDispose(timer.cancel);

--- a/lib/presentation/email_verification/email_verification_page_notifier.dart
+++ b/lib/presentation/email_verification/email_verification_page_notifier.dart
@@ -20,11 +20,11 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
   @override
   EmailVerificationState build() {
     /// メール認証が完了しているかを一秒ごとに確認する。
-    final timer =
-        Timer.periodic(const Duration(seconds: 1), (Timer timer) async {
+    final checkVerifyTimer = Timer.periodic(const Duration(seconds: 1),
+        (Timer checkVerifyTimer) async {
       final emailVerified = await authenticationDataSource.isEmailVerified();
       if (emailVerified) {
-        timer.cancel();
+        checkVerifyTimer.cancel();
         state = state.copyWith(
           isEmailVerified: true,
           emailVerificationButtonState: EmailVerificationButtonState.verified,
@@ -35,7 +35,8 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
         }
       }
     });
-    ref.onDispose(timer.cancel);
+
+    ref.onDispose(checkVerifyTimer.cancel);
     return const EmailVerificationState();
   }
 

--- a/lib/presentation/email_verification/email_verification_page_notifier.g.dart
+++ b/lib/presentation/email_verification/email_verification_page_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'email_verification_page_notifier.dart';
 // **************************************************************************
 
 String _$emailVerificationPageNotifierHash() =>
-    r'1bb67154242b67c53fae45374f536ed0dc31d06f';
+    r'36e776e1a978fdb3ec72da98490104d4ced2f26d';
 
 /// See also [EmailVerificationPageNotifier].
 @ProviderFor(EmailVerificationPageNotifier)

--- a/lib/presentation/home/home_page_notifier.g.dart
+++ b/lib/presentation/home/home_page_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'home_page_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$homePageNotifierHash() => r'f77bb8133730e8cef7b3d5161b2a67869d04770c';
+String _$homePageNotifierHash() => r'259dd5aad3ab2ef683146aa6b5cf047425461e4c';
 
 /// See also [HomePageNotifier].
 @ProviderFor(HomePageNotifier)

--- a/lib/utils/providers/in_app_purchase/in_app_purchase_service.g.dart
+++ b/lib/utils/providers/in_app_purchase/in_app_purchase_service.g.dart
@@ -7,7 +7,7 @@ part of 'in_app_purchase_service.dart';
 // **************************************************************************
 
 String _$inAppPurchaseServiceHash() =>
-    r'b51bcad7515946f8e75957e0b5277e51df643b8d';
+    r'602a02a43e0574e18244076b002123f751033c7d';
 
 /// See also [InAppPurchaseService].
 @ProviderFor(InAppPurchaseService)


### PR DESCRIPTION
## 対応したこと

<!-- 対応したことを箇条書きでわかりやすく -->

- メール認証ページに遷移時、自動でメールを一度送信するよう修正

## 関連資料

<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->
特になし

## 残タスク

<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->
特になし

## 画面キャプチャ

<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->

https://github.com/user-attachments/assets/2acc6c4a-34bb-41a9-80ff-8cbada555460

