### PR TITLE
課金詳細ページの購入の復元の説明を外部ブラウザに移行

### DIFF
--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 5
-/// Strings: 1395 (279 per locale)
+/// Strings: 1390 (278 per locale)
 ///
-/// Built on 2025-02-02 at 14:14 UTC
+/// Built on 2025-02-04 at 16:51 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -453,9 +453,8 @@
             }
         },
         "restorePurchaseSection": {
-            "title": "Restore Purchase",
-            "description": "If you have valid items purchased in the past using the same AppStore or Google Play account, you can restore those purchases.",
-            "button": "Restore Purchase"
+            "button": "Restore Purchase",
+            "textButton": "What is Restore Purchase?"
         },
         "upgradeButton": "Upgrade to Premium",
         "snackBar": {

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -857,9 +857,8 @@ class TranslationsBillDetailsPageRestorePurchaseSectionEn {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	String get title => 'Restore Purchase';
-	String get description => 'If you have valid items purchased in the past using the same AppStore or Google Play account, you can restore those purchases.';
 	String get button => 'Restore Purchase';
+	String get textButton => 'What is Restore Purchase?';
 }
 
 // Path: billDetailsPage.snackBar
@@ -1623,9 +1622,8 @@ extension on Translations {
 			case 'billDetailsPage.pricingOptions.unlimited.duration': return 'Unlimited';
 			case 'billDetailsPage.pricingOptions.unlimited.discount': return '-20%';
 			case 'billDetailsPage.pricingOptions.unlimited.price': return '25,800 yen';
-			case 'billDetailsPage.restorePurchaseSection.title': return 'Restore Purchase';
-			case 'billDetailsPage.restorePurchaseSection.description': return 'If you have valid items purchased in the past using the same AppStore or Google Play account, you can restore those purchases.';
 			case 'billDetailsPage.restorePurchaseSection.button': return 'Restore Purchase';
+			case 'billDetailsPage.restorePurchaseSection.textButton': return 'What is Restore Purchase?';
 			case 'billDetailsPage.upgradeButton': return 'Upgrade to Premium';
 			case 'billDetailsPage.snackBar.error.failedToPurchase': return 'Purchase failed. Please try again later.';
 			case 'billDetailsPage.snackBar.error.PurchaseHistoryNotFound': return 'No purchase history found.';

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -853,9 +853,8 @@ class _TranslationsBillDetailsPageRestorePurchaseSectionJa implements Translatio
 	final TranslationsJa _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '購入の復元';
-	@override String get description => '過去に、現在と同じAppStoreアカウントやGoogle Playアカウントで購入した有効な購入アイテムがある場合、それらを復元することが可能です。';
 	@override String get button => '購入を復元';
+	@override String get textButton => '購入の復元とは？';
 }
 
 // Path: billDetailsPage.snackBar
@@ -1619,9 +1618,8 @@ extension on TranslationsJa {
 			case 'billDetailsPage.pricingOptions.unlimited.duration': return 'Unlimited';
 			case 'billDetailsPage.pricingOptions.unlimited.discount': return '-20%';
 			case 'billDetailsPage.pricingOptions.unlimited.price': return '25,800円';
-			case 'billDetailsPage.restorePurchaseSection.title': return '購入の復元';
-			case 'billDetailsPage.restorePurchaseSection.description': return '過去に、現在と同じAppStoreアカウントやGoogle Playアカウントで購入した有効な購入アイテムがある場合、それらを復元することが可能です。';
 			case 'billDetailsPage.restorePurchaseSection.button': return '購入を復元';
+			case 'billDetailsPage.restorePurchaseSection.textButton': return '購入の復元とは？';
 			case 'billDetailsPage.upgradeButton': return 'プレミアムにアップグレード';
 			case 'billDetailsPage.snackBar.error.failedToPurchase': return '購入に失敗しました。時間をおいて再度お試しください。';
 			case 'billDetailsPage.snackBar.error.PurchaseHistoryNotFound': return '購入履歴がありません。';

--- a/lib/i18n/strings_ja.i18n.json
+++ b/lib/i18n/strings_ja.i18n.json
@@ -453,9 +453,8 @@
             }
         },
         "restorePurchaseSection": {
-            "title": "購入の復元",
-            "description": "過去に、現在と同じAppStoreアカウントやGoogle Playアカウントで購入した有効な購入アイテムがある場合、それらを復元することが可能です。",
-            "button": "購入を復元"
+            "button": "購入を復元",
+            "textButton": "購入の復元とは？"
         },
         "upgradeButton": "プレミアムにアップグレード",
         "snackBar": {

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -853,9 +853,8 @@ class _TranslationsBillDetailsPageRestorePurchaseSectionKo implements Translatio
 	final TranslationsKo _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '구매 복원';
-	@override String get description => '이전에 동일한 AppStore 계정이나 Google Play 계정으로 구매한 유효한 항목이 있는 경우, 이를 복원할 수 있습니다.';
 	@override String get button => '구매 복원';
+	@override String get textButton => '구매 복원이란?';
 }
 
 // Path: billDetailsPage.snackBar
@@ -1619,9 +1618,8 @@ extension on TranslationsKo {
 			case 'billDetailsPage.pricingOptions.unlimited.duration': return '무제한';
 			case 'billDetailsPage.pricingOptions.unlimited.discount': return '-20%';
 			case 'billDetailsPage.pricingOptions.unlimited.price': return '25,800원';
-			case 'billDetailsPage.restorePurchaseSection.title': return '구매 복원';
-			case 'billDetailsPage.restorePurchaseSection.description': return '이전에 동일한 AppStore 계정이나 Google Play 계정으로 구매한 유효한 항목이 있는 경우, 이를 복원할 수 있습니다.';
 			case 'billDetailsPage.restorePurchaseSection.button': return '구매 복원';
+			case 'billDetailsPage.restorePurchaseSection.textButton': return '구매 복원이란?';
 			case 'billDetailsPage.upgradeButton': return '프리미엄으로 업그레이드';
 			case 'billDetailsPage.snackBar.error.failedToPurchase': return '구매에 실패했습니다. 잠시 후 다시 시도해주세요.';
 			case 'billDetailsPage.snackBar.error.PurchaseHistoryNotFound': return '구매 기록이 없습니다.';

--- a/lib/i18n/strings_ko.i18n.json
+++ b/lib/i18n/strings_ko.i18n.json
@@ -453,9 +453,8 @@
             }
         },
         "restorePurchaseSection": {
-            "title": "구매 복원",
-            "description": "이전에 동일한 AppStore 계정이나 Google Play 계정으로 구매한 유효한 항목이 있는 경우, 이를 복원할 수 있습니다.",
-            "button": "구매 복원"
+            "button": "구매 복원",
+            "textButton": "구매 복원이란?"
         },
         "upgradeButton": "프리미엄으로 업그레이드",
         "snackBar": {

--- a/lib/i18n/strings_zh-Hans.i18n.json
+++ b/lib/i18n/strings_zh-Hans.i18n.json
@@ -453,9 +453,8 @@
             }
         },
         "restorePurchaseSection": {
-            "title": "恢复购买",
-            "description": "如果您过去使用相同的AppStore账户或Google Play账户购买了有效的项目，可以恢复这些购买。",
-            "button": "恢复购买"
+            "button": "恢复购买",
+            "textButton": "什么是购买恢复？"
         },
         "upgradeButton": "升级到高级计划",
         "snackBar": {

--- a/lib/i18n/strings_zh-Hant.i18n.json
+++ b/lib/i18n/strings_zh-Hant.i18n.json
@@ -453,9 +453,8 @@
             }
         },
         "restorePurchaseSection": {
-            "title": "恢復購買",
-            "description": "如果您過去使用相同的AppStore帳戶或Google Play帳戶購買了有效的項目，可以恢復這些購買。",
-            "button": "恢復購買"
+            "button": "恢復購買",
+            "textButton": "什麼是購買恢復？"
         },
         "upgradeButton": "升級到高級方案",
         "snackBar": {

--- a/lib/i18n/strings_zh_Hans.g.dart
+++ b/lib/i18n/strings_zh_Hans.g.dart
@@ -853,9 +853,8 @@ class _TranslationsBillDetailsPageRestorePurchaseSectionZhHans implements Transl
 	final TranslationsZhHans _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '恢复购买';
-	@override String get description => '如果您过去使用相同的AppStore账户或Google Play账户购买了有效的项目，可以恢复这些购买。';
 	@override String get button => '恢复购买';
+	@override String get textButton => '什么是购买恢复？';
 }
 
 // Path: billDetailsPage.snackBar
@@ -1619,9 +1618,8 @@ extension on TranslationsZhHans {
 			case 'billDetailsPage.pricingOptions.unlimited.duration': return '无限制';
 			case 'billDetailsPage.pricingOptions.unlimited.discount': return '-20%';
 			case 'billDetailsPage.pricingOptions.unlimited.price': return '25,800日元';
-			case 'billDetailsPage.restorePurchaseSection.title': return '恢复购买';
-			case 'billDetailsPage.restorePurchaseSection.description': return '如果您过去使用相同的AppStore账户或Google Play账户购买了有效的项目，可以恢复这些购买。';
 			case 'billDetailsPage.restorePurchaseSection.button': return '恢复购买';
+			case 'billDetailsPage.restorePurchaseSection.textButton': return '什么是购买恢复？';
 			case 'billDetailsPage.upgradeButton': return '升级到高级计划';
 			case 'billDetailsPage.snackBar.error.failedToPurchase': return '购买失败，请稍后再试。';
 			case 'billDetailsPage.snackBar.error.PurchaseHistoryNotFound': return '未找到购买记录。';

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -853,9 +853,8 @@ class _TranslationsBillDetailsPageRestorePurchaseSectionZhHant implements Transl
 	final TranslationsZhHant _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => '恢復購買';
-	@override String get description => '如果您過去使用相同的AppStore帳戶或Google Play帳戶購買了有效的項目，可以恢復這些購買。';
 	@override String get button => '恢復購買';
+	@override String get textButton => '什麼是購買恢復？';
 }
 
 // Path: billDetailsPage.snackBar
@@ -1619,9 +1618,8 @@ extension on TranslationsZhHant {
 			case 'billDetailsPage.pricingOptions.unlimited.duration': return '無限制';
 			case 'billDetailsPage.pricingOptions.unlimited.discount': return '-20%';
 			case 'billDetailsPage.pricingOptions.unlimited.price': return '25,800日圓';
-			case 'billDetailsPage.restorePurchaseSection.title': return '恢復購買';
-			case 'billDetailsPage.restorePurchaseSection.description': return '如果您過去使用相同的AppStore帳戶或Google Play帳戶購買了有效的項目，可以恢復這些購買。';
 			case 'billDetailsPage.restorePurchaseSection.button': return '恢復購買';
+			case 'billDetailsPage.restorePurchaseSection.textButton': return '什麼是購買恢復？';
 			case 'billDetailsPage.upgradeButton': return '升級到高級方案';
 			case 'billDetailsPage.snackBar.error.failedToPurchase': return '購買失敗，請稍後再試。';
 			case 'billDetailsPage.snackBar.error.PurchaseHistoryNotFound': return '未找到購買記錄。';

--- a/lib/presentation/bill_details/bill_detail_page_notifier.dart
+++ b/lib/presentation/bill_details/bill_detail_page_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../i18n/strings.g.dart';
 import '../../utils/providers/in_app_purchase/in_app_purchase_service.dart';
@@ -97,6 +98,17 @@ class BillDetailPageNotifier extends _$BillDetailPageNotifier {
       return PurchaseItemConfig.unlimitedPremium.packageId;
     } else {
       return '';
+    }
+  }
+
+  Future<void> launchNotion() async {
+    final url = Uri.parse(
+      'https://pond-link-c69.notion.site/1904d7d3b38980f0a608e48ccd13dce4?pvs=4',
+    );
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    } else {
+      debugPrint('Could not launch $url');
     }
   }
 }

--- a/lib/presentation/bill_details/bill_detail_page_notifier.dart
+++ b/lib/presentation/bill_details/bill_detail_page_notifier.dart
@@ -105,8 +105,6 @@ class BillDetailPageNotifier extends _$BillDetailPageNotifier {
     final url = Uri.parse(
       'https://pond-link-c69.notion.site/1904d7d3b38980f0a608e48ccd13dce4?pvs=4',
     );
-    if (await canLaunchUrl(url)) {
-      await launchUrl(url, mode: LaunchMode.externalApplication);
-    }
+    await launchUrl(url, mode: LaunchMode.externalApplication);
   }
 }

--- a/lib/presentation/bill_details/bill_detail_page_notifier.dart
+++ b/lib/presentation/bill_details/bill_detail_page_notifier.dart
@@ -107,8 +107,6 @@ class BillDetailPageNotifier extends _$BillDetailPageNotifier {
     );
     if (await canLaunchUrl(url)) {
       await launchUrl(url, mode: LaunchMode.externalApplication);
-    } else {
-      debugPrint('Could not launch $url');
     }
   }
 }

--- a/lib/presentation/bill_details/bill_detail_page_notifier.g.dart
+++ b/lib/presentation/bill_details/bill_detail_page_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'bill_detail_page_notifier.dart';
 // **************************************************************************
 
 String _$billDetailPageNotifierHash() =>
-    r'fbcd7b278fc28e5372938b39a4b653916a92bc54';
+    r'2538516c8f76b68fa551fffab260d92a6dedb411';
 
 /// See also [BillDetailPageNotifier].
 @ProviderFor(BillDetailPageNotifier)

--- a/lib/presentation/bill_details/components/restore_purchase_section.dart
+++ b/lib/presentation/bill_details/components/restore_purchase_section.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../i18n/strings.g.dart';
@@ -14,31 +13,30 @@ class RestorePurchaseSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final i18n = Translations.of(context);
+    final notifier = ref.read(billDetailPageNotifierProvider.notifier);
 
     return Column(
       children: [
-        Text(
-          i18n.billDetailsPage.restorePurchaseSection.title,
-          style: AppTextStyle.textStyle.copyWith(
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        const Gap(16),
-        Text(
-          i18n.billDetailsPage.restorePurchaseSection.description,
-          textAlign: TextAlign.center,
-          style: AppTextStyle.textStyle.copyWith(
-            fontSize: 16,
-          ),
-        ),
-        const Gap(16),
         WideButton(
           label: i18n.billDetailsPage.restorePurchaseSection.button,
           color: AppColor.grey200,
-          onPressed: () async => ref
-              .read(billDetailPageNotifierProvider.notifier)
-              .restorePurhcaseItem(),
+          onPressed: () async => notifier.restorePurhcaseItem(),
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(
+            onPressed: notifier.launchNotion,
+            child: Text.rich(
+              TextSpan(
+                text: '購入の復元とは?',
+                style: AppTextStyle.textStyle.copyWith(
+                  color: AppColor.grey800,
+                  decoration: TextDecoration.underline,
+                  decorationColor: AppColor.grey600,
+                ),
+              ),
+            ),
+          ),
         ),
       ],
     );

--- a/lib/presentation/bill_details/components/restore_purchase_section.dart
+++ b/lib/presentation/bill_details/components/restore_purchase_section.dart
@@ -23,7 +23,9 @@ class RestorePurchaseSection extends ConsumerWidget {
           onPressed: notifier.restorePurhcaseItem,
         ),
         TextButton(
-          onPressed: notifier.launchNotion,
+          onPressed: () async => ref
+              .read(billDetailPageNotifierProvider.notifier)
+              .restorePurhcaseItem(),
           child: Text(
             i18n.billDetailsPage.restorePurchaseSection.textButton,
             style: AppTextStyle.textStyle.copyWith(

--- a/lib/presentation/bill_details/components/restore_purchase_section.dart
+++ b/lib/presentation/bill_details/components/restore_purchase_section.dart
@@ -23,9 +23,7 @@ class RestorePurchaseSection extends ConsumerWidget {
           onPressed: notifier.restorePurhcaseItem,
         ),
         TextButton(
-          onPressed: () async => ref
-              .read(billDetailPageNotifierProvider.notifier)
-              .restorePurhcaseItem(),
+          onPressed: notifier.launchNotion,
           child: Text(
             i18n.billDetailsPage.restorePurchaseSection.textButton,
             style: AppTextStyle.textStyle.copyWith(

--- a/lib/presentation/bill_details/components/restore_purchase_section.dart
+++ b/lib/presentation/bill_details/components/restore_purchase_section.dart
@@ -25,7 +25,7 @@ class RestorePurchaseSection extends ConsumerWidget {
         TextButton(
           onPressed: notifier.launchNotion,
           child: Text(
-            '購入の復元とは?',
+            i18n.billDetailsPage.restorePurchaseSection.textButton,
             style: AppTextStyle.textStyle.copyWith(
               color: AppColor.grey800,
               decoration: TextDecoration.underline,

--- a/lib/presentation/bill_details/components/restore_purchase_section.dart
+++ b/lib/presentation/bill_details/components/restore_purchase_section.dart
@@ -14,27 +14,22 @@ class RestorePurchaseSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final i18n = Translations.of(context);
     final notifier = ref.read(billDetailPageNotifierProvider.notifier);
-
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
       children: [
         WideButton(
           label: i18n.billDetailsPage.restorePurchaseSection.button,
           color: AppColor.grey200,
-          onPressed: () async => notifier.restorePurhcaseItem(),
+          onPressed: notifier.restorePurhcaseItem,
         ),
-        Align(
-          alignment: Alignment.centerRight,
-          child: TextButton(
-            onPressed: notifier.launchNotion,
-            child: Text.rich(
-              TextSpan(
-                text: '購入の復元とは?',
-                style: AppTextStyle.textStyle.copyWith(
-                  color: AppColor.grey800,
-                  decoration: TextDecoration.underline,
-                  decorationColor: AppColor.grey600,
-                ),
-              ),
+        TextButton(
+          onPressed: notifier.launchNotion,
+          child: Text(
+            '購入の復元とは?',
+            style: AppTextStyle.textStyle.copyWith(
+              color: AppColor.grey800,
+              decoration: TextDecoration.underline,
+              decorationColor: AppColor.grey600,
             ),
           ),
         ),


### PR DESCRIPTION
## 対応したこと
- url_launcherを使用したlaunchNotion関数を作成
- 購入の復元とは？のテキストボタンを作成
- Notionに説明を移行
- 必要がなくなった多言語を削除し、textButtonの多言語を追加
<!-- 対応したことを箇条書きでわかりやすく -->

## 関連資料
[Flutter大学](https://blog.flutteruniv.com/flutter-package-url_launcher/)
<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->

## 残タスク
特になし
<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

## 画面キャプチャ
権限周りの関係でprod環境でもページが開けないので、エラーページにコンポーネントを表示しています。
※エラーページの変更はコミットしておりません

https://github.com/user-attachments/assets/e722faf4-7b6c-41c6-8c6f-7ba735615c75


<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
