### PR TITLE
SMSコード送信時にOverlayLoadingが出ない問題を修正

### DIFF
--- a/lib/presentation/phone_number_input/phone_number_input_page_notifier.dart
+++ b/lib/presentation/phone_number_input/phone_number_input_page_notifier.dart
@@ -67,12 +67,14 @@ class PhoneNumberInputPageNotifier extends _$PhoneNumberInputPageNotifier {
           );
           // 遷移処理をonSuccessで受け取る
           onSuccess(verificationId);
+          ref.read(isShowLoadingOverlayProvider.notifier).state = false;
         },
         onError: (error) {
           // 電話番号が間違っている場合やサーバーエラーの場合
           scaffoldMessenger.showExceptionSnackBar(
             i18n.error,
           );
+          ref.read(isShowLoadingOverlayProvider.notifier).state = false;
         },
       );
     } on Exception catch (error) {
@@ -81,7 +83,6 @@ class PhoneNumberInputPageNotifier extends _$PhoneNumberInputPageNotifier {
       scaffoldMessenger.showExceptionSnackBar(
         '${i18n.unexpectedError} $error',
       );
-    } finally {
       ref.read(isShowLoadingOverlayProvider.notifier).state = false;
     }
   }


### PR DESCRIPTION
## 対応したこと
- sendSmsCodeのonSuccess,onError時にoverlayをfalseにする記述を追加
<!-- 対応したことを箇条書きでわかりやすく -->

## 関連資料
[ChatGPT](https://chatgpt.com)
<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->

## 残タスク
特になし
<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

## 画面キャプチャ
https://github.com/user-attachments/assets/737532de-a01f-4d1e-9ac6-d7c76a4037a2
<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
