### PR TITLE
loggerでエラーを扱った際に自動でイベント送信をするように変更

### DIFF
--- a/lib/infrastructure/gemini/gemini_data_source.dart
+++ b/lib/infrastructure/gemini/gemini_data_source.dart
@@ -147,7 +147,7 @@ class GeminiDataSource extends _$GeminiDataSource implements GeminiRepository {
         TextPart(message),
       ]),
     );
-    if (response.text == null) {
+    if (response.text == null || response.text!.isEmpty) {
       return throw Exception('Failed to send message');
     }
     final jsonMap = jsonDecode(response.text!) as Map<String, dynamic>;
@@ -172,7 +172,7 @@ class GeminiDataSource extends _$GeminiDataSource implements GeminiRepository {
       TextPart(translatedPrompt),
     ]);
     final response = await state.sendMessage(convertModelToString);
-    if (response.text == null) {
+    if (response.text == null || response.text!.isEmpty) {
       return throw Exception('Failed to send plan detail');
     }
     final jsonMap = jsonDecode(response.text!) as Map<String, dynamic>;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,7 +75,10 @@ void setupGeofenceListener() {
   if (success) {
     logger.d('Successfully registered geofenceReceivePort');
   } else {
-    logger.e('Failed to register geofenceReceivePort');
+    logger.error(
+      'Failed to register geofenceReceivePort',
+      methodName: 'setupGeofenceListener',
+    );
   }
 
   geofenceReceivePort.listen((dynamic data) async {

--- a/lib/presentation/account/account_page_notifier.dart
+++ b/lib/presentation/account/account_page_notifier.dart
@@ -59,7 +59,10 @@ class AccountPageNotifier extends _$AccountPageNotifier {
         state = state.copyWith(googleLinkage: false);
       }
     } on FirebaseAuthException catch (e) {
-      logger.e('unlinkSocialAccount: $e');
+      logger.error(
+        'unlinkSocialAccount: $e',
+        methodName: 'unlinkSocialAccount',
+      );
       scaffoldMessenger.showExceptionSnackBar(snackBari18n.unlinkageFailure);
     }
   }
@@ -70,12 +73,13 @@ class AccountPageNotifier extends _$AccountPageNotifier {
       state = state.copyWith(appleLinkage: true);
       scaffoldMessenger.showSuccessSnackBar(snackBari18n.successfulLinkage);
     } on FirebaseAuthException catch (e) {
-      logger.e('linkedWithApple: $e');
+      logger.error('linkedWithApple: $e', methodName: 'linkedWithApple');
       final exceptionMessage = e.toLocalizedMessage;
       ref
           .read(scaffoldMessengerProvider.notifier)
           .showExceptionSnackBar(exceptionMessage);
-    } on Exception {
+    } on Exception catch (e) {
+      logger.error('linkedWithApple: $e', methodName: 'linkedWithApple');
       scaffoldMessenger.showExceptionSnackBar(snackBari18n.linkageCancelled);
     }
   }
@@ -86,12 +90,13 @@ class AccountPageNotifier extends _$AccountPageNotifier {
       state = state.copyWith(googleLinkage: true);
       scaffoldMessenger.showSuccessSnackBar(snackBari18n.successfulLinkage);
     } on FirebaseAuthException catch (e) {
-      logger.e('linkedWithGoogle: $e');
+      logger.error('linkedWithGoogle: $e', methodName: 'linkedWithGoogle');
       final exceptionMessage = e.toLocalizedMessage;
       ref
           .read(scaffoldMessengerProvider.notifier)
           .showExceptionSnackBar(exceptionMessage);
-    } on Exception {
+    } on Exception catch (e) {
+      logger.error('linkedWithGoogle: $e', methodName: 'linkedWithGoogle');
       scaffoldMessenger.showExceptionSnackBar(snackBari18n.linkageCancelled);
     }
   }
@@ -104,7 +109,7 @@ class AccountPageNotifier extends _$AccountPageNotifier {
       scaffoldMessenger.showSuccessSnackBar(snackBari18n.signOut);
       await onSuccess();
     } on FirebaseAuthException catch (e) {
-      logger.e('signOut: $e');
+      logger.error('signOut: $e', methodName: 'signOut');
       scaffoldMessenger.showExceptionSnackBar(snackBari18n.signOutFailure);
     }
   }
@@ -120,7 +125,7 @@ class AccountPageNotifier extends _$AccountPageNotifier {
       scaffoldMessenger.showSuccessSnackBar(snackBari18n.deleteAccount);
       await onSuccess();
     } on FirebaseAuthException catch (e) {
-      logger.e('deleteAccount: $e');
+      logger.error('deleteAccount: $e', methodName: 'deleteAccount');
       scaffoldMessenger
           .showExceptionSnackBar(snackBari18n.deleteAccountFailure);
     }

--- a/lib/presentation/authentication/authentication_page_notifier.dart
+++ b/lib/presentation/authentication/authentication_page_notifier.dart
@@ -57,6 +57,10 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
         });
       }
     } on FirebaseAuthException catch (e) {
+      logger.error(
+        'signInWithEmailAndPassword: $e',
+        methodName: 'signInWithEmailAndPassword',
+      );
       final exceptionMessage = e.toLocalizedMessage;
       scaffoldMessenger.showExceptionSnackBar(exceptionMessage);
     } finally {
@@ -77,7 +81,10 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
       );
       onSuccess();
     } on FirebaseAuthException catch (e) {
-      logger.e('signUpWithEmailAndPassword: $e');
+      logger.error(
+        'signUpWithEmailAndPassword: $e',
+        methodName: 'signUpWithEmailAndPassword',
+      );
       final exceptionMessage = e.toLocalizedMessage;
       ref
           .read(scaffoldMessengerProvider.notifier)
@@ -104,6 +111,10 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
         onSuccess();
       }
     } on FirebaseAuthException catch (e) {
+      logger.error(
+        'signInWithGoogle: $e',
+        methodName: 'signInWithGoogle',
+      );
       final exceptionMessage = e.toLocalizedMessage;
       scaffoldMessenger.showExceptionSnackBar(exceptionMessage);
     } finally {
@@ -128,6 +139,10 @@ class AuthenticationPageNotifier extends _$AuthenticationPageNotifier {
         onSuccess();
       }
     } on FirebaseAuthException catch (e) {
+      logger.error(
+        'signInWithApple: $e',
+        methodName: 'signInWithApple',
+      );
       final exceptionMessage = e.toLocalizedMessage;
       scaffoldMessenger.showExceptionSnackBar(exceptionMessage);
     } finally {

--- a/lib/presentation/bill_details/bill_detail_page_notifier.dart
+++ b/lib/presentation/bill_details/bill_detail_page_notifier.dart
@@ -40,7 +40,10 @@ class BillDetailPageNotifier extends _$BillDetailPageNotifier {
       final price = inAppPurchaseService.getPurchaseItemPrice();
       return price;
     } on Exception catch (e) {
-      logger.e('getPurchaseItemPrice: $e');
+      logger.error(
+        'getPurchaseItemPrice: $e',
+        methodName: 'getPurchaseItemPrice',
+      );
       return {};
     }
   }
@@ -52,7 +55,7 @@ class BillDetailPageNotifier extends _$BillDetailPageNotifier {
       await inAppPurchaseService.makePurchase(packageId);
       onSuccess();
     } on Exception catch (e) {
-      logger.e('purchaseItem: $e');
+      logger.error('purchaseItem: $e', methodName: 'purchaseItem');
       scaffoldMessenger
           .showExceptionSnackBar(i18nSnackBarError.failedToPurchase);
     } finally {
@@ -71,7 +74,10 @@ class BillDetailPageNotifier extends _$BillDetailPageNotifier {
         return;
       }
     } on Exception catch (e) {
-      logger.e('restorePurhcaseItem: $e');
+      logger.error(
+        'restorePurhcaseItem: $e',
+        methodName: 'restorePurhcaseItem',
+      );
       scaffoldMessenger
           .showExceptionSnackBar(i18nSnackBarError.failedToRestorePurchase);
     } finally {

--- a/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
+++ b/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
@@ -108,7 +108,7 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
         ),
       );
     } on Exception catch (e) {
-      logger.e('recieveMessage: $e');
+      logger.error('recieveMessage: $e', methodName: 'recieveMessage');
       scaffoldMessenger.showExceptionSnackBar(
         t.buddyChatPage.snackBar.error.failedRecieveMessage,
       );
@@ -163,7 +163,7 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
 
       await onSuccess();
     } on Exception catch (e) {
-      logger.e('completeCreatePlan: $e');
+      logger.error('completeCreatePlan: $e', methodName: 'completeCreatePlan');
       scaffoldMessenger.showExceptionSnackBar(
         t.buddyChatPage.snackBar.error.failedCompleteCreatePlan,
       );
@@ -233,18 +233,27 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
           return res;
         }
       } on Exception catch (e) {
-        logger.e('${retryCount + 1} 回目失敗: $e');
+        logger.error(
+          '${retryCount + 1} 回目失敗: $e',
+          methodName: 'sendPlanDetail',
+        );
       }
 
       retryCount++;
 
       if (retryCount < maxRetries) {
-        logger.e('再執行($retryCount/$maxRetries)');
+        logger.error(
+          '再執行($retryCount/$maxRetries)',
+          methodName: 'sendPlanDetail',
+        );
         await Future<void>.delayed(const Duration(seconds: 1));
       }
     }
     if (res == null || res.places == null || res.plan == null) {
-      logger.e('Failed to fetch response after $maxRetries attempts.');
+      logger.error(
+        'Failed to fetch response after $maxRetries attempts.',
+        methodName: 'sendPlanDetail',
+      );
       throw Exception('Failed to fetch AI response.');
     }
     return null;
@@ -278,7 +287,7 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
         placeIds: placeIds,
       );
     } on Exception catch (e) {
-      logger.e('getPlacesPhotoUrls: $e');
+      logger.error('getPlacesPhotoUrls: $e', methodName: 'getPlacesPhotoUrls');
     }
     if (forFirstBuild) {
       return chatMessage.copyWith(

--- a/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
+++ b/lib/presentation/buddy_chat/buddy_chat_page_notifier.dart
@@ -201,11 +201,11 @@ class BuddyChatPageNotifier extends _$BuddyChatPageNotifier {
     );
     await loadingNotifier.updateLoadingIndicator(20);
     final res = await sendPlanDetail();
-    if (res?.places == null || res?.plan == null) {
+    if (res == null || res.places == null || res.plan == null) {
       return throw Exception('Failed to fetch AI response.');
     }
     await loadingNotifier.updateLoadingIndicator(80);
-    final buddyMessage = await _getAllFilledMessage(res!, forFirstBuild: true);
+    final buddyMessage = await _getAllFilledMessage(res, forFirstBuild: true);
     final message = ChatMessage(
       id: buddyMessage.id,
       message: buddyMessage.plan!.description,

--- a/lib/presentation/components/error_view.dart
+++ b/lib/presentation/components/error_view.dart
@@ -48,10 +48,12 @@ class ErrorView extends HookConsumerWidget {
           return false; // 最初の親ウィジェットを取得したら終了
         });
 
-        logger
-          ..e('ErrorView: $error')
-          ..e('ErrorView: $stackTrace')
-          ..e('Parent Widget: $parentWidgetName');
+        logger.error(
+          'ErrorView: $error',
+          methodName: parentWidgetName,
+          error: error,
+          stackTrace: stackTrace,
+        );
 
         Future.delayed(Duration.zero, () async {
           await ref.read(analyticsNotifierProvider.notifier).logScreenView(

--- a/lib/presentation/create_plan/create_plan_notifier.dart
+++ b/lib/presentation/create_plan/create_plan_notifier.dart
@@ -31,7 +31,7 @@ class CreatePlanNotifier extends _$CreatePlanNotifier {
     try {
       return await topicDataSource.getTopics();
     } on Exception catch (e) {
-      logger.e('getTopics: $e');
+      logger.error('getTopics: $e', methodName: 'getTopics');
       return [];
     }
   }

--- a/lib/presentation/email_verification/email_verification_page_notifier.dart
+++ b/lib/presentation/email_verification/email_verification_page_notifier.dart
@@ -67,7 +67,10 @@ class EmailVerificationPageNotifier extends _$EmailVerificationPageNotifier {
       });
       scaffoldMessenger.showSuccessSnackBar(i18n.success);
     } on Exception catch (e) {
-      logger.e('sendEmailVerification: $e');
+      logger.error(
+        'sendEmailVerification: $e',
+        methodName: 'sendEmailVerification',
+      );
       scaffoldMessenger.showExceptionSnackBar(i18n.error.unexpected);
     }
   }

--- a/lib/presentation/home/home_page_notifier.dart
+++ b/lib/presentation/home/home_page_notifier.dart
@@ -48,7 +48,10 @@ class HomePageNotifier extends _$HomePageNotifier {
         await ref.read(inAppPurchaseServiceProvider.notifier).build();
       }
     } on Exception catch (e) {
-      logger.e('initializeAppServices: $e');
+      logger.error(
+        'initializeAppServices: $e',
+        methodName: 'initializeAppServices',
+      );
     }
   }
 
@@ -56,7 +59,7 @@ class HomePageNotifier extends _$HomePageNotifier {
     try {
       return await planDataSource.getPopularPlans();
     } on Exception catch (e) {
-      logger.e('getPopularPlans: $e');
+      logger.error('getPopularPlans: $e', methodName: 'getPopularPlans');
       return <Plan>[];
     }
   }
@@ -65,7 +68,7 @@ class HomePageNotifier extends _$HomePageNotifier {
     try {
       return await topicDataSource.getPopularTopics();
     } on Exception catch (e) {
-      logger.e('getPopularTopics: $e');
+      logger.error('getPopularTopics: $e', methodName: 'getPopularTopics');
       return <Topic>[];
     }
   }
@@ -74,7 +77,7 @@ class HomePageNotifier extends _$HomePageNotifier {
     try {
       return await planDataSource.getRecentPlansMadeByPersonal();
     } on Exception catch (e) {
-      logger.e('getRecentPlans: $e');
+      logger.error('getRecentPlans: $e', methodName: 'getRecentPlans');
     }
     return null;
   }

--- a/lib/presentation/my_plan/my_plan_page_notifier.dart
+++ b/lib/presentation/my_plan/my_plan_page_notifier.dart
@@ -45,11 +45,11 @@ class MyPlanPageNotifier extends _$MyPlanPageNotifier {
       }
       return plans;
     } on FirebaseException catch (e) {
-      logger.e('getBookmarkPlans: $e');
+      logger.error('getBookmarkPlans: $e', methodName: 'getBookmarkPlans');
       scaffoldMessenger.showExceptionSnackBar(snacki18n.failedGetPlanData);
       return [];
     } on Exception catch (e) {
-      logger.e('getBookmarkPlans: $e');
+      logger.error('getBookmarkPlans: $e', methodName: 'getBookmarkPlans');
       scaffoldMessenger.showExceptionSnackBar(snacki18n.displayError);
       return [];
     }
@@ -60,7 +60,7 @@ class MyPlanPageNotifier extends _$MyPlanPageNotifier {
       final plans = await planDataSource.getPlansMadeByPersonal();
       return plans;
     } on Exception catch (e) {
-      logger.e('getCreatedPlans: $e');
+      logger.error('getCreatedPlans: $e', methodName: 'getCreatedPlans');
       scaffoldMessenger.showExceptionSnackBar(t.myPlanPage.error.displayError);
       return [];
     }
@@ -83,7 +83,7 @@ class MyPlanPageNotifier extends _$MyPlanPageNotifier {
         ),
       );
     } on FirebaseException catch (e) {
-      logger.e('unBookmark: $e');
+      logger.error('unBookmark: $e', methodName: 'unBookmark');
       scaffoldMessenger
           .showExceptionSnackBar(t.myPlanPage.error.failedUnBookmark);
     }

--- a/lib/presentation/mypage/edit_profile/edit_profile_page_notifier.dart
+++ b/lib/presentation/mypage/edit_profile/edit_profile_page_notifier.dart
@@ -61,7 +61,7 @@ class EditProfilePageNotifier extends _$EditProfilePageNotifier {
         onSuccess();
       }
     } on Exception catch (e) {
-      logger.e('editProfile: $e');
+      logger.error('editProfile: $e', methodName: 'editProfile');
       scaffoldMessenger.showExceptionSnackBar(
         t.editProfilePage.snackBar.error.failedToUpdate,
       );
@@ -83,7 +83,7 @@ class EditProfilePageNotifier extends _$EditProfilePageNotifier {
         );
       }
     } on Exception catch (e) {
-      logger.e('pickImage: $e');
+      logger.error('pickImage: $e', methodName: 'pickImage');
       scaffoldMessenger.showExceptionSnackBar(
         t.editProfilePage.snackBar.error.failedToPickImage,
       );
@@ -107,7 +107,10 @@ class EditProfilePageNotifier extends _$EditProfilePageNotifier {
       );
       return url;
     } on Exception catch (e) {
-      logger.e('getUploadedImageUri: $e');
+      logger.error(
+        'getUploadedImageUri: $e',
+        methodName: 'getUploadedImageUri',
+      );
     }
 
     return null;

--- a/lib/presentation/phone_number_input/phone_number_input_page_notifier.dart
+++ b/lib/presentation/phone_number_input/phone_number_input_page_notifier.dart
@@ -70,6 +70,7 @@ class PhoneNumberInputPageNotifier extends _$PhoneNumberInputPageNotifier {
           ref.read(isShowLoadingOverlayProvider.notifier).state = false;
         },
         onError: (error) {
+          logger.error('sendSmsCode: $error', methodName: 'sendSmsCode');
           // 電話番号が間違っている場合やサーバーエラーの場合
           scaffoldMessenger.showExceptionSnackBar(
             i18n.error,
@@ -78,7 +79,7 @@ class PhoneNumberInputPageNotifier extends _$PhoneNumberInputPageNotifier {
         },
       );
     } on Exception catch (error) {
-      logger.e('sendSmsCode: $error');
+      logger.error('sendSmsCode: $error', methodName: 'sendSmsCode');
       // その他の例外エラー
       scaffoldMessenger.showExceptionSnackBar(
         '${i18n.unexpectedError} $error',

--- a/lib/presentation/plan_detail/plan_detail_page_notifier.dart
+++ b/lib/presentation/plan_detail/plan_detail_page_notifier.dart
@@ -78,7 +78,7 @@ class PlanDetailPageNotifier extends _$PlanDetailPageNotifier {
     try {
       return await planDataSource.getPlanData(planId: plan.id);
     } on Exception catch (e) {
-      logger.e('getPlan: $e');
+      logger.error('getPlan: $e', methodName: 'getPlan');
       return plan;
     }
   }
@@ -87,7 +87,7 @@ class PlanDetailPageNotifier extends _$PlanDetailPageNotifier {
     try {
       return await planReviewDataSource.getPlanReviews(planId: plan.id);
     } on Exception catch (e) {
-      logger.e('getPlanReviews: $e');
+      logger.error('getPlanReviews: $e', methodName: 'getPlanReviews');
       return [];
     }
   }
@@ -131,7 +131,10 @@ class PlanDetailPageNotifier extends _$PlanDetailPageNotifier {
       // あまりしたくはないが、MyPlanPageNotifierの状態を更新するためにinvalidateする
       ref.invalidate(myPlanPageNotifierProvider);
     } on Exception catch (e) {
-      logger.e('onBookmarkButtonTap: $e');
+      logger.error(
+        'onBookmarkButtonTap: $e',
+        methodName: 'onBookmarkButtonTap',
+      );
       scaffoldMessenger.showExceptionSnackBar(
         planDetailPageSnackBari18n.error.failedToUpdateBookmark,
       );
@@ -184,7 +187,7 @@ class PlanDetailPageNotifier extends _$PlanDetailPageNotifier {
       await _refreshReviews();
       onSuccess();
     } on Exception catch (e) {
-      logger.e('createReview: $e');
+      logger.error('createReview: $e', methodName: 'createReview');
       scaffoldMessenger.showExceptionSnackBar(
         planDetailPageSnackBari18n.error.failedToCreateReview,
       );
@@ -222,7 +225,7 @@ class PlanDetailPageNotifier extends _$PlanDetailPageNotifier {
         ),
       );
     } on Exception catch (e) {
-      logger.e('refreshReviews: $e');
+      logger.error('refreshReviews: $e', methodName: 'refreshReviews');
     }
   }
 }

--- a/lib/presentation/plans_related_in_topic/plans_related_in_topic_page_notifier.dart
+++ b/lib/presentation/plans_related_in_topic/plans_related_in_topic_page_notifier.dart
@@ -28,7 +28,10 @@ class PlansRelatedInTopicPageNotifier
       }
       return plans;
     } on Exception catch (e) {
-      logger.e('getPlansRelatedInTopic: $e');
+      logger.error(
+        'getPlansRelatedInTopic: $e',
+        methodName: 'getPlansRelatedInTopic',
+      );
       return <Plan>[];
     }
   }

--- a/lib/presentation/register_profile/register_profile_page_notifier.dart
+++ b/lib/presentation/register_profile/register_profile_page_notifier.dart
@@ -63,7 +63,10 @@ class RegisterProfilePageNotifier extends _$RegisterProfilePageNotifier {
       await currentUser.updateDisplayName(name);
       onSuccess();
     } on Exception catch (e) {
-      logger.e('registerInformation: $e');
+      logger.error(
+        'registerInformation: $e',
+        methodName: 'registerInformation',
+      );
       scaffoldMessenger.showExceptionSnackBar(i18nSnackBarError.unexpected);
     } finally {
       ref.read(isShowLoadingOverlayProvider.notifier).state = false;
@@ -78,7 +81,7 @@ class RegisterProfilePageNotifier extends _$RegisterProfilePageNotifier {
         state = state.copyWith(pickedFile: pickedImageFile);
       }
     } on Exception catch (e) {
-      logger.e('pickImage: $e');
+      logger.error('pickImage: $e', methodName: 'pickImage');
       scaffoldMessenger.showExceptionSnackBar(i18nSnackBarError.unexpected);
     } finally {
       ref.read(isShowLoadingOverlayProvider.notifier).state = false;
@@ -94,7 +97,10 @@ class RegisterProfilePageNotifier extends _$RegisterProfilePageNotifier {
           await fileDataSource.getUploadedImageUrl(file: state.pickedFile!);
       return url;
     } on Exception catch (e) {
-      logger.e('_getUploadedImageUri: $e');
+      logger.error(
+        '_getUploadedImageUri: $e',
+        methodName: '_getUploadedImageUri',
+      );
       scaffoldMessenger.showExceptionSnackBar(i18nSnackBarError.unexpected);
     }
 

--- a/lib/presentation/reset_password/reset_password_page_notifier.dart
+++ b/lib/presentation/reset_password/reset_password_page_notifier.dart
@@ -37,7 +37,10 @@ class ResetPasswordPageNotifier extends _$ResetPasswordPageNotifier {
         i18nCompleteSendEmailPage.successResendEmail,
       );
     } on FirebaseAuthException catch (e) {
-      logger.e('sendPasswordResetEmail: $e');
+      logger.error(
+        'sendPasswordResetEmail: $e',
+        methodName: 'sendPasswordResetEmail',
+      );
       final exceptionMessage = e.toLocalizedMessage;
       scaffoldMessenger.showExceptionSnackBar(exceptionMessage);
     }

--- a/lib/presentation/sms_verification/sms_verification_page_notifier.dart
+++ b/lib/presentation/sms_verification/sms_verification_page_notifier.dart
@@ -72,7 +72,7 @@ class SmsVerificationNotifier extends _$SmsVerificationNotifier {
       );
       onSuccess();
     } on Object catch (error) {
-      logger.e('verifySmsCode: $error');
+      logger.error('verifySmsCode: $error', methodName: 'verifySmsCode');
       scaffoldMessenger.showExceptionSnackBar(
         '${i18n.error} $error',
       );
@@ -107,7 +107,7 @@ class SmsVerificationNotifier extends _$SmsVerificationNotifier {
         },
       );
     } on Exception catch (error) {
-      logger.e('sendSmsCode: $error');
+      logger.error('sendSmsCode: $error', methodName: 'sendSmsCode');
       scaffoldMessenger.showExceptionSnackBar(
         '${i18nPhoneNumberInputScaffoldMessenger.unexpectedError} $error',
       );

--- a/lib/utils/custom_logger.dart
+++ b/lib/utils/custom_logger.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
 import 'dart:developer' as dev;
 
 import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
+
+import 'analytics_event.dart';
+import 'providers/analytics/analytics.dart';
 
 final logger = CustomLogger();
 
@@ -23,6 +27,34 @@ class CustomLogger extends Logger {
           ),
           level: kReleaseMode ? Level.info : Level.trace,
         );
+
+  void error(
+    dynamic message, {
+    required String methodName,
+    DateTime? time,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    if (kReleaseMode) {
+      unawaited(
+        AnalyticsNotifier().logEvent(
+          UserActionEvent.customError,
+          parameters: {
+            'error': error.toString(),
+            'stackTrace': stackTrace.toString(),
+            'errorBy': methodName,
+          },
+        ),
+      );
+    } else {
+      super.e(
+        message,
+        time: time,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
 }
 
 /// log出力をカスタマイズします。

--- a/lib/utils/providers/ad_helper/ad_helper.dart
+++ b/lib/utils/providers/ad_helper/ad_helper.dart
@@ -61,7 +61,10 @@ class AdHelper extends _$AdHelper {
             logger.i('Banner ad loaded');
           },
           onAdFailedToLoad: (ad, err) async {
-            logger.e('Failed to load a banner ad: $err');
+            logger.error(
+              'Failed to load a banner ad: $err',
+              methodName: 'loadBannerAd',
+            );
             await ad.dispose();
           },
         ),
@@ -83,7 +86,10 @@ class AdHelper extends _$AdHelper {
           },
           onAdFailedToLoad: (ad, error) async {
             // Dispose the ad here to free resources.
-            logger.e('Failed to load a native ad: $error');
+            logger.error(
+              'Failed to load a native ad: $error',
+              methodName: 'loadNativeAd',
+            );
             await ad.dispose();
           },
         ),

--- a/lib/utils/providers/analytics/analytics.dart
+++ b/lib/utils/providers/analytics/analytics.dart
@@ -24,16 +24,18 @@ class AnalyticsNotifier extends _$AnalyticsNotifier {
       await _dataSource.logEvent(event.key, parameters: parameters);
       logger.t('Event logged: ${event.key}');
     } on FirebaseException catch (e, stackTrace) {
-      logger.e(
+      logger.error(
         'Firebase error logging event: ${event.key}',
         error: e,
         stackTrace: stackTrace,
+        methodName: 'logEvent',
       );
     } on Exception catch (e, stackTrace) {
-      logger.e(
+      logger.error(
         'General error logging event: ${event.key}',
         error: e,
         stackTrace: stackTrace,
+        methodName: 'logEvent',
       );
     }
   }
@@ -50,16 +52,18 @@ class AnalyticsNotifier extends _$AnalyticsNotifier {
       );
       logger.t('Screen view logged: ${event.key}');
     } on FirebaseException catch (e, stackTrace) {
-      logger.e(
+      logger.error(
         'Firebase error logging screen view: ${event.key}',
         error: e,
         stackTrace: stackTrace,
+        methodName: 'logScreenView',
       );
     } on Exception catch (e, stackTrace) {
-      logger.e(
+      logger.error(
         'General error logging screen view: ${event.key}',
         error: e,
         stackTrace: stackTrace,
+        methodName: 'logScreenView',
       );
     }
   }

--- a/lib/utils/providers/current_user/current_user.dart
+++ b/lib/utils/providers/current_user/current_user.dart
@@ -36,7 +36,7 @@ class CurrentUser extends _$CurrentUser {
           await userDataSource.fetchUser(userId: firebaseAuth.currentUser!.uid);
       state = user;
     } on Exception catch (e) {
-      logger.e('fetchUser: $e');
+      logger.error('fetchUser: $e', methodName: 'fetchUser');
     }
   }
 }

--- a/lib/utils/providers/in_app_purchase/in_app_purchase_service.dart
+++ b/lib/utils/providers/in_app_purchase/in_app_purchase_service.dart
@@ -76,7 +76,7 @@ class InAppPurchaseService extends _$InAppPurchaseService {
         return offerings;
       }
     } on PlatformException catch (e) {
-      logger.e('getOfferingItems error $e');
+      logger.error('getOfferingItems error $e', methodName: 'getOfferingItems');
     }
     return null;
   }
@@ -140,7 +140,7 @@ class InAppPurchaseService extends _$InAppPurchaseService {
       );
       ref.invalidate(currentUserProvider);
     } on PlatformException catch (e) {
-      logger.e('makePurchase: $e');
+      logger.error('makePurchase: $e', methodName: 'makePurchase');
     }
   }
 
@@ -166,7 +166,7 @@ class InAppPurchaseService extends _$InAppPurchaseService {
         return false;
       }
     } on PlatformException catch (e) {
-      logger.e('canRestorePurchase: $e');
+      logger.error('canRestorePurchase: $e', methodName: 'canRestorePurchase');
       return false;
     }
   }


### PR DESCRIPTION
## 対応したこと

<!-- 対応したことを箇条書きでわかりやすく -->

- loggerでエラーを扱った際に自動でイベント送信をするように変更
- geminiの生成関連時のエラー判定を正確に

## 関連資料

<!-- 対応する中で参考にしたWebサイトがあれば、何の対応に対して参考にしたか明記しながら、URLを貼る -->
特になし

## 残タスク

<!-- 対応しきれなかった部分、自分では実装できない部分をchecklistで箇条書き -->
動作確認

## 画面キャプチャ

<!-- UIの新規実装の場合、スクショを貼る。UIの修正の場合は修正後スクショと、あればbeforeのスクショもあるとレビューしやすい -->
特になし