### PR TITLE
Geminiに関するエラーハンドリングの実装

### DIFF
--- a/lib/infrastructure/gemini/gemini_data_source.dart
+++ b/lib/infrastructure/gemini/gemini_data_source.dart
@@ -147,6 +147,9 @@ class GeminiDataSource extends _$GeminiDataSource implements GeminiRepository {
         TextPart(message),
       ]),
     );
+    if (response.text == null) {
+      return throw Exception('Failed to send message');
+    }
     final jsonMap = jsonDecode(response.text!) as Map<String, dynamic>;
     final geminiResponse = GeminiResponse.fromJson(jsonMap);
 
@@ -169,6 +172,9 @@ class GeminiDataSource extends _$GeminiDataSource implements GeminiRepository {
       TextPart(translatedPrompt),
     ]);
     final response = await state.sendMessage(convertModelToString);
+    if (response.text == null) {
+      return throw Exception('Failed to send plan detail');
+    }
     final jsonMap = jsonDecode(response.text!) as Map<String, dynamic>;
     final geminiResponse = GeminiResponse.fromJson(jsonMap);
     return ChatMessage(

--- a/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
+++ b/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
@@ -200,9 +200,12 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
       scrollController.dispose,
     );
     await loadingNotifier.updateLoadingIndicator(20);
-    final res = await geminiDataSource.sendPlanDetail(planPrompt: planPrompt);
+    final res = await sendPlanDetail();
+    if (res?.places == null || res?.plan == null) {
+      return throw Exception('Failed to fetch AI response.');
+    }
     await loadingNotifier.updateLoadingIndicator(80);
-    final buddyMessage = await _getAllFilledMessage(res, forFirstBuild: true);
+    final buddyMessage = await _getAllFilledMessage(res!, forFirstBuild: true);
     final message = ChatMessage(
       id: buddyMessage.id,
       message: buddyMessage.plan!.description,
@@ -215,6 +218,36 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
       possibleChatCount: null,
       scrollController: scrollController,
     );
+  }
+
+  Future<ChatMessage?> sendPlanDetail() async {
+    ChatMessage? res;
+    const maxRetries = 3;
+    var retryCount = 0;
+
+    while (retryCount < maxRetries) {
+      try {
+        res = await geminiDataSource.sendPlanDetail(planPrompt: planPrompt);
+
+        if (res.places != null && res.plan != null) {
+          return res;
+        }
+      } on Exception catch (e) {
+        logger.e('${retryCount + 1} 回目失敗: $e');
+      }
+
+      retryCount++;
+
+      if (retryCount < maxRetries) {
+        logger.e('再執行($retryCount/$maxRetries)');
+        await Future<void>.delayed(const Duration(seconds: 1));
+      }
+    }
+    if (res == null || res.places == null || res.plan == null) {
+      logger.e('Failed to fetch response after $maxRetries attempts.');
+      throw Exception('Failed to fetch AI response.');
+    }
+    return null;
   }
 
   Future<ChatMessage> _getAllFilledMessage(

--- a/lib/presentation/components/error_view.dart
+++ b/lib/presentation/components/error_view.dart
@@ -27,11 +27,13 @@ class ErrorView extends HookConsumerWidget {
     required this.error,
     required this.stackTrace,
     required this.onRetry,
+    this.isRootPage = false,
   });
 
   final Object error;
   final StackTrace stackTrace;
   final VoidCallback onRetry;
+  final bool isRootPage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -62,6 +64,17 @@ class ErrorView extends HookConsumerWidget {
     );
 
     return Scaffold(
+      appBar: AppBar(
+        backgroundColor: AppColor.white,
+        forceMaterialTransparency: true,
+        elevation: 0,
+        leading: isRootPage
+            ? null
+            : IconButton(
+                icon: const Icon(Icons.arrow_back_ios),
+                onPressed: () => context.pop(),
+              ),
+      ),
       body: SafeArea(
         child: Center(
           child: Padding(

--- a/lib/presentation/components/error_view.dart
+++ b/lib/presentation/components/error_view.dart
@@ -12,6 +12,16 @@ import '../../utils/providers/analytics/analytics.dart';
 import '../../utils/styles/app_color.dart';
 
 class ErrorView extends HookConsumerWidget {
+  /// このUIを使用する際は、必ずルートの画面なのかどうかを指定してください。
+  /// why: ルートの画面の場合、戻るボタンを表示する必要がないため。
+  /// ```dart
+  /// ErrorView(
+  ///  error: error,
+  /// stackTrace: stackTrace,
+  /// onRetry: () => ref.invalidate(~~~NotifierProvider),
+  /// isRootPage: true,
+  /// )
+  /// ```
   const ErrorView({
     super.key,
     required this.error,

--- a/lib/presentation/components/error_view.dart
+++ b/lib/presentation/components/error_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../i18n/strings.g.dart';
@@ -38,12 +39,19 @@ class ErrorView extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final i18n = Translations.of(context);
+    var parentWidgetName = 'Unknown';
 
     useEffect(
       () {
+        context.visitAncestorElements((ancestor) {
+          parentWidgetName = ancestor.widget.runtimeType.toString();
+          return false; // 最初の親ウィジェットを取得したら終了
+        });
+
         logger
           ..e('ErrorView: $error')
-          ..e('ErrorView: $stackTrace');
+          ..e('ErrorView: $stackTrace')
+          ..e('Parent Widget: $parentWidgetName');
 
         Future.delayed(Duration.zero, () async {
           await ref.read(analyticsNotifierProvider.notifier).logScreenView(
@@ -54,6 +62,7 @@ class ErrorView extends HookConsumerWidget {
             parameters: {
               'error': error.toString(),
               'stackTrace': stackTrace.toString(),
+              'errorBy': parentWidgetName,
             },
           );
         });

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -58,6 +58,7 @@ class HomePage extends ConsumerWidget {
         error: e,
         stackTrace: s,
         onRetry: () => ref.invalidate(homePageNotifierProvider),
+        isRootPage: true,
       ),
       loading: Loading.new,
     );

--- a/lib/presentation/my_plan/my_plan_page.dart
+++ b/lib/presentation/my_plan/my_plan_page.dart
@@ -79,6 +79,7 @@ class MyPlanPage extends ConsumerWidget {
         error: e,
         stackTrace: s,
         onRetry: () => ref.invalidate(myPlanPageNotifierProvider),
+        isRootPage: true,
       ),
       loading: Loading.new,
     );

--- a/lib/presentation/mypage/my_page.dart
+++ b/lib/presentation/mypage/my_page.dart
@@ -113,6 +113,7 @@ class MyPage extends ConsumerWidget {
         error: e,
         stackTrace: s,
         onRetry: () => ref.invalidate(currentUserStreamProvider),
+        isRootPage: true,
       ),
       loading: Loading.new,
     );


### PR DESCRIPTION
## 対応したこと

<!-- 対応したことを箇条書きでわかりやすく -->
- Geminiに関するエラーハンドリングの実装
- ErrorViewにてログを送る際にエラーが出たクラス名も送るように変更
- Geminiにリトライをさせる処理を追加

## 関連資料

<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->
特になし

## 残タスク

<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->

Testflightやリリース版でのみプラン生成失敗が起きるので一旦Testflightにて確認を行いたい(でしか行えない)
- [ ] 動作確認

## 画面キャプチャ

<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->

https://github.com/user-attachments/assets/8ff84988-9d28-4490-b05d-0266fe44597b


https://github.com/user-attachments/assets/94bab98d-0c8e-4f4c-b5a8-12c3904e96c6

