### PR TITLE
Android端末でサインインページ表示時はAppleサインインを表示しない

### DIFF
--- a/lib/presentation/account/account_page.dart
+++ b/lib/presentation/account/account_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_svg/svg.dart';
@@ -40,36 +42,37 @@ class AccountPage extends ConsumerWidget {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            Opacity(
-              opacity: accountLinkage.appleLinkage ? 0.4 : 1,
-              child: WideButton.icon(
-                label: accountLinkage.appleLinkage
-                    ? itemi18n.alreadyLinkedApple
-                    : itemi18n.linkedWithApple,
-                color: AppColor.blue50Background,
-                icon: SvgPicture.asset(Assets.icons.appleIcon),
-                onPressed: () async {
-                  if (accountLinkage.appleLinkage) {
-                    await showDialog<void>(
-                      context: context,
-                      builder: (context) {
-                        return ConfirmDialog(
-                          onConfirm: () async {
-                            await notifier.unlinkSocialAccount(
-                              SocialAuthDomain.apple,
-                            );
-                          },
-                          titleText: diaLogi18n.title,
-                          bodyText: diaLogi18n.appleText,
-                        );
-                      },
-                    );
-                  } else {
-                    await notifier.linkedWithApple();
-                  }
-                },
+            if (!Platform.isAndroid)
+              Opacity(
+                opacity: accountLinkage.appleLinkage ? 0.4 : 1,
+                child: WideButton.icon(
+                  label: accountLinkage.appleLinkage
+                      ? itemi18n.alreadyLinkedApple
+                      : itemi18n.linkedWithApple,
+                  color: AppColor.blue50Background,
+                  icon: SvgPicture.asset(Assets.icons.appleIcon),
+                  onPressed: () async {
+                    if (accountLinkage.appleLinkage) {
+                      await showDialog<void>(
+                        context: context,
+                        builder: (context) {
+                          return ConfirmDialog(
+                            onConfirm: () async {
+                              await notifier.unlinkSocialAccount(
+                                SocialAuthDomain.apple,
+                              );
+                            },
+                            titleText: diaLogi18n.title,
+                            bodyText: diaLogi18n.appleText,
+                          );
+                        },
+                      );
+                    } else {
+                      await notifier.linkedWithApple();
+                    }
+                  },
+                ),
               ),
-            ),
             const SizedBox(height: 16),
             Opacity(
               opacity: accountLinkage.googleLinkage ? 0.4 : 1,

--- a/lib/presentation/sign_in/sign_in_page.dart
+++ b/lib/presentation/sign_in/sign_in_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -220,22 +221,23 @@ class SignInPage extends HookConsumerWidget {
                   ),
                 ),
                 const SliverGap(16),
-                SliverToBoxAdapter(
-                  child: WideButton.icon(
-                    label: i18nSignInPage.buttons.appleSignIn,
-                    color: AppColor.blue50Background,
-                    icon: SvgPicture.asset(Assets.icons.appleIcon),
-                    onPressed: () async => notifier.signInWithApple(
-                      needEmailVerify: (email) async =>
-                          EmailVerificationPageRouteData(email: email)
-                              .go(context),
-                      needPhoneVerify: () async =>
-                          const PhoneNumberInputPageRouteData().go(context),
-                      onSuccess: () async =>
-                          const HomeScreenRouteData().go(context),
+                if (!Platform.isAndroid)
+                  SliverToBoxAdapter(
+                    child: WideButton.icon(
+                      label: i18nSignInPage.buttons.appleSignIn,
+                      color: AppColor.blue50Background,
+                      icon: SvgPicture.asset(Assets.icons.appleIcon),
+                      onPressed: () async => notifier.signInWithApple(
+                        needEmailVerify: (email) async =>
+                            EmailVerificationPageRouteData(email: email)
+                                .go(context),
+                        needPhoneVerify: () async =>
+                            const PhoneNumberInputPageRouteData().go(context),
+                        onSuccess: () async =>
+                            const HomeScreenRouteData().go(context),
+                      ),
                     ),
                   ),
-                ),
                 const SliverGap(16),
                 SliverToBoxAdapter(
                   child: WideButton.icon(


### PR DESCRIPTION
## 対応したこと

<!-- 対応したことを箇条書きでわかりやすく -->

- Android端末でサインインページ表示時はAppleサインインを表示しない

## 関連資料

<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->
https://medium.com/flutter-jp/sign-in-with-apple-d0d123cbbe17

## 残タスク

<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->
Android V1リリースでは一旦消し、のちに必要なら実装する

## 画面キャプチャ

<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
<img width="360" alt="スクリーンショット 2025-02-03 14 45 43" src="https://github.com/user-attachments/assets/2b927ccd-0951-4c39-8ffc-c9ef22d93f90" />
<img width="360" alt="スクリーンショット 2025-02-03 14 45 51" src="https://github.com/user-attachments/assets/4e046934-362c-441f-bbd9-3c8e7d743343" />
