### PR TITLE
ログイン時にoverlayLoadingを出す処理を追加

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -60,7 +60,7 @@
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIStatusBarHidden</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -78,8 +78,6 @@
 	<string>${GoogleMapAPIKey}</string>
 	<key>GADApplicationIdentifier</key>
 	<string>${admobiOSAppId}</string>
-	<key>UIStatusBarHidden</key>
-	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/lib/presentation/authentication/authentication_page_notifier.dart
+++ b/lib/presentation/authentication/authentication_page_notifier.dart
@@ -41,6 +41,8 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
     required Future<void> Function() onFailure,
   }) async {
     final i18n = t.authentication.emailVerificationPage.snackBar;
+    ref.read(isShowLoadingOverlayProvider.notifier).state = true;
+
     try {
       await authenticationDataSource.signInWithEmailAndPassword(
         emailAddress,
@@ -57,6 +59,8 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
     } on FirebaseAuthException catch (e) {
       final exceptionMessage = e.toLocalizedMessage;
       scaffoldMessenger.showExceptionSnackBar(exceptionMessage);
+    } finally {
+      ref.read(isShowLoadingOverlayProvider.notifier).state = false;
     }
   }
 

--- a/lib/presentation/authentication/authentication_page_notifier.dart
+++ b/lib/presentation/authentication/authentication_page_notifier.dart
@@ -92,6 +92,7 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
     required void Function() needPhoneVerify,
     required void Function() onSuccess,
   }) async {
+    ref.read(isShowLoadingOverlayProvider.notifier).state = true;
     try {
       await authenticationDataSource.signInWithGoogle();
       if (firebaseAuth.currentUser!.phoneNumber == null ||
@@ -105,6 +106,8 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
     } on FirebaseAuthException catch (e) {
       final exceptionMessage = e.toLocalizedMessage;
       scaffoldMessenger.showExceptionSnackBar(exceptionMessage);
+    } finally {
+      ref.read(isShowLoadingOverlayProvider.notifier).state = false;
     }
   }
 
@@ -113,6 +116,7 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
     required void Function() needPhoneVerify,
     required void Function() onSuccess,
   }) async {
+    ref.read(isShowLoadingOverlayProvider.notifier).state = true;
     try {
       await authenticationDataSource.signInWithApple();
       if (firebaseAuth.currentUser!.phoneNumber == null ||
@@ -126,6 +130,8 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
     } on FirebaseAuthException catch (e) {
       final exceptionMessage = e.toLocalizedMessage;
       scaffoldMessenger.showExceptionSnackBar(exceptionMessage);
+    } finally {
+      ref.read(isShowLoadingOverlayProvider.notifier).state = false;
     }
   }
 


### PR DESCRIPTION
## 対応したこと
- signInWithEmailAndPassword発火時にoverlayLoadingのstateをboolで切り替える処理を追加
- socialログイン(GoogleとApple)発火時にoverlayLoadingのstateをboolで切り替える処理を追加

ex. info.plistの<key>UIStatusBarHidden</key>をfalseに変更
<!-- 対応したことを箇条書きでわかりやすく -->

## 関連資料
特になし
<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->

## 残タスク
特になし
<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

## 画面キャプチャ
https://github.com/user-attachments/assets/a0f602bf-6fe9-456f-914a-8e4a296acf19
<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
